### PR TITLE
chore: improve gh-issue body authoring quality

### DIFF
--- a/.claude/commands/gh-issue.md
+++ b/.claude/commands/gh-issue.md
@@ -12,7 +12,10 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
    - **Title**: Full issue title in `type: description` format. Valid types: `feat`, `fix`, `bug`, `chore`, `task`, `spike`, `epic`. Example: `feat: add gh-pm-workflow-commands`. Do NOT use `[Sprint V3][Task]` prefix — that convention is deprecated as of V3.
    - **Sprint label**: The sprint label to apply (e.g., `sprint:v3` or `sprint:v4`). If not provided, ask before creating the issue rather than assuming a sprint.
    - **Priority**: If the user explicitly mentions urgency (e.g., "critical", "blocking", "low priority"), map it to `p0`/`p1`/`p2` accordingly. Otherwise, default to `p1` without asking.
+   - **Additional labels** (optional): Extra labels to apply (e.g., `documentation`). Use `documentation` for docs-related issues.
    - **Parent epic** (optional): Epic issue number to link as parent (e.g., `22`)
+   - **Body context**: Goal/problem, concrete scope, completion criteria, and any constraints or references. If the user provided enough context, infer these sections. If any required section would be vague, ask at most 2 concise follow-up questions before creating the issue.
+   - **Language**: Write issue body content and any follow-up questions in Korean by default. Keep conventional title prefixes, labels, code identifiers, file paths, command names, and established Markdown headings in their original language. If the user explicitly asks for another language, follow that request.
 
 2. Infer the `type:*` label from the title prefix:
    - `feat:` → `type:feature`
@@ -22,23 +25,57 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
    - `spike:` → `type:spike`
    - `epic:` → `type:epic`
 
-3. Construct the issue body:
+3. Construct a complete issue body:
    - If a parent epic number was provided, the first line of the body MUST be: `Parent epic: #<N>`
-   - Otherwise, leave the body empty.
+   - Include the following sections after the optional parent epic line:
+     ```markdown
+     ## Purpose
+     <1-3 sentences explaining the problem or goal. Do not merely repeat the title.>
 
-4. Create the issue:
+     ## Scope & Requirements
+     - [ ] <Concrete requirement or task>
+     - [ ] <Concrete requirement or task>
+
+     ## Acceptance Criteria
+     - [ ] <Observable completion condition>
+     ```
+   - Add `## Notes` only when there are useful constraints, links, implementation hints, or explicit non-goals.
+   - Write the prose and checklist item descriptions in Korean by default.
+   - For `bug:` or `fix:` issues, use concrete behavior in `Scope & Requirements`; include reproduction details in `## Notes` when available.
+   - For `spike:` issues, make `Acceptance Criteria` describe the expected decision, research note, or recommendation.
+   - For `epic:` issues, include child issue planning in `Scope & Requirements`.
+
+4. Quality bar — before creating the issue, verify:
+   - `## Purpose`, `## Scope & Requirements`, and `## Acceptance Criteria` are present.
+   - `Purpose` explains why the work matters and does not only restate the title.
+   - `Scope & Requirements` has at least 2 checklist items unless this is a tiny bug.
+   - `Acceptance Criteria` has at least 1 observable completion condition.
+   - Body prose and checklist item descriptions are Korean by default unless the user explicitly requested another language.
+   - No section contains placeholder text like `<...>`, `TBD`, or `TODO`.
+   - If a parent epic was provided, `Parent epic: #<N>` remains the first line.
+
+5. Write the body to a temporary Markdown file. Use `--body-file` rather than inline `--body` so multiline Markdown, checkboxes, and backticks are preserved:
+   ```bash
+   BODY_FILE=$(mktemp)
+   cat > "$BODY_FILE" <<'EOF'
+   <body>
+   EOF
+   ```
+
+6. Create the issue:
    ```bash
    gh issue create \
      --repo pureliture/ai-cli-orch-wrapper \
      --title "<title>" \
-     --label "<type-label>,<sprint-label>,<priority>" \
-     --body "<body>"
+     --label "<type-label>,<sprint-label>,<priority>,<additional-labels>" \
+     --body-file "$BODY_FILE"
    ```
    Where `<priority>` is one of `p0`, `p1`, or `p2` (default: `p1` if not specified).
+   If no additional labels were provided, omit `<additional-labels>` from the label string.
 
-5. Capture the created issue URL from the output.
+7. Capture the created issue URL from the output.
 
-6. Add the issue to Project #3 and set fields:
+8. Add the issue to Project #3 and set fields:
    Add to project and capture the item ID:
    ```bash
    ITEM_ID=$(gh project item-add 3 --owner pureliture --url <issue_url> --format json --jq '.id')
@@ -54,7 +91,7 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
      --field-id PVTSSF_lAHOA6302M4BT5fAzhBFN_U --single-select-option-id <priority-option-id>
    ```
 
-7. If a parent epic was provided, establish native sub-issue linkage:
+9. If a parent epic was provided, establish native sub-issue linkage:
    - Get node IDs for both issues:
      ```bash
      PARENT_ID=$(gh issue view <parent-N> --repo pureliture/ai-cli-orch-wrapper --json id -q .id)
@@ -71,4 +108,4 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
      ```
    - If this step fails, print a warning `⚠ Native epic linkage failed — body reference maintained` and continue. Do NOT fail the command.
 
-8. Report the created issue URL and number to the user.
+10. Report the created issue URL and number to the user.

--- a/.claude/commands/gh-issue.md
+++ b/.claude/commands/gh-issue.md
@@ -57,9 +57,10 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
 5. Write the body to a temporary Markdown file. Use `--body-file` rather than inline `--body` so multiline Markdown, checkboxes, and backticks are preserved:
    ```bash
    BODY_FILE=$(mktemp)
-   cat > "$BODY_FILE" <<'EOF'
+   trap 'rm -f "$BODY_FILE"' EXIT
+   cat > "$BODY_FILE" <<'_CLAUDE_GH_ISSUE_BODY_'
    <body>
-   EOF
+   _CLAUDE_GH_ISSUE_BODY_
    ```
 
 6. Create the issue:
@@ -67,11 +68,19 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
    gh issue create \
      --repo pureliture/ai-cli-orch-wrapper \
      --title "<title>" \
-     --label "<type-label>,<sprint-label>,<priority>,<additional-labels>" \
+     --label "$LABELS" \
      --body-file "$BODY_FILE"
    ```
    Where `<priority>` is one of `p0`, `p1`, or `p2` (default: `p1` if not specified).
-   If no additional labels were provided, omit `<additional-labels>` from the label string.
+   Construct `LABELS` to avoid trailing commas when `additional-labels` is empty:
+   ```bash
+   BASE_LABELS="<type-label>,<sprint-label>,<priority>"
+   if [ -n "<additional-labels>" ]; then
+     LABELS="$BASE_LABELS,<additional-labels>"
+   else
+     LABELS="$BASE_LABELS"
+   fi
+   ```
 
 7. Capture the created issue URL from the output.
 

--- a/docs/pm-board.md
+++ b/docs/pm-board.md
@@ -85,6 +85,29 @@ Rules:
   - Initial `Status` must be set to `Backlog`.
   - `Priority` (`P0`/`P1`/`P2`) must be mirrored from label to Project field.
 
+### Issue Body Template
+
+`/gh-issue` must create actionable issue bodies, not empty placeholders. Every issue body should include:
+
+```md
+## Purpose
+<1-3 sentences explaining the problem or goal>
+
+## Scope & Requirements
+- [ ] <Concrete requirement or task>
+- [ ] <Concrete requirement or task>
+
+## Acceptance Criteria
+- [ ] <Observable completion condition>
+```
+
+Rules:
+- If a parent epic exists, `Parent epic: #N` remains the first line before the template sections.
+- Write issue body prose and checklist item descriptions in Korean by default. Keep conventional title prefixes, labels, file paths, command names, and established Markdown headings in their original language.
+- Ask at most two concise follow-up questions before creation when the available context is too vague to fill the required sections.
+- Use `--body-file` for multiline Markdown issue bodies so headings, checkboxes, and code spans are preserved.
+- Do not create an issue body containing placeholder text such as `<...>`, `TBD`, or `TODO`.
+
 **Legacy format** (pre-V3, for reference only):
 ```text
 [Sprint V3][Epic] PM 하네스 구축 — GitHub Projects + Actions + Claude Code

--- a/docs/pm-board.md
+++ b/docs/pm-board.md
@@ -90,6 +90,8 @@ Rules:
 `/gh-issue` must create actionable issue bodies, not empty placeholders. Every issue body should include:
 
 ```md
+[Parent epic: #N]
+
 ## Purpose
 <1-3 sentences explaining the problem or goal>
 

--- a/openspec/changes/improve-gh-issue-body-quality/.openspec.yaml
+++ b/openspec/changes/improve-gh-issue-body-quality/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-21

--- a/openspec/changes/improve-gh-issue-body-quality/proposal.md
+++ b/openspec/changes/improve-gh-issue-body-quality/proposal.md
@@ -1,0 +1,18 @@
+## Why
+
+`/gh-issue` currently creates issues with sparse bodies because the command template only preserves `Parent epic: #N` and otherwise allows an empty body. Issue #44 showed the operational cost: the generated issue was not actionable enough and had to be rewritten manually after creation.
+
+## What Changes
+
+- Update `/gh-issue` to construct structured issue bodies with `Purpose`, `Scope & Requirements`, and `Acceptance Criteria`.
+- Write issue body prose and checklist items in Korean by default while preserving conventional prefixes, labels, code identifiers, and established Markdown headings.
+- Require concise follow-up questions when the provided context is too vague to fill the required body sections concretely.
+- Use `gh issue create --body-file` instead of inline `--body` for multiline Markdown safety.
+- Document the issue authoring contract in `docs/pm-board.md`.
+
+## Impact
+
+- `templates/commands/gh-issue.md`
+- `.claude/commands/gh-issue.md`
+- `docs/pm-board.md`
+- New OpenSpec delta for `gh-issue-cmd`

--- a/openspec/changes/improve-gh-issue-body-quality/specs/gh-issue-cmd/spec.md
+++ b/openspec/changes/improve-gh-issue-body-quality/specs/gh-issue-cmd/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: /gh-issue slash command creates a GitHub issue
+The system SHALL provide a `/gh-issue` Claude Code slash command that creates a GitHub issue in `pureliture/ai-cli-orch-wrapper` with conventional commit format title, appropriate labels including a priority label, an actionable structured body, explicit Project #3 Backlog assignment, and optional native parent epic linkage.
+
+#### Scenario: Basic issue creation
+- **WHEN** user invokes `/gh-issue` with a title, type, sprint label, and enough body context
+- **THEN** system runs `gh issue create --repo pureliture/ai-cli-orch-wrapper` with the provided title and labels (`type:<type>`, provided `sprint:v*`, `p0`/`p1`/`p2`)
+- **AND** system SHALL use `--body-file` to pass the generated Markdown issue body
+- **AND** system SHALL add the created issue to Project #3 and set its Status to `Backlog`
+
+#### Scenario: Structured body creation
+- **WHEN** user invokes `/gh-issue`
+- **THEN** the issue body SHALL include `## Purpose`, `## Scope & Requirements`, and `## Acceptance Criteria`
+- **AND** `## Scope & Requirements` SHALL contain concrete checklist items unless the issue is a tiny bug
+- **AND** `## Acceptance Criteria` SHALL contain at least one observable completion condition
+
+#### Scenario: Korean body by default
+- **WHEN** user invokes `/gh-issue` without explicitly requesting another language
+- **THEN** issue body prose and checklist item descriptions SHALL be written in Korean
+- **AND** conventional title prefixes, labels, code identifiers, file paths, command names, and established Markdown headings MAY remain in their original language
+
+#### Scenario: Missing body context
+- **WHEN** available user input is insufficient to fill required body sections concretely
+- **THEN** the command SHALL ask concise follow-up questions before creating the issue
+- **AND** the command SHALL ask no more than two follow-up questions in one turn
+
+#### Scenario: Placeholder rejection
+- **WHEN** the generated issue body still contains placeholder text such as `<...>`, `TBD`, or `TODO`
+- **THEN** the command SHALL revise the body before calling `gh issue create`
+
+#### Scenario: Title convention enforcement
+- **WHEN** user invokes `/gh-issue`
+- **THEN** the created issue title SHALL follow `<type>: <description>` format (e.g., `feat: add user auth`) with no `[Sprint V*]` or `[Task]` prefix
+
+#### Scenario: Epic parent linking
+- **WHEN** user invokes `/gh-issue` with a parent epic number
+- **THEN** issue body SHALL include `Parent epic: #<N>` as the first line
+- **AND** system SHALL attempt GitHub native sub-issue linkage for the created issue under the parent epic
+
+#### Scenario: Native sub-issue linkage failure does not block issue creation
+- **WHEN** the native sub-issue linkage mutation fails after the issue is created
+- **THEN** system SHALL print a warning and continue without rolling back the created issue
+
+#### Scenario: Project Backlog assignment
+- **WHEN** issue is created
+- **THEN** system SHALL add the issue to GitHub Project #3 (`PVT_kwHOA6302M4BT5fA`)
+- **AND** system SHALL set the Project item status to `Backlog`
+
+#### Scenario: Priority label applied at creation
+- **WHEN** user invokes `/gh-issue`
+- **THEN** system SHALL prompt for or infer a `p0`/`p1`/`p2` priority label and include it in the `gh issue create --label` argument

--- a/openspec/changes/improve-gh-issue-body-quality/tasks.md
+++ b/openspec/changes/improve-gh-issue-body-quality/tasks.md
@@ -1,0 +1,12 @@
+## 1. `/gh-issue` body quality
+
+- [x] 1.1 Replace the empty-body rule with a structured body template.
+- [x] 1.2 Add a quality bar for required sections, concrete checklist items, and placeholder rejection.
+- [x] 1.3 Switch issue creation instructions from inline `--body` to `--body-file`.
+
+## 2. Documentation and validation
+
+- [x] 2.1 Document issue body authoring rules in `docs/pm-board.md`.
+- [x] 2.2 Add OpenSpec requirements for actionable issue body creation.
+- [x] 2.3 Validate the change with OpenSpec.
+- [x] 2.4 Create a GitHub tracking issue using the updated `/gh-issue` contract.

--- a/templates/commands/gh-issue.md
+++ b/templates/commands/gh-issue.md
@@ -12,7 +12,10 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
    - **Title**: Full issue title in `type: description` format. Valid types: `feat`, `fix`, `bug`, `chore`, `task`, `spike`, `epic`. Example: `feat: add gh-pm-workflow-commands`. Do NOT use `[Sprint V3][Task]` prefix — that convention is deprecated as of V3.
    - **Sprint label**: The sprint label to apply (e.g., `sprint:v3` or `sprint:v4`). If not provided, ask before creating the issue rather than assuming a sprint.
    - **Priority**: If the user explicitly mentions urgency (e.g., "critical", "blocking", "low priority"), map it to `p0`/`p1`/`p2` accordingly. Otherwise, default to `p1` without asking.
+   - **Additional labels** (optional): Extra labels to apply (e.g., `documentation`). Use `documentation` for docs-related issues.
    - **Parent epic** (optional): Epic issue number to link as parent (e.g., `22`)
+   - **Body context**: Goal/problem, concrete scope, completion criteria, and any constraints or references. If the user provided enough context, infer these sections. If any required section would be vague, ask at most 2 concise follow-up questions before creating the issue.
+   - **Language**: Write issue body content and any follow-up questions in Korean by default. Keep conventional title prefixes, labels, code identifiers, file paths, command names, and established Markdown headings in their original language. If the user explicitly asks for another language, follow that request.
 
 2. Infer the `type:*` label from the title prefix:
    - `feat:` → `type:feature`
@@ -22,23 +25,57 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
    - `spike:` → `type:spike`
    - `epic:` → `type:epic`
 
-3. Construct the issue body:
+3. Construct a complete issue body:
    - If a parent epic number was provided, the first line of the body MUST be: `Parent epic: #<N>`
-   - Otherwise, leave the body empty.
+   - Include the following sections after the optional parent epic line:
+     ```markdown
+     ## Purpose
+     <1-3 sentences explaining the problem or goal. Do not merely repeat the title.>
 
-4. Create the issue:
+     ## Scope & Requirements
+     - [ ] <Concrete requirement or task>
+     - [ ] <Concrete requirement or task>
+
+     ## Acceptance Criteria
+     - [ ] <Observable completion condition>
+     ```
+   - Add `## Notes` only when there are useful constraints, links, implementation hints, or explicit non-goals.
+   - Write the prose and checklist item descriptions in Korean by default.
+   - For `bug:` or `fix:` issues, use concrete behavior in `Scope & Requirements`; include reproduction details in `## Notes` when available.
+   - For `spike:` issues, make `Acceptance Criteria` describe the expected decision, research note, or recommendation.
+   - For `epic:` issues, include child issue planning in `Scope & Requirements`.
+
+4. Quality bar — before creating the issue, verify:
+   - `## Purpose`, `## Scope & Requirements`, and `## Acceptance Criteria` are present.
+   - `Purpose` explains why the work matters and does not only restate the title.
+   - `Scope & Requirements` has at least 2 checklist items unless this is a tiny bug.
+   - `Acceptance Criteria` has at least 1 observable completion condition.
+   - Body prose and checklist item descriptions are Korean by default unless the user explicitly requested another language.
+   - No section contains placeholder text like `<...>`, `TBD`, or `TODO`.
+   - If a parent epic was provided, `Parent epic: #<N>` remains the first line.
+
+5. Write the body to a temporary Markdown file. Use `--body-file` rather than inline `--body` so multiline Markdown, checkboxes, and backticks are preserved:
+   ```bash
+   BODY_FILE=$(mktemp)
+   cat > "$BODY_FILE" <<'EOF'
+   <body>
+   EOF
+   ```
+
+6. Create the issue:
    ```bash
    gh issue create \
      --repo pureliture/ai-cli-orch-wrapper \
      --title "<title>" \
-     --label "<type-label>,<sprint-label>,<priority>" \
-     --body "<body>"
+     --label "<type-label>,<sprint-label>,<priority>,<additional-labels>" \
+     --body-file "$BODY_FILE"
    ```
    Where `<priority>` is one of `p0`, `p1`, or `p2` (default: `p1` if not specified).
+   If no additional labels were provided, omit `<additional-labels>` from the label string.
 
-5. Capture the created issue URL from the output.
+7. Capture the created issue URL from the output.
 
-6. Add the issue to Project #3 and set fields:
+8. Add the issue to Project #3 and set fields:
    Add to project and capture the item ID:
    ```bash
    ITEM_ID=$(gh project item-add 3 --owner pureliture --url <issue_url> --format json --jq '.id')
@@ -54,7 +91,7 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
      --field-id PVTSSF_lAHOA6302M4BT5fAzhBFN_U --single-select-option-id <priority-option-id>
    ```
 
-7. If a parent epic was provided, establish native sub-issue linkage:
+9. If a parent epic was provided, establish native sub-issue linkage:
    - Get node IDs for both issues:
      ```bash
      PARENT_ID=$(gh issue view <parent-N> --repo pureliture/ai-cli-orch-wrapper --json id -q .id)
@@ -71,4 +108,4 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
      ```
    - If this step fails, print a warning `⚠ Native epic linkage failed — body reference maintained` and continue. Do NOT fail the command.
 
-8. Report the created issue URL and number to the user.
+10. Report the created issue URL and number to the user.

--- a/templates/commands/gh-issue.md
+++ b/templates/commands/gh-issue.md
@@ -57,9 +57,10 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
 5. Write the body to a temporary Markdown file. Use `--body-file` rather than inline `--body` so multiline Markdown, checkboxes, and backticks are preserved:
    ```bash
    BODY_FILE=$(mktemp)
-   cat > "$BODY_FILE" <<'EOF'
+   trap 'rm -f "$BODY_FILE"' EXIT
+   cat > "$BODY_FILE" <<'_CLAUDE_GH_ISSUE_BODY_'
    <body>
-   EOF
+   _CLAUDE_GH_ISSUE_BODY_
    ```
 
 6. Create the issue:
@@ -67,11 +68,19 @@ Create a GitHub issue in `pureliture/ai-cli-orch-wrapper` following the conventi
    gh issue create \
      --repo pureliture/ai-cli-orch-wrapper \
      --title "<title>" \
-     --label "<type-label>,<sprint-label>,<priority>,<additional-labels>" \
+     --label "$LABELS" \
      --body-file "$BODY_FILE"
    ```
    Where `<priority>` is one of `p0`, `p1`, or `p2` (default: `p1` if not specified).
-   If no additional labels were provided, omit `<additional-labels>` from the label string.
+   Construct `LABELS` to avoid trailing commas when `additional-labels` is empty:
+   ```bash
+   BASE_LABELS="<type-label>,<sprint-label>,<priority>"
+   if [ -n "<additional-labels>" ]; then
+     LABELS="$BASE_LABELS,<additional-labels>"
+   else
+     LABELS="$BASE_LABELS"
+   fi
+   ```
 
 7. Capture the created issue URL from the output.
 


### PR DESCRIPTION
Closes #45

## What

`/gh-issue`가 빈 본문이나 한 줄짜리 본문을 만들지 않도록 slash command 계약을 강화했습니다. `templates/commands/gh-issue.md`와 `.claude/commands/gh-issue.md`에 구조화된 본문 템플릿, 생성 전 quality bar, `--body-file` 사용, 기본 한국어 작성 규칙을 추가했습니다.

## Why

#44처럼 생성 직후 사용자가 이슈 본문을 다시 작성해야 하는 문제가 있었습니다. 이 변경은 이슈 생성 시점부터 목적, 범위, 완료 기준이 포함된 실행 가능한 작업 단위를 만들기 위한 것입니다.

## Changes

- Update `/gh-issue` to collect body context and ask concise follow-up questions when needed
- Add required `Purpose`, `Scope & Requirements`, and `Acceptance Criteria` sections for issue bodies
- Switch issue creation guidance from inline `--body` to `--body-file`
- Document the issue body authoring rules in `docs/pm-board.md`
- Add the `improve-gh-issue-body-quality` OpenSpec delta and validation tasks

## Checklist

- [x] `openspec validate improve-gh-issue-body-quality --strict` passes
- [x] `templates/commands/gh-issue.md` and `.claude/commands/gh-issue.md` are synchronized
- [x] manual smoke test