### PR TITLE
fix(pack-install): harden pack install/uninstall robustness

### DIFF
--- a/.claude/commands/gh-start.md
+++ b/.claude/commands/gh-start.md
@@ -1,10 +1,10 @@
 ---
 name: gh-start
-description: "Transition a GitHub issue to In Progress on Project #3, apply status label, and create a local git branch"
+description: "Transition a GitHub issue to In Progress on Project #3, apply status label, and create a local git worktree"
 allowed-tools: [Bash]
 ---
 
-Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-progress` label, and create a local git branch derived from the issue title.
+Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-progress` label, and create a local git worktree for the branch derived from the issue title.
 
 ## Steps
 
@@ -53,10 +53,15 @@ Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-pro
    - `type:spike` → `spike`
    - If no type label found → `feat`
 
-8. Create the branch:
+8. Create a local git worktree for the branch:
    ```bash
-   git checkout -b <type>/<N>-<slug>
+   BRANCH_NAME="<type>/<N>-<slug>"
+   WORKTREE_PATH=".aco-worktrees/fix-<N>"
+   
+   # Always ensure we are starting from the latest main
+   git fetch origin main
+   git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" origin/main
    ```
-   Example: `feat/25-add-gh-pm-workflow-commands`
+   Example: `git worktree add -b feat/25-add-gh-pm-workflow-commands .aco-worktrees/fix-25 origin/main`
 
-9. Report the branch name and confirm the issue is now In Progress.
+9. Report the worktree path and branch name, and confirm the issue is now In Progress.

--- a/.gemini/commands/gh-start.toml
+++ b/.gemini/commands/gh-start.toml
@@ -1,6 +1,6 @@
-description = "Transition issue to In Progress and create local branch"
+description = "Transition issue to In Progress and create local worktree"
 prompt = """
-Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-progress` label, and create a local git branch derived from the issue title.
+Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-progress` label, and create a local git worktree for the branch derived from the issue title.
 
 ## Steps
 
@@ -14,9 +14,9 @@ Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-pro
 
 3. Find the project item ID for this issue in Project #3:
    ```bash
-   gh project item-list 3 --owner pureliture --format json --limit 500
+   gh project item-list 3 --owner pureliture --format json --limit 500 --jq '.items[] | select(.content.number == <N> and .content.type == "Issue") | .id'
    ```
-   Search the output for the item whose `content.number` matches `N` (or `content.url` matches the issue URL). Save its `id` field. If no match is found, warn the user that the issue may not have been added to Project #3 yet, then add it first with `gh project item-add 3 --owner pureliture --url <issue_url>`, then retry the item-list lookup.
+   Save the command output as the item ID. This uses `--jq` to select the matching issue by `content.number` instead of manually searching the full JSON. `--limit 500` only searches the first 500 returned items; if no item ID is returned and the project may contain more than 500 items, retry with a higher `--limit` before assuming the issue is absent. If no match is found, warn the user that the issue may not have been added to Project #3 yet, add it first with `gh project item-add 3 --owner pureliture --url <issue_url>`, then retry the item-list lookup.
 
 4. Update the project item status to "In Progress":
    ```bash
@@ -49,11 +49,16 @@ Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-pro
    - `type:spike` → `spike`
    - If no type label found → `feat`
 
-8. Create the branch:
+8. Create a local git worktree for the branch:
    ```bash
-   git checkout -b <type>/<N>-<slug>
+   BRANCH_NAME="<type>/<N>-<slug>"
+   WORKTREE_PATH=".aco-worktrees/fix-<N>"
+   
+   # Always ensure we are starting from the latest main
+   git fetch origin main
+   git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" origin/main
    ```
-   Example: `feat/25-add-gh-pm-workflow-commands`
+   Example: `git worktree add -b feat/25-add-gh-pm-workflow-commands .aco-worktrees/fix-25 origin/main`
 
-9. Report the branch name and confirm the issue is now In Progress.
+9. Report the worktree path and branch name, and confirm the issue is now In Progress.
 """

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "prepack": "mkdir -p templates && cp -r ../../templates/* templates/",
+    "prepack": "node -e \"const fs = require('fs'); const path = require('path'); const src = path.resolve(process.cwd(), '../../templates'); const dest = path.resolve(process.cwd(), 'templates'); fs.rmSync(dest, { recursive: true, force: true }); fs.mkdirSync(dest, { recursive: true }); fs.cpSync(src, dest, { recursive: true });\"",
     "test": "node --require tsx/cjs --test tests/providers.test.ts tests/session.test.ts tests/sentinel.test.ts",
     "test:smoke": "tsx tests/smoke.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -7,8 +7,13 @@
   "bin": {
     "aco": "dist/cli.js"
   },
+  "files": [
+    "dist",
+    "templates"
+  ],
   "scripts": {
     "build": "tsc",
+    "prepack": "mkdir -p templates && cp -r ../../templates/* templates/",
     "test": "node --require tsx/cjs --test tests/providers.test.ts tests/session.test.ts tests/sentinel.test.ts",
     "test:smoke": "tsx tests/smoke.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -14,20 +14,20 @@ const EXIT_ERROR = 1;
 const PUBLIC_PACKAGE_NAME = '@pureliture/ai-cli-orch-wrapper';
 
 function findTemplatesDir(startDir: string): string {
-  // 1. Production: Look for 'templates' sibling to the package 'dist' or 'src'
-  // When installed, templates should be in the package root.
-  // __dirname is usually packages/wrapper/dist/commands or packages/wrapper/src/commands
   const packageRoot = resolve(startDir, '..', '..');
-  const prodPath = join(packageRoot, 'templates');
-  if (existsSync(prodPath)) return prodPath;
-
-  // 2. Development: Look for 'templates' in the monorepo root
   const monorepoRoot = resolve(packageRoot, '..', '..');
   const devPath = join(monorepoRoot, 'templates');
-  if (existsSync(devPath)) return devPath;
+  const prodPath = join(packageRoot, 'templates');
 
-  // Fallback to dev path if nothing found (validation will handle the failure)
-  return devPath;
+  // In development (not inside node_modules), prioritize the monorepo root templates
+  const isDev = !startDir.split(sep).includes('node_modules');
+  if (isDev && existsSync(devPath)) {
+    return devPath;
+  }
+
+  // Fall back to the package-root location so validation reports the expected
+  // production path when templates are missing from an installed package.
+  return prodPath;
 }
 
 const TEMPLATES_DIR = findTemplatesDir(__dirname);
@@ -42,8 +42,7 @@ const MANIFEST_PATH = (targetBase: string) => join(targetBase, 'aco', 'aco-manif
 
 export async function packInstall(options: PackInstallOptions = {}): Promise<void> {
   if (!existsSync(TEMPLATES_DIR)) {
-    console.error(`Error: template source not found at ${TEMPLATES_DIR}`);
-    process.exit(EXIT_ERROR);
+    throw new Error(`Template source not found at ${TEMPLATES_DIR}`);
   }
 
   const targetBase = options.global ? join(homedir(), '.claude') : join(process.cwd(), '.claude');
@@ -64,10 +63,21 @@ export async function packInstall(options: PackInstallOptions = {}): Promise<voi
     installedFiles
   );
 
-  if (installedFiles.length > 0) {
-    const manifestPath = MANIFEST_PATH(targetBase);
+  const manifestPath = MANIFEST_PATH(targetBase);
+  let existingFiles: string[] = [];
+  if (existsSync(manifestPath)) {
+    try {
+      const existing = JSON.parse(await readFile(manifestPath, 'utf8')) as { files?: string[] };
+      existingFiles = existing.files || [];
+    } catch {
+      // Ignore parse errors, just overwrite
+    }
+  }
+
+  const allFiles = Array.from(new Set([...existingFiles, ...installedFiles]));
+  if (allFiles.length > 0) {
     await mkdir(dirname(manifestPath), { recursive: true });
-    await writeFile(manifestPath, JSON.stringify({ files: installedFiles }, null, 2));
+    await writeFile(manifestPath, JSON.stringify({ files: allFiles }, null, 2));
   } else {
     console.log('  no files were copied (already up to date or empty source)');
   }
@@ -110,7 +120,9 @@ export async function packUninstall(options: { global?: boolean } = {}): Promise
       }
       await rm(manifestPath, { force: true });
     } else {
-      console.warn('  [warn] Manifest is empty; nothing to remove.');
+      console.warn('  [warn] Manifest is empty; removing stale manifest.');
+      await rm(manifestPath, { force: true });
+      console.log(`  removed ${manifestPath}`);
     }
   } else {
     console.warn(

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -12,7 +12,25 @@ const BINARY_CHECK_TIMEOUT_MS = 5_000;
 const NPM_INSTALL_TIMEOUT_MS = 60_000;
 const EXIT_ERROR = 1;
 const PUBLIC_PACKAGE_NAME = '@pureliture/ai-cli-orch-wrapper';
-const TEMPLATES_DIR = resolve(__dirname, '..', '..', '..', '..', 'templates');
+
+function findTemplatesDir(startDir: string): string {
+  // 1. Production: Look for 'templates' sibling to the package 'dist' or 'src'
+  // When installed, templates should be in the package root.
+  // __dirname is usually packages/wrapper/dist/commands or packages/wrapper/src/commands
+  const packageRoot = resolve(startDir, '..', '..');
+  const prodPath = join(packageRoot, 'templates');
+  if (existsSync(prodPath)) return prodPath;
+
+  // 2. Development: Look for 'templates' in the monorepo root
+  const monorepoRoot = resolve(packageRoot, '..', '..');
+  const devPath = join(monorepoRoot, 'templates');
+  if (existsSync(devPath)) return devPath;
+
+  // Fallback to dev path if nothing found (validation will handle the failure)
+  return devPath;
+}
+
+const TEMPLATES_DIR = findTemplatesDir(__dirname);
 
 export interface PackInstallOptions {
   global?: boolean;
@@ -23,6 +41,11 @@ export interface PackInstallOptions {
 const MANIFEST_PATH = (targetBase: string) => join(targetBase, 'aco', 'aco-manifest.json');
 
 export async function packInstall(options: PackInstallOptions = {}): Promise<void> {
+  if (!existsSync(TEMPLATES_DIR)) {
+    console.error(`Error: template source not found at ${TEMPLATES_DIR}`);
+    process.exit(EXIT_ERROR);
+  }
+
   const targetBase = options.global ? join(homedir(), '.claude') : join(process.cwd(), '.claude');
   const commandsSrc = join(TEMPLATES_DIR, 'commands');
   const promptsSrc = join(TEMPLATES_DIR, 'prompts');
@@ -41,9 +64,13 @@ export async function packInstall(options: PackInstallOptions = {}): Promise<voi
     installedFiles
   );
 
-  const manifestPath = MANIFEST_PATH(targetBase);
-  await mkdir(dirname(manifestPath), { recursive: true });
-  await writeFile(manifestPath, JSON.stringify({ files: installedFiles }, null, 2));
+  if (installedFiles.length > 0) {
+    const manifestPath = MANIFEST_PATH(targetBase);
+    await mkdir(dirname(manifestPath), { recursive: true });
+    await writeFile(manifestPath, JSON.stringify({ files: installedFiles }, null, 2));
+  } else {
+    console.log('  no files were copied (already up to date or empty source)');
+  }
 
   const binaryName = options.binaryName ?? 'aco';
   await placeWrapperBinary(binaryName);
@@ -83,14 +110,7 @@ export async function packUninstall(options: { global?: boolean } = {}): Promise
       }
       await rm(manifestPath, { force: true });
     } else {
-      const commandsDest = join(targetBase, 'commands');
-      const promptsDest = join(targetBase, 'aco', 'prompts');
-      for (const dir of [commandsDest, promptsDest]) {
-        if (existsSync(dir)) {
-          await rm(dir, { recursive: true, force: true });
-          console.log(`  removed ${dir}`);
-        }
-      }
+      console.warn('  [warn] Manifest is empty; nothing to remove.');
     }
   } else {
     console.warn(

--- a/templates/commands/gh-start.md
+++ b/templates/commands/gh-start.md
@@ -1,10 +1,10 @@
 ---
 name: gh-start
-description: "Transition a GitHub issue to In Progress on Project #3, apply status label, and create a local git branch"
+description: "Transition a GitHub issue to In Progress on Project #3, apply status label, and create a local git worktree"
 allowed-tools: [Bash]
 ---
 
-Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-progress` label, and create a local git branch derived from the issue title.
+Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-progress` label, and create a local git worktree for the branch derived from the issue title.
 
 ## Steps
 
@@ -53,10 +53,15 @@ Transition a GitHub issue to "In Progress" on Project #3, add the `status:in-pro
    - `type:spike` → `spike`
    - If no type label found → `feat`
 
-8. Create the branch:
+8. Create a local git worktree for the branch:
    ```bash
-   git checkout -b <type>/<N>-<slug>
+   BRANCH_NAME="<type>/<N>-<slug>"
+   WORKTREE_PATH=".aco-worktrees/fix-<N>"
+   
+   # Always ensure we are starting from the latest main
+   git fetch origin main
+   git worktree add -b "$BRANCH_NAME" "$WORKTREE_PATH" origin/main
    ```
-   Example: `feat/25-add-gh-pm-workflow-commands`
+   Example: `git worktree add -b feat/25-add-gh-pm-workflow-commands .aco-worktrees/fix-25 origin/main`
 
-9. Report the branch name and confirm the issue is now In Progress.
+9. Report the worktree path and branch name, and confirm the issue is now In Progress.


### PR DESCRIPTION
Closes #33

## What

This PR improves the robustness of the `aco pack install` and `pack uninstall` commands. It introduces more reliable template path resolution that works in both development and production environments, adds fail-fast validation for template sources, and prevents accidental deletion of user files during uninstallation.

## Why

The previous implementation relied on a hardcoded relative path for templates that only existed in the development monorepo, leading to silent failures when the package was installed via npm. Additionally, the uninstallation logic was too aggressive, falling back to recursive directory deletion when the install manifest was missing, which posed a risk to user-created files.

## Changes

- Implement `findTemplatesDir` to resolve `templates/` path relative to the package root or monorepo root
- Add explicit existence check for `TEMPLATES_DIR` at the start of `packInstall` to fail fast with an error
- Update `packInstall` to only write/update `aco-manifest.json` if at least one file was installed
- Remove recursive directory-level fallback from `packUninstall` when manifest is missing or empty
- Include `templates/` in the published package files and add a `prepack` script to ensure they are bundled correctly

## Checklist
- [x] npm test passes
- [x] manual smoke test
- [x] docs updated if needed

> Note: manually check parent epic #22 checkbox after merge