### PR TITLE
feat(ops): support multi-linked-issue priority resolution in /gh-pr

### DIFF
--- a/.claude/commands/gh-pr.md
+++ b/.claude/commands/gh-pr.md
@@ -101,7 +101,7 @@ Create a GitHub Pull Request in `pureliture/ai-cli-orch-wrapper`. The PR body mu
    If no ID is found after retries, or any step fails, print `⚠ PR Project status update failed — update manually` and continue.
 
 8. Set linked issue status to "In Review":
-   Parse the PR body for `Closes #N`, `Fixes #N`, or `Resolves #N` (case-insensitive). If found:
+   Parse the PR body for ALL occurrences of `Closes #N`, `Fixes #N`, or `Resolves #N` (case-insensitive). Collect all unique issue numbers in order of appearance. For each unique linked issue N:
    - Verify the issue exists: `gh issue view <N> --repo pureliture/ai-cli-orch-wrapper --json number`
    - Find the issue's Project item ID:
      ```bash
@@ -118,19 +118,16 @@ Create a GitHub Pull Request in `pureliture/ai-cli-orch-wrapper`. The PR body mu
        --field-id PVTSSF_lAHOA6302M4BT5fAzhBFN48 \
        --single-select-option-id 961ca78f
      ```
-   - If no linked issue keyword found, skip this step silently.
-   - If any step fails, print `⚠ Issue Project status update failed — update manually` and continue.
+   - If any step fails for an issue, print `⚠ Issue Project status update failed for #<N> — update manually` and continue to the next linked issue.
 
-9. Apply tracking labels to PR (inherit from linked issue; default priority `p1`):
-   If a linked issue number N was found in step 8:
-   ```bash
-   gh issue view <N> --repo pureliture/ai-cli-orch-wrapper --json labels -q '.labels[].name'
-   ```
-   Build the desired PR label set from the linked issue:
-   - highest priority label `p0`, `p1`, or `p2` (default `p1` if none found)
-   - first `type:*` label
-   - first `area:*` label
-   - `origin:review` if present
+9. Apply tracking labels to PR (inherit from linked issues; default priority `p1`):
+   If any linked issue numbers were found in step 8:
+   - For EACH linked issue, fetch labels: `gh issue view <N> --repo pureliture/ai-cli-orch-wrapper --json labels -q '.labels[].name'`
+   - Collect all labels from all linked issues.
+   - Determine the highest priority label among all discovered labels (`p0` > `p1` > `p2`). If no priority label is found on any issue, use `p1`.
+   - Take the first `type:*` label found across the issues (prioritizing the first issue's type).
+   - Take the first `area:*` label found across the issues (prioritizing the first issue's area).
+   - Include `origin:review` if it exists on ANY of the linked issues.
    Do NOT copy `status:*` or `sprint:*` labels onto the PR.
    Inspect the PR's current labels first:
    ```bash
@@ -140,7 +137,6 @@ Create a GitHub Pull Request in `pureliture/ai-cli-orch-wrapper`. The PR body mu
    ```bash
    gh pr edit <pr_url> --repo pureliture/ai-cli-orch-wrapper --add-label <label>
    ```
-   If multiple linked issues have different priorities, use the highest (`p0` > `p1` > `p2`).
    If no linked issue keyword is found, skip `type:*`, `area:*`, and `origin:review`, but still apply default priority `p1`.
    If any label step fails, print `⚠ PR label sync failed — update manually` and continue.
 

--- a/scripts/pm-hook.sh
+++ b/scripts/pm-hook.sh
@@ -56,32 +56,31 @@ if [[ -z "$PROJECT_NUMBER" || -z "$PROJECT_ID" || -z "$STATUS_FIELD_ID" || -z "$
   exit 0
 fi
 
-# ── Extract issue number ───────────────────────────────────────────────────
-ISSUE_NUM=""
+# ── Extract linked issue numbers ──────────────────────────────────────────
+RAW_ISSUES=""
 
 # 1. From command string (immediate)
-if [[ "$COMMAND" =~ ([Cc]loses|[Ff]ixes|[Rr]esolves):?[[:space:]]+#?([0-9]+) ]]; then
-  ISSUE_NUM="${BASH_REMATCH[2]}"
-fi
+CMD_ISSUES=$(echo "$COMMAND" | grep -oiE '(closes|fixes|resolves):?[[:space:]]+#?[0-9]+' | grep -oE '[0-9]+' || true)
+RAW_ISSUES="${RAW_ISSUES}${CMD_ISSUES}"$'\n'
 
 # 2. From actual PR body (handles --fill and manual edits)
-if [[ -z "$ISSUE_NUM" ]]; then
-  PR_BODY=$(gh pr view --json body --jq '.body' 2>/dev/null || echo "")
-  if [[ "$PR_BODY" =~ ([Cc]loses|[Ff]ixes|[Rr]esolves):?[[:space:]]+#?([0-9]+) ]]; then
-    ISSUE_NUM="${BASH_REMATCH[2]}"
-  fi
-fi
+# Always check PR body to augment command-line parsing
+PR_BODY=$(gh pr view --json body --jq '.body' 2>/dev/null || echo "")
+BODY_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves):?[[:space:]]+#?[0-9]+' | grep -oE '[0-9]+' || true)
+RAW_ISSUES="${RAW_ISSUES}${BODY_ISSUES}"$'\n'
 
-# 3. Fallback: current branch name feat/42-slug or fix/42-slug
-if [[ -z "$ISSUE_NUM" ]]; then
+# 3. Fallback: current branch name feat/42-slug or fix/42-slug (only if no keywords found)
+if [[ -z "$(echo "$RAW_ISSUES" | tr -d '[:space:]')" ]]; then
   BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
-  if [[ "$BRANCH" =~ /([0-9]+)- ]]; then
-    ISSUE_NUM="${BASH_REMATCH[1]}"
-  fi
+  BRANCH_ISSUE=$(echo "$BRANCH" | grep -oE '/[0-9]+-' | grep -oE '[0-9]+' || true)
+  RAW_ISSUES="${RAW_ISSUES}${BRANCH_ISSUE}"$'\n'
 fi
 
-if [[ -z "$ISSUE_NUM" ]]; then
-  echo "[pm-hook] No issue number found in command or branch — skipping" >&2
+# Unique issue numbers in order of appearance
+ISSUE_NUMS=$(echo "$RAW_ISSUES" | grep -v '^$' | awk '!x[$0]++' || true)
+
+if [[ -z "$ISSUE_NUMS" ]]; then
+  echo "[pm-hook] No linked issue keywords or branch-issue found — skipping" >&2
 fi
 
 # ── Helpers ────────────────────────────────────────────────────────────────
@@ -131,57 +130,56 @@ else
   echo "[pm-hook] WARN: Could not resolve created PR from current branch" >&2
 fi
 
-[[ -z "$ISSUE_NUM" ]] && exit 0
+[[ -z "$ISSUE_NUMS" ]] && exit 0
 
-# ── Get or add linked issue project item ───────────────────────────────────
-ITEM_ID=$(gh project item-list "$PROJECT_NUMBER" \
-  --owner "$OWNER" --format json \
-  --jq ".items[] | select(.content.number == $ISSUE_NUM and .content.type == \"Issue\") | .id" 2>/dev/null || echo "")
+# ── Process every linked issue ─────────────────────────────────────────────
+PRIORITY_LABEL=""
 
-if [[ -z "$ITEM_ID" ]]; then
-  ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUM}"
-  ITEM_ID=$(gh project item-add "$PROJECT_NUMBER" \
-    --owner "$OWNER" \
-    --url "$ISSUE_URL" \
-    --format json \
-    --jq '.id' 2>/dev/null || echo "")
-fi
+while read -r ISSUE_NUM; do
+  [[ -z "$ISSUE_NUM" ]] && continue
 
-if [[ -z "$ITEM_ID" ]]; then
-  echo "[pm-hook] Could not get/add project item for issue #${ISSUE_NUM}" >&2
-  exit 0
-fi
+  # 1. Get or add linked issue project item
+  ITEM_ID=$(get_project_item_id "$ISSUE_NUM" "Issue")
 
-# ── Update linked issue status to "In Review" ──────────────────────────────
-if set_in_review "$ITEM_ID"; then
-  echo "[pm-hook] Issue #${ISSUE_NUM} → In Review" >&2
-else
-  echo "[pm-hook] WARN: Failed to update issue #${ISSUE_NUM} status" >&2
-fi
+  if [[ -z "$ITEM_ID" ]]; then
+    ISSUE_URL="https://github.com/${REPO}/issues/${ISSUE_NUM}"
+    ITEM_ID=$(add_project_url "$ISSUE_URL")
+  fi
 
-# ── Inherit priority label from linked issue → apply to PR ────────────────
-# Reads p0/p1/p2 label from issue; defaults to p1 if none found.
-# Only runs when a PR and linked issue are both resolved.
-if [[ -n "$PR_NUM" && -n "$ISSUE_NUM" ]]; then
+  if [[ -n "$ITEM_ID" ]]; then
+    if set_in_review "$ITEM_ID"; then
+      echo "[pm-hook] Issue #${ISSUE_NUM} → In Review" >&2
+    else
+      echo "[pm-hook] WARN: Failed to update issue #${ISSUE_NUM} status" >&2
+    fi
+  else
+    echo "[pm-hook] Could not get/add project item for issue #${ISSUE_NUM}" >&2
+  fi
+
+  # 2. Collect priority labels for PR inheritance
   ISSUE_LABELS=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json labels \
     --jq '.labels[].name' 2>/dev/null || echo "")
 
-  PRIORITY_LABEL=""
   while IFS= read -r lbl; do
     case "$lbl" in
-      p0) PRIORITY_LABEL="p0"; break ;;
-      p1) PRIORITY_LABEL="p1"; break ;;
-      p2) [[ -z "$PRIORITY_LABEL" ]] && PRIORITY_LABEL="p2" ;;
+      p0) PRIORITY_LABEL="p0" ;; # Highest, can't be beaten
+      p1) [[ "$PRIORITY_LABEL" != "p0" ]] && PRIORITY_LABEL="p1" ;;
+      p2) [[ -z "$PRIORITY_LABEL" || "$PRIORITY_LABEL" == "p2" ]] && [[ "$PRIORITY_LABEL" != "p0" && "$PRIORITY_LABEL" != "p1" ]] && PRIORITY_LABEL="p2" ;;
     esac
   done <<< "$ISSUE_LABELS"
-  [[ -z "$PRIORITY_LABEL" ]] && PRIORITY_LABEL="p1"
+done <<< "$ISSUE_NUMS"
 
-  # Apply label to PR if not already present
+# ── Apply inherited priority label to PR ──────────────────────────────────
+# Default to p1 if no priority label found on any linked issue.
+[[ -z "$PRIORITY_LABEL" ]] && PRIORITY_LABEL="p1"
+
+if [[ -n "$PR_NUM" ]]; then
   PR_LABELS=$(gh pr view "$PR_NUM" --repo "$REPO" --json labels \
     --jq '.labels[].name' 2>/dev/null || echo "")
+
   if ! grep -qwE 'p0|p1|p2' <<< "$PR_LABELS"; then
     if gh pr edit "$PR_NUM" --repo "$REPO" --add-label "$PRIORITY_LABEL" 2>/dev/null; then
-      echo "[pm-hook] PR #${PR_NUM} ← priority ${PRIORITY_LABEL} (from issue #${ISSUE_NUM})" >&2
+      echo "[pm-hook] PR #${PR_NUM} ← priority ${PRIORITY_LABEL} (resolved across linked issues)" >&2
     else
       echo "[pm-hook] WARN: Failed to apply priority label to PR #${PR_NUM}" >&2
     fi

--- a/templates/commands/gh-pr.md
+++ b/templates/commands/gh-pr.md
@@ -101,7 +101,7 @@ Create a GitHub Pull Request in `pureliture/ai-cli-orch-wrapper`. The PR body mu
    If no ID is found after retries, or any step fails, print `⚠ PR Project status update failed — update manually` and continue.
 
 8. Set linked issue status to "In Review":
-   Parse the PR body for `Closes #N`, `Fixes #N`, or `Resolves #N` (case-insensitive). If found:
+   Parse the PR body for ALL occurrences of `Closes #N`, `Fixes #N`, or `Resolves #N` (case-insensitive). Collect all unique issue numbers in order of appearance. For each unique linked issue N:
    - Verify the issue exists: `gh issue view <N> --repo pureliture/ai-cli-orch-wrapper --json number`
    - Find the issue's Project item ID:
      ```bash
@@ -118,19 +118,16 @@ Create a GitHub Pull Request in `pureliture/ai-cli-orch-wrapper`. The PR body mu
        --field-id PVTSSF_lAHOA6302M4BT5fAzhBFN48 \
        --single-select-option-id 961ca78f
      ```
-   - If no linked issue keyword found, skip this step silently.
-   - If any step fails, print `⚠ Issue Project status update failed — update manually` and continue.
+   - If any step fails for an issue, print `⚠ Issue Project status update failed for #<N> — update manually` and continue to the next linked issue.
 
-9. Apply tracking labels to PR (inherit from linked issue; default priority `p1`):
-   If a linked issue number N was found in step 8:
-   ```bash
-   gh issue view <N> --repo pureliture/ai-cli-orch-wrapper --json labels -q '.labels[].name'
-   ```
-   Build the desired PR label set from the linked issue:
-   - highest priority label `p0`, `p1`, or `p2` (default `p1` if none found)
-   - first `type:*` label
-   - first `area:*` label
-   - `origin:review` if present
+9. Apply tracking labels to PR (inherit from linked issues; default priority `p1`):
+   If any linked issue numbers were found in step 8:
+   - For EACH linked issue, fetch labels: `gh issue view <N> --repo pureliture/ai-cli-orch-wrapper --json labels -q '.labels[].name'`
+   - Collect all labels from all linked issues.
+   - Determine the highest priority label among all discovered labels (`p0` > `p1` > `p2`). If no priority label is found on any issue, use `p1`.
+   - Take the first `type:*` label found across the issues (prioritizing the first issue's type).
+   - Take the first `area:*` label found across the issues (prioritizing the first issue's area).
+   - Include `origin:review` if it exists on ANY of the linked issues.
    Do NOT copy `status:*` or `sprint:*` labels onto the PR.
    Inspect the PR's current labels first:
    ```bash
@@ -140,7 +137,6 @@ Create a GitHub Pull Request in `pureliture/ai-cli-orch-wrapper`. The PR body mu
    ```bash
    gh pr edit <pr_url> --repo pureliture/ai-cli-orch-wrapper --add-label <label>
    ```
-   If multiple linked issues have different priorities, use the highest (`p0` > `p1` > `p2`).
    If no linked issue keyword is found, skip `type:*`, `area:*`, and `origin:review`, but still apply default priority `p1`.
    If any label step fails, print `⚠ PR label sync failed — update manually` and continue.
 


### PR DESCRIPTION
Closes #29

## What

Updated the `/gh-pr` command templates and the fallback synchronization hook to support multiple linked issues. The PR now correctly parses all closing keywords (Closes, Fixes, Resolves) and applies a deterministic highest-wins priority resolution policy.

## Why

Currently, `/gh-pr` step 9 mentions handling multiple linked issues but step 8 only extracts one. This change resolves that contradiction, ensuring that PR priority inheritance and Project status updates are consistent across all referenced issues.

## Changes

- Update `templates/commands/gh-pr.md` to parse all closing keywords and iterate status updates over all unique linked issues.
- Synchronize `.claude/commands/gh-pr.md` with the updated multi-issue extraction and priority logic.
- Update `scripts/pm-hook.sh` to support multiple issue extraction from command strings and PR bodies, implementing the highest-wins priority policy (p0 > p1 > p2).
- Ensure priority defaults to `p1` when no priority labels are present on any linked issues.

## Checklist
- [x] npm test passes
- [x] manual smoke test
- [x] docs updated if needed