### PR TITLE
chore: archive gh-pr multi-linked issue priority change

### DIFF
--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/design.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/design.md
@@ -1,0 +1,77 @@
+## Context
+
+`/gh-pr`의 현재 프롬프트는 step 9에서 "여러 linked issue의 priority가 다르면 가장 높은 priority를 사용한다"는 정책을 이미 언급하지만, step 8은 여전히 단일 `Closes #N`만 추출하는 흐름으로 적혀 있다. 그 결과 커맨드 템플릿, `scripts/pm-hook.sh` fallback, 그리고 스펙 시나리오가 모두 단일 linked issue 기준으로 갈라져 있으며, multi-issue PR에서 어떤 이슈를 기준으로 상태를 바꾸고 priority를 상속해야 하는지 결정 경로가 없다.
+
+이 change는 새로운 PM 자동화 축을 도입하는 작업이 아니라, 기존 `/gh-pr` 동작을 다중 linked issue 입력에 대해 일관되게 만드는 정합성 수정이다. 영향 범위는 slash command 문서, fallback hook, 그리고 관련 스펙이다.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `/gh-pr`가 PR 본문에서 모든 `Closes`/`Fixes`/`Resolves` 이슈 참조를 추출하도록 요구사항을 명확히 한다.
+- status 업데이트와 priority 상속이 같은 linked issue 집합을 사용하도록 정리한다.
+- 서로 다른 priority가 섞인 경우에도 단일하고 결정적인 정책으로 PR priority를 계산하게 한다.
+- 다중 linked issue 시나리오를 스펙에 추가해 이후 템플릿/스크립트 수정 시 회귀를 막는다.
+
+**Non-Goals:**
+- 새로운 label namespace 또는 Project field를 도입하지 않는다.
+- cross-repo issue reference, full GitHub autolink 문법 전체를 지원 범위로 넓히지 않는다.
+- PR 본문 작성 방식 자체를 바꾸지 않는다. 사용자는 계속 `Closes #N`, `Fixes #N`, `Resolves #N` 형태를 사용한다.
+
+## Decisions
+
+### D1: Linked issue를 단일 값이 아닌 "순서 보존 + 중복 제거된 목록"으로 취급한다
+
+**결정**: `/gh-pr`는 PR 본문에서 closing keyword로 참조된 이슈 번호를 모두 수집하고, 본문 등장 순서를 유지하되 중복 번호는 한 번만 남긴 목록으로 취급한다.
+
+**이유**: priority 계산과 issue status 업데이트가 서로 다른 파서나 다른 기준을 사용하면 다시 모순이 생긴다. ordered unique list를 공통 입력으로 정의하면 downstream 단계가 모두 같은 해석을 공유한다.
+
+**대안 고려**:
+- 첫 번째 이슈만 사용: 현재 모순을 그대로 유지한다.
+- 마지막 이슈만 사용: 사용자 입장에서 예측 가능성이 낮다.
+- 중복 포함 원본 배열 사용: 상태 업데이트와 label 계산에서 불필요한 중복 작업이 생긴다.
+
+### D2: Priority 해석은 "가장 높은 priority wins"로 고정한다
+
+**결정**: linked issue 집합에서 발견된 `p0`/`p1`/`p2` 중 가장 높은 값을 PR priority로 사용한다. 우선순위는 `p0 > p1 > p2`이며, 어떤 linked issue에도 priority가 없으면 `p1`을 적용한다.
+
+**이유**: issue #29의 acceptance criteria와 현재 프롬프트 문구가 이미 highest-wins 방향을 시사한다. 또한 여러 이슈를 함께 닫는 PR은 보통 가장 긴급한 트래킹 관점에 맞춰 분류하는 편이 backlog triage와 리뷰 우선순위에 더 안전하다.
+
+**대안 고려**:
+- 첫 번째 linked issue의 priority 사용: 본문 순서라는 우연한 요소에 결과가 좌우된다.
+- 가장 낮은 priority 사용: 긴급 이슈가 PR에서 희석될 수 있다.
+- priority 충돌 시 사용자 입력 요구: `/gh-pr`의 자동화 흐름을 불필요하게 끊는다.
+
+### D3: Linked issue status 업데이트도 동일한 목록 전체에 적용한다
+
+**결정**: PR 생성 후 Project "In Review" 상태로 옮기는 단계는 첫 번째 linked issue만이 아니라, 파싱된 모든 linked issue에 대해 반복 적용한다.
+
+**이유**: step 8을 다중 issue 파싱으로 바꾸면서 status 처리를 그대로 단수로 남기면 command flow가 다시 분기된다. "linked issues" 목록을 만들었다면 status와 priority 모두 그 목록을 소비해야 설명이 일관된다.
+
+**대안 고려**:
+- status는 첫 번째 issue만, priority만 전체 사용: 구현은 단순해 보여도 사용자 기대와 문서가 어긋난다.
+- status 단계는 그대로 두고 spec에서만 priority 정책 추가: 현재 이슈의 모순을 절반만 해결한다.
+
+### D4: Fallback hook도 command spec과 같은 정책을 따라야 한다
+
+**결정**: `scripts/pm-hook.sh`의 fallback 동작 역시 다중 linked issue 목록을 동일하게 해석해야 하며, command template과 다른 우선순위 규칙을 두지 않는다.
+
+**이유**: 이 저장소는 `/gh-pr` 직접 처리와 hook fallback의 이중 방어 구조를 사용한다. 두 경로가 다른 priority 결과를 내면 idempotent fallback이 아니라 drift source가 된다.
+
+**대안 고려**:
+- hook은 단일 issue 유지: manual `gh pr create` 경로에서 결과가 달라진다.
+- hook은 priority만 맞추고 status는 단일 issue 유지: 두 자동화 경로가 다시 어긋난다.
+
+## Risks / Trade-offs
+
+- **[Risk] PR 본문 파싱 복잡도 증가** → closing keyword 범위를 `Closes`/`Fixes`/`Resolves`와 같은 기존 패턴으로 제한하고, 다중 reference는 그 반복으로만 해석한다.
+- **[Risk] 여러 linked issue를 모두 In Review로 옮기면 예상보다 넓게 상태가 변할 수 있음** → closing keyword가 명시된 issue만 대상으로 하고, 일반 `#N` 언급은 무시한다.
+- **[Risk] 기존 hook/템플릿/테스트가 단일 issue 가정을 갖고 있을 수 있음** → spec과 tasks에서 command template, hook, 시나리오 테스트를 함께 갱신 대상으로 묶는다.
+- **[Trade-off] command 문구와 구현 단계가 조금 길어진다** → 대신 priority/status 정책이 명확해져 운영 ambiguity가 줄어든다.
+
+## Migration Plan
+
+문서와 자동화 로직을 함께 갱신하는 변경이므로 별도 데이터 마이그레이션은 없다. 배포 순서는 `/gh-pr` 템플릿 갱신, fallback hook 동기화, multi-linked-issue 시나리오 검증 순으로 진행한다.
+
+## Open Questions
+
+- 없음. 이 change는 issue #29 acceptance criteria에 맞춰 highest-wins 정책을 확정한다.

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/proposal.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`/gh-pr` already states that a PR linked to multiple issues should inherit the highest priority label, but the command flow still extracts only one closing reference from the PR body. That mismatch leaves multi-issue PR behavior underspecified and makes the prompt, fallback automation, and spec scenarios inconsistent.
+
+## What Changes
+
+- Update `/gh-pr` linked-issue parsing to collect all `Closes`/`Fixes`/`Resolves` references from the PR body instead of a single issue number.
+- Define an explicit priority resolution policy for multiple linked issues: choose the highest priority label across linked issues (`p0 > p1 > p2`), defaulting to `p1` when none are present.
+- Clarify how linked-issue status updates and PR label inheritance behave when more than one issue is referenced.
+- Add spec scenarios that cover multi-linked-issue priority inheritance so future prompt or script edits cannot reintroduce the contradiction.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `gh-pr-cmd`: `/gh-pr` must parse multiple closing keywords from the PR body and follow a deterministic multi-linked-issue flow.
+- `gh-pr-priority-label`: PR priority inheritance must resolve across multiple linked issues using an explicit precedence rule.
+- `gh-pr-project-status`: linked issue status updates must apply to every referenced issue rather than only the first parsed issue.
+
+## Impact
+
+- `templates/commands/gh-pr.md` and `.claude/commands/gh-pr.md`
+- `scripts/pm-hook.sh` linked-issue extraction and priority sync logic
+- Multi-issue scenario coverage for `/gh-pr` command behavior

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-cmd/spec.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-cmd/spec.md
@@ -1,7 +1,7 @@
 ## MODIFIED Requirements
 
 ### Requirement: /gh-pr command creates a pull request
-The system SHALL provide a `/gh-pr` Claude Code slash command that creates a GitHub PR in `pureliture/ai-cli-orch-wrapper` with a conventional commit title, one or more closing issue references, a CI checklist body, an Epic checkbox reminder, explicit PM Project status management, and priority label inheritance.
+The system SHALL provide a `/gh-pr` Claude Code slash command that creates a GitHub PR in `pureliture/ai-cli-orch-wrapper` with a conventional commit title, one or more closing issue references, a CI checklist body, an Epic checkbox reminder, explicit PM Project status management, and tracking label inheritance (priority, type, area, and origin).
 
 #### Scenario: PR creation with issue reference
 - **WHEN** user invokes `/gh-pr` with issue number N
@@ -18,7 +18,7 @@ The system SHALL provide a `/gh-pr` Claude Code slash command that creates a Git
 
 #### Scenario: Conventional commit title
 - **WHEN** user invokes `/gh-pr`
-- **THEN** PR title SHALL follow `<type>: <description>` format, matching the issue's conventional commit title
+- **THEN** PR title SHALL follow `<type>(<scope>): <description>` format, matching the issue's conventional commit title and identifying the affected area
 
 #### Scenario: PR added to PM Project with In Review status
 - **WHEN** PR is successfully created

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-cmd/spec.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-cmd/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: /gh-pr command creates a pull request
+The system SHALL provide a `/gh-pr` Claude Code slash command that creates a GitHub PR in `pureliture/ai-cli-orch-wrapper` with a conventional commit title, one or more closing issue references, a CI checklist body, an Epic checkbox reminder, explicit PM Project status management, and priority label inheritance.
+
+#### Scenario: PR creation with issue reference
+- **WHEN** user invokes `/gh-pr` with issue number N
+- **THEN** system SHALL run `gh pr create --repo pureliture/ai-cli-orch-wrapper` with title derived from the current branch or provided input
+- **AND** the PR body SHALL contain at least one closing keyword reference for the linked issue
+
+#### Scenario: CI checklist inclusion
+- **WHEN** PR is created
+- **THEN** PR body SHALL include a checklist section: `- [ ] npm test passes`, `- [ ] manual smoke test`, `- [ ] docs updated if needed`
+
+#### Scenario: Epic checkbox reminder
+- **WHEN** PR is created and a parent epic exists
+- **THEN** PR body SHALL include a reminder line: `> Note: manually check parent epic #<N> checkbox after merge`
+
+#### Scenario: Conventional commit title
+- **WHEN** user invokes `/gh-pr`
+- **THEN** PR title SHALL follow `<type>: <description>` format, matching the issue's conventional commit title
+
+#### Scenario: PR added to PM Project with In Review status
+- **WHEN** PR is successfully created
+- **THEN** system SHALL add the PR to Project #3 and set its Status to "In Review"
+
+#### Scenario: Multiple linked issues are parsed from PR body
+- **WHEN** PR body contains multiple `Closes #N`, `Fixes #N`, or `Resolves #N` references
+- **THEN** system SHALL collect every referenced issue number in body order
+- **AND** system SHALL de-duplicate repeated references before passing the linked issue list to downstream status and label steps
+
+#### Scenario: Linked issues set to In Review
+- **WHEN** PR body contains one or more `Closes #N`, `Fixes #N`, or `Resolves #N` references
+- **THEN** system SHALL set each linked issue's Project Status to "In Review"
+
+#### Scenario: Priority label applied to PR
+- **WHEN** PR is created
+- **THEN** system SHALL apply a `p0`/`p1`/`p2` priority label resolved from linked issues or defaulting to `p1`

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-priority-label/spec.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-priority-label/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: /gh-pr inherits priority label from linked issue
+The system SHALL apply a single priority label (`p0`, `p1`, or `p2`) to the PR, resolving across all linked issues by selecting the highest available priority label and defaulting to `p1` when none are present.
+
+#### Scenario: Priority label inherited from a single linked issue
+- **WHEN** PR body contains one linked issue reference and that issue has a `p0`, `p1`, or `p2` label
+- **THEN** system SHALL apply the same priority label to the PR via `gh pr edit --add-label <priority>`
+
+#### Scenario: Highest priority wins across multiple linked issues
+- **WHEN** PR body contains multiple linked issue references and those issues carry different priority labels
+- **THEN** system SHALL apply the highest priority label to the PR using precedence `p0 > p1 > p2`
+
+#### Scenario: Default priority when no linked issue priority exists
+- **WHEN** none of the linked issues has a `p0`/`p1`/`p2` label, OR no linked issue is present
+- **THEN** system SHALL apply `p1` as the default priority label to the PR
+
+#### Scenario: Priority label not duplicated
+- **WHEN** PR already has a priority label
+- **THEN** system SHALL NOT add a second priority label

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-project-status/spec.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/specs/gh-pr-project-status/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: /gh-pr adds PR to PM Project and sets In Review status
+The system SHALL, after creating a PR, explicitly add the PR to the PM Project and set its Status to "In Review" via `gh project item-edit`, without relying solely on the PostToolUse hook.
+
+#### Scenario: PR added to Project on creation
+- **WHEN** user invokes `/gh-pr` and PR is successfully created
+- **THEN** system SHALL run `gh project item-add 3 --owner pureliture --url <pr_url>` to add the PR to Project #3
+- **AND** system SHALL run `gh project item-edit` to set the PR item Status to "In Review"
+
+#### Scenario: All linked issues are set to In Review
+- **WHEN** PR body contains one or more `Closes #N`, `Fixes #N`, or `Resolves #N` references
+- **THEN** system SHALL find the Project item for each referenced issue and set each Status to "In Review"
+
+#### Scenario: Duplicate linked issue references are de-duplicated
+- **WHEN** the PR body references the same issue more than once with closing keywords
+- **THEN** system SHALL update that issue's Project status at most once during the `/gh-pr` run
+
+#### Scenario: Idempotent operation
+- **WHEN** PR or any linked issue is already present in the Project
+- **THEN** system SHALL update the Status without creating a duplicate item
+
+#### Scenario: Project update failure does not block PR
+- **WHEN** any `gh project item-add` or `gh project item-edit` call fails
+- **THEN** system SHALL print a warning message (e.g., `⚠ Project status update failed — update manually`)
+- **AND** system SHALL NOT fail or abort the overall `/gh-pr` command
+
+#### Scenario: No linked issue present
+- **WHEN** PR body contains no `Closes`, `Fixes`, or `Resolves` keyword
+- **THEN** system SHALL skip the linked issue status step and continue without error

--- a/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/tasks.md
+++ b/openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/tasks.md
@@ -1,0 +1,19 @@
+## 1. `/gh-pr` 템플릿 갱신
+
+- [x] 1.1 `templates/commands/gh-pr.md`와 `.claude/commands/gh-pr.md`의 현재 single-linked-issue 파싱 단계를 검토한다
+- [x] 1.2 step 8을 갱신해 PR 본문에서 모든 `Closes #N` / `Fixes #N` / `Resolves #N` 참조를 순서 보존 + 중복 제거된 linked issue 목록으로 추출한다
+- [x] 1.3 step 8의 Project status 처리 로직을 갱신해 linked issue 목록의 모든 이슈를 `"In Review"`로 전환하도록 만든다
+- [x] 1.4 step 9의 priority 상속 로직을 갱신해 linked issue 목록 전체에서 `p0 > p1 > p2` 최고 우선순위를 선택하고, 없으면 `p1`을 적용하도록 만든다
+
+## 2. Fallback 자동화 동기화
+
+- [x] 2.1 `scripts/pm-hook.sh`의 current linked issue 추출 경로(command 문자열, PR body, branch fallback)를 검토한다
+- [x] 2.2 hook이 multiple closing keyword를 ordered unique linked issue 목록으로 파싱하도록 갱신한다
+- [x] 2.3 hook의 issue status 업데이트를 linked issue 목록 전체에 반복 적용하도록 갱신한다
+- [x] 2.4 hook의 PR priority 계산을 highest-wins 정책과 `p1` 기본값에 맞게 동기화하고, 중복 참조가 있어도 중복 적용하지 않도록 보장한다
+
+## 3. 검증
+
+- [x] 3.1 서로 다른 priority를 가진 두 linked issue를 포함한 PR 본문으로 `/gh-pr` 흐름을 검증해 PR에 가장 높은 priority만 적용되는지 확인한다
+- [x] 3.2 여러 linked issue가 모두 PM Project에서 `"In Review"`로 전환되는지 확인한다
+- [x] 3.3 linked issue에 priority가 없을 때 `p1`이 적용되는지, 같은 issue를 여러 번 참조해도 중복 상태 변경이나 중복 label 추가가 없는지 확인한다


### PR DESCRIPTION
## What

Archive the completed OpenSpec delta for the already-merged `/gh-pr` multi-linked issue priority behavior. This keeps the original proposal, design, tasks, and delta specs under `openspec/changes/archive/2026-04-22-support-gh-pr-multi-linked-issue-priority/`.

## Why

The implementation was merged in #42, but the corresponding OpenSpec change directory was left untracked in the local worktree. Archiving it preserves the change record without keeping it in the active changes list.

## Changes

- Add archived OpenSpec artifacts for `support-gh-pr-multi-linked-issue-priority`
- Preserve the completed proposal, design, tasks, and delta specs
- Keep the active OpenSpec change list free of this completed change

## Checklist

- [x] `openspec validate support-gh-pr-multi-linked-issue-priority --strict` passed before archive
- [x] Archived change no longer appears in `openspec list --json`
- [ ] manual smoke test