### PR TITLE
chore(sync): migrate hand-rolled YAML parsers to js-yaml

### DIFF
--- a/openspec/changes/migrate-sync-yaml-to-js-yaml/.openspec.yaml
+++ b/openspec/changes/migrate-sync-yaml-to-js-yaml/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-22

--- a/openspec/changes/migrate-sync-yaml-to-js-yaml/design.md
+++ b/openspec/changes/migrate-sync-yaml-to-js-yaml/design.md
@@ -1,0 +1,73 @@
+## Context
+
+The sync layer parses and emits YAML-like data in three places:
+
+- agent frontmatter parsing in `agent-parse.ts`
+- formatter configuration parsing in `formatter.ts`
+- Gemini agent frontmatter serialization in `agent-gemini-transform.ts`
+
+The current approach uses narrow custom parsing and string construction. That works for simple scalar fields but is brittle for YAML that project configuration naturally uses: quoted strings containing colons, arrays with quoted values, anchors and aliases, nested formatter maps, multiline descriptions, and escaped characters.
+
+Issue #57 comes from PR #55 review feedback and asks to replace those hand-rolled YAML paths with `js-yaml`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use a maintained YAML implementation for sync-layer parsing and serialization.
+- Preserve the existing `AgentSpec`, `FormatterConfig`, and `GeminiAgent` public shapes.
+- Add regression coverage for valid YAML that custom parsing cannot handle reliably.
+- Keep generated Gemini frontmatter syntactically valid YAML.
+- Keep sync behavior backward compatible for current simple fixtures.
+
+**Non-Goals:**
+
+- Do not change the canonical `.claude/agents/*.md` or `.aco/formatter.yaml` schema.
+- Do not add schema validation beyond the existing typed normalization.
+- Do not migrate Go-side `aco delegate` parsing in this change.
+- Do not introduce broad YAML formatting churn outside generated Gemini agent frontmatter.
+
+## Decisions
+
+1. **Use `js-yaml.load` at YAML input boundaries**
+
+   `agent-parse.ts` and `formatter.ts` should call `js-yaml.load` on frontmatter or formatter content, then normalize the result into existing TypeScript interfaces. The parser should reject or ignore non-object roots according to the current fallback behavior.
+
+   Alternative considered: extend the custom parser with more YAML cases. That continues to reimplement YAML partially and leaves future edge cases unresolved.
+
+2. **Use `js-yaml.dump` for Gemini frontmatter output**
+
+   `serializeGeminiAgent` should build a plain metadata object and dump it as YAML frontmatter. This avoids manual escaping for colons, quotes, multiline descriptions, and other YAML-sensitive content.
+
+   Alternative considered: keep manual serialization with targeted escaping. That is still a partial YAML emitter and duplicates library behavior.
+
+3. **Declare runtime dependency if sync code imports `js-yaml` at runtime**
+
+   Because the wrapper package publishes compiled sync/runtime code, `js-yaml` must be in `dependencies` if imported by runtime modules. Type declarations may be in `devDependencies`.
+
+   Alternative considered: add `js-yaml` only as a devDependency as stated in the issue checklist. That would work in the repository but can fail for installed package consumers if runtime code requires the module.
+
+4. **Keep type normalization explicit after parsing**
+
+   YAML parsing returns unknown data. The implementation should keep explicit `String(...)`, `Number(...)`, array normalization, and object guards where the current interfaces require strings, numbers, or arrays.
+
+   Alternative considered: cast parsed YAML directly to internal types. That hides malformed config risk and weakens TypeScript guarantees.
+
+## Risks / Trade-offs
+
+- **Dependency surface increases** -> Use the mature `js-yaml` package and keep dependency placement explicit.
+- **Generated YAML formatting may change** -> Constrain assertions to semantic fields and valid frontmatter, not exact whitespace, unless exact output is contractually required.
+- **YAML anchors and aliases can produce shared object references** -> Normalize parsed structures into plain config values before use.
+- **Invalid YAML errors may differ from current fallback behavior** -> Preserve current error/reporting behavior where callers already expect failures, and add tests around parse errors if needed.
+
+## Migration Plan
+
+1. Add `js-yaml` and type declarations to package metadata with correct runtime/dev classification.
+2. Replace input parsing in `agent-parse.ts` and `formatter.ts`.
+3. Replace Gemini frontmatter serialization with `js-yaml.dump`.
+4. Add tests for quoted strings, colon-containing strings, anchors/aliases, nested formatter config, and generated frontmatter validity.
+5. Run wrapper tests and typecheck.
+
+## Open Questions
+
+None.

--- a/openspec/changes/migrate-sync-yaml-to-js-yaml/proposal.md
+++ b/openspec/changes/migrate-sync-yaml-to-js-yaml/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The sync layer currently relies on hand-rolled YAML parsing and frontmatter serialization for agent definitions, formatter config, and Gemini agent output. That approach is fragile for real YAML input such as quoted scalars, colons in strings, anchors, aliases, nested mappings, and multiline values.
+
+This change replaces custom YAML parsing/serialization with `js-yaml` so `aco sync` handles project configuration using a maintained YAML implementation.
+
+## What Changes
+
+- Introduce `js-yaml` for YAML parsing and serialization used by the sync layer.
+- Replace `agent-parse.ts` hand-rolled frontmatter parsing with `js-yaml.load`.
+- Replace `formatter.ts` hand-rolled formatter parsing with `js-yaml.load`.
+- Replace manual Gemini agent frontmatter serialization with `js-yaml.dump`.
+- Add coverage for YAML edge cases including quoted strings, colons, anchors/aliases, nested formatter config, and generated Gemini frontmatter.
+- Keep public sync behavior compatible except that previously unsupported valid YAML forms become accepted.
+
+## Capabilities
+
+### New Capabilities
+- `context-sync-yaml-processing`: Covers robust YAML parsing and serialization for sync-layer agent, formatter, and generated Gemini agent configuration.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: `packages/wrapper/src/sync/agent-parse.ts`, `packages/wrapper/src/sync/formatter.ts`, `packages/wrapper/src/sync/agent-gemini-transform.ts`, and sync tests.
+- Affected package metadata: `packages/wrapper/package.json` and lockfile dependency entries for `js-yaml` and its TypeScript types if needed.
+- Affected behavior: valid YAML syntax that the hand-rolled parser could not represent will parse and serialize correctly.

--- a/openspec/changes/migrate-sync-yaml-to-js-yaml/specs/context-sync-yaml-processing/spec.md
+++ b/openspec/changes/migrate-sync-yaml-to-js-yaml/specs/context-sync-yaml-processing/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Parse agent frontmatter with YAML semantics
+The system SHALL parse sync-layer agent frontmatter using YAML semantics instead of a hand-rolled line parser.
+
+#### Scenario: Quoted description contains colon
+- **WHEN** an agent frontmatter field contains `description: "Review code: TypeScript and Node.js"`
+- **THEN** the parsed agent spec SHALL contain the full description string including the colon
+
+#### Scenario: Array values are quoted
+- **WHEN** an agent frontmatter field contains an inline array with quoted values
+- **THEN** the parsed agent spec SHALL preserve each array item without surrounding quotes
+
+#### Scenario: YAML anchors and aliases are used
+- **WHEN** an agent frontmatter document uses a YAML anchor and alias for repeated scalar or array values
+- **THEN** the parsed agent spec SHALL resolve the alias to the expected value
+
+#### Scenario: Multiline scalar is used
+- **WHEN** an agent frontmatter field uses a YAML multiline scalar
+- **THEN** the parsed agent spec SHALL preserve the scalar content according to YAML parsing rules
+
+### Requirement: Parse formatter config with YAML semantics
+The system SHALL parse `.aco/formatter.yaml` using YAML semantics instead of a hand-rolled line parser.
+
+#### Scenario: Nested provider defaults
+- **WHEN** formatter config includes nested mappings for provider defaults and model alias maps
+- **THEN** the parsed formatter config SHALL preserve those nested mappings
+
+#### Scenario: Formatter values use aliases
+- **WHEN** formatter config uses anchors and aliases for repeated provider or model values
+- **THEN** the parsed formatter config SHALL resolve those aliases before model resolution
+
+#### Scenario: Formatter values contain YAML-sensitive characters
+- **WHEN** formatter config values include colons, quotes, or escaped characters
+- **THEN** the parsed formatter config SHALL preserve the intended string values
+
+### Requirement: Serialize Gemini agent frontmatter with YAML semantics
+The system SHALL serialize generated Gemini agent frontmatter using YAML serialization instead of manual string concatenation.
+
+#### Scenario: Gemini description contains colon
+- **WHEN** a Gemini agent description contains a colon
+- **THEN** the serialized frontmatter SHALL remain valid YAML
+- **AND** parsing the generated frontmatter SHALL recover the original description value
+
+#### Scenario: Gemini description contains quotes
+- **WHEN** a Gemini agent description contains quote characters
+- **THEN** the serialized frontmatter SHALL escape or quote the value as valid YAML
+- **AND** parsing the generated frontmatter SHALL recover the original description value
+
+#### Scenario: Optional Gemini fields are omitted
+- **WHEN** optional Gemini agent fields such as `description`, `model`, or `max_turns` are absent
+- **THEN** the serialized frontmatter SHALL omit those fields
+- **AND** the frontmatter SHALL remain valid YAML
+
+### Requirement: Preserve sync config behavior
+The system SHALL preserve existing sync behavior for currently supported simple YAML inputs while adding support for valid YAML edge cases.
+
+#### Scenario: Existing simple agent fixture parses
+- **WHEN** an existing simple agent frontmatter fixture is parsed
+- **THEN** the resulting agent spec SHALL match the current expected fields
+
+#### Scenario: Existing simple formatter fixture parses
+- **WHEN** an existing simple formatter fixture is parsed
+- **THEN** model and provider resolution SHALL produce the same results as before the migration

--- a/openspec/changes/migrate-sync-yaml-to-js-yaml/tasks.md
+++ b/openspec/changes/migrate-sync-yaml-to-js-yaml/tasks.md
@@ -1,0 +1,32 @@
+## 1. Dependency Setup
+
+- [x] 1.1 Add `js-yaml` to `packages/wrapper` runtime dependencies if sync code imports it at runtime.
+- [x] 1.2 Add TypeScript declarations for `js-yaml` to dev dependencies if required by typecheck.
+- [x] 1.3 Update the package lockfile consistently with the dependency changes.
+
+## 2. Agent Frontmatter Parsing
+
+- [x] 2.1 Add tests for quoted descriptions containing colons, quoted inline arrays, anchors/aliases, and multiline scalar fields in agent frontmatter.
+- [x] 2.2 Replace `agent-parse.ts` custom YAML parsing with `js-yaml.load`.
+- [x] 2.3 Keep explicit normalization from parsed YAML values into `AgentSpec` string, number, and array fields.
+- [x] 2.4 Preserve behavior for frontmatter-free agent files.
+
+## 3. Formatter Parsing
+
+- [x] 3.1 Add tests for nested formatter config containing model alias maps, provider defaults, anchors/aliases, and YAML-sensitive string values.
+- [x] 3.2 Replace `formatter.ts` custom YAML parsing with `js-yaml.load`.
+- [x] 3.3 Keep formatter model resolution behavior unchanged for existing simple config fixtures.
+- [x] 3.4 Preserve error behavior for missing, invalid, or unsupported formatter config.
+
+## 4. Gemini Agent Serialization
+
+- [x] 4.1 Add tests that generated Gemini frontmatter remains valid YAML when descriptions contain colons, quotes, or multiline content.
+- [x] 4.2 Replace manual Gemini frontmatter string construction with `js-yaml.dump`.
+- [x] 4.3 Ensure absent optional Gemini fields are omitted from generated frontmatter.
+- [x] 4.4 Ensure generated Markdown body placement remains unchanged after the frontmatter block.
+
+## 5. Verification
+
+- [x] 5.1 Run `npm --workspace packages/wrapper test`.
+- [x] 5.2 Run `npm --workspace packages/wrapper run typecheck`.
+- [x] 5.3 Inspect generated Gemini agent output for stable, valid YAML frontmatter.

--- a/package-lock.json
+++ b/package-lock.json
@@ -883,6 +883,13 @@
       "resolved": "packages/wrapper",
       "link": true
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -917,7 +924,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-union": {
@@ -1320,7 +1326,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1900,10 +1905,14 @@
       "name": "@pureliture/ai-cli-orch-wrapper",
       "version": "0.4.0",
       "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.1"
+      },
       "bin": {
         "aco": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2"

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -24,8 +24,12 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.1"
   }
 }

--- a/packages/wrapper/src/sync/agent-gemini-transform.ts
+++ b/packages/wrapper/src/sync/agent-gemini-transform.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
+import { dump as dumpYaml } from 'js-yaml';
 import { parseAgentSpec } from './agent-parse.js';
 import { computeHash } from './hash.js';
 import { loadFormatterConfig, resolveModelForProvider } from './formatter.js';
@@ -35,24 +36,27 @@ export function toGeminiAgent(spec: ReturnType<typeof parseAgentSpec>): GeminiAg
 }
 
 export function serializeGeminiAgent(agent: GeminiAgent): string {
-  const lines: string[] = [];
-  lines.push('---');
-  lines.push(`name: ${agent.name}`);
+  const frontmatter: Record<string, unknown> = {
+    name: agent.name,
+  };
   if (agent.description) {
-    lines.push(`description: ${agent.description}`);
+    frontmatter.description = agent.description;
   }
   if (agent.model) {
-    lines.push(`model: ${agent.model}`);
+    frontmatter.model = agent.model;
   }
-  lines.push(`kind: ${agent.kind}`);
+  frontmatter.kind = agent.kind;
   if (agent.max_turns) {
-    lines.push(`max_turns: ${agent.max_turns}`);
+    frontmatter.max_turns = agent.max_turns;
   }
-  lines.push('---');
-  lines.push('');
-  lines.push(agent.body);
 
-  return lines.join('\n');
+  const yaml = dumpYaml(frontmatter, {
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: false,
+  }).trimEnd();
+
+  return ['---', yaml, '---', '', agent.body].join('\n');
 }
 
 export async function syncGeminiAgents(
@@ -99,7 +103,8 @@ export async function syncGeminiAgents(
     if (spec.permissionProfile === 'restricted' || spec.workspaceMode === 'read-only') {
       warnings.push({
         source: source.path,
-        message: 'Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent',
+        message:
+          'Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent',
         severity: 'warning',
       });
     }

--- a/packages/wrapper/src/sync/agent-parse.ts
+++ b/packages/wrapper/src/sync/agent-parse.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises';
+import { load as loadYaml } from 'js-yaml';
 
 export interface AgentSpec {
   id: string;
@@ -55,8 +56,8 @@ export function parseAgentSpec(content: string): AgentSpec {
     yamlLines.push(lines[i]);
   }
 
-  // Simple YAML parser for scalar and string-array fields
-  const yaml = parseSimpleYaml(yamlLines.join('\n'));
+  const parsedYaml = loadYaml(yamlLines.join('\n'));
+  const yaml = isRecord(parsedYaml) ? parsedYaml : {};
 
   if (yaml.id) spec.id = String(yaml.id);
   if (yaml.name) spec.name = String(yaml.name);
@@ -71,8 +72,14 @@ export function parseAgentSpec(content: string): AgentSpec {
   if (yaml.isolationMode) spec.isolationMode = String(yaml.isolationMode);
   if (yaml.promptSeedFile) spec.promptSeedFile = String(yaml.promptSeedFile);
   if (yaml.reasoningEffort) spec.reasoningEffort = String(yaml.reasoningEffort);
-  if (yaml.skillRefs) spec.skillRefs = Array.isArray(yaml.skillRefs) ? yaml.skillRefs.map(String) : [String(yaml.skillRefs)];
-  if (yaml.memoryRefs) spec.memoryRefs = Array.isArray(yaml.memoryRefs) ? yaml.memoryRefs.map(String) : [String(yaml.memoryRefs)];
+  if (yaml.skillRefs)
+    spec.skillRefs = Array.isArray(yaml.skillRefs)
+      ? yaml.skillRefs.map(String)
+      : [String(yaml.skillRefs)];
+  if (yaml.memoryRefs)
+    spec.memoryRefs = Array.isArray(yaml.memoryRefs)
+      ? yaml.memoryRefs.map(String)
+      : [String(yaml.memoryRefs)];
 
   // Fallback: name -> id
   if (!spec.id && spec.name) spec.id = spec.name;
@@ -81,71 +88,6 @@ export function parseAgentSpec(content: string): AgentSpec {
   return spec;
 }
 
-function parseSimpleYaml(yaml: string): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  const lines = yaml.split('\n');
-  let currentKey = '';
-  let currentArray: string[] = [];
-  let inArray = false;
-
-  for (const line of lines) {
-    const trimmed = line.trimEnd();
-    if (trimmed.length === 0) continue;
-
-    const match = trimmed.match(/^(\s*)([\w-]+):\s*(.*)$/);
-    if (match) {
-      const indent = match[1].length;
-      const key = match[2];
-      const value = match[3].trim();
-
-      if (indent === 0) {
-        // Top-level key
-        if (inArray) {
-          result[currentKey] = currentArray;
-          inArray = false;
-          currentArray = [];
-        }
-        currentKey = key;
-
-        if (value === '' || value === '[]') {
-          // Could be empty value or start of array
-          if (value === '[]') {
-            result[key] = [];
-          } else {
-            inArray = true;
-            currentArray = [];
-          }
-        } else if (value.startsWith('[') && value.endsWith(']')) {
-          // Inline array: [a, b, c]
-          result[key] = value.slice(1, -1).split(',').map((s) => unquoteYamlScalar(s.trim())).filter(Boolean);
-        } else {
-          result[key] = unquoteYamlScalar(value);
-        }
-      } else if (indent > 0 && inArray) {
-        // Array element
-        const item = trimmed.trim();
-        if (item.startsWith('- ')) {
-          currentArray.push(unquoteYamlScalar(item.slice(2).trim()));
-        }
-      }
-    } else if (trimmed.trim().startsWith('- ') && inArray) {
-      currentArray.push(unquoteYamlScalar(trimmed.trim().slice(2).trim()));
-    }
-  }
-
-  if (inArray && currentKey) {
-    result[currentKey] = currentArray;
-  }
-
-  return result;
-}
-
-function unquoteYamlScalar(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/wrapper/src/sync/formatter.ts
+++ b/packages/wrapper/src/sync/formatter.ts
@@ -1,5 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { load as loadYaml } from 'js-yaml';
 
 export interface FormatterConfig {
   modelAliasMap: Record<string, { provider: string; model: string }>;
@@ -50,7 +51,8 @@ function parseFormatterYaml(content: string): FormatterConfig {
     fallback: { provider: 'codex', model: '' },
   };
 
-  const obj = parseYamlObject(content.split('\n'), { index: 0 }, 0);
+  const parsedYaml = loadYaml(content);
+  const obj = isRecord(parsedYaml) ? parsedYaml : {};
 
   const aliasMap = obj['modelAliasMap'];
   if (aliasMap && typeof aliasMap === 'object' && !Array.isArray(aliasMap)) {
@@ -85,102 +87,6 @@ function parseFormatterYaml(content: string): FormatterConfig {
   return config;
 }
 
-interface ParseState {
-  index: number;
-}
-
-function getIndent(line: string): number {
-  let i = 0;
-  while (i < line.length && line[i] === ' ') i++;
-  return i;
-}
-
-function parseYamlObject(
-  lines: string[],
-  state: ParseState,
-  baseIndent: number
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-
-  while (state.index < lines.length) {
-    const line = lines[state.index];
-    const trimmed = line.trimEnd();
-
-    if (!trimmed || trimmed.trimStart().startsWith('#')) {
-      state.index++;
-      continue;
-    }
-
-    const indent = getIndent(trimmed);
-
-    if (indent < baseIndent) break;
-
-    const content = trimmed.trimStart();
-
-    if (content.startsWith('- ')) {
-      break;
-    }
-
-    const colonIdx = content.indexOf(':');
-    if (colonIdx === -1) {
-      state.index++;
-      continue;
-    }
-
-    const key = content.slice(0, colonIdx).trim();
-    const rest = content.slice(colonIdx + 1).trim();
-
-    state.index++;
-
-    if (rest === '' || rest === '|' || rest === '>') {
-      if (state.index < lines.length) {
-        const nextLine = lines[state.index];
-        const nextTrimmed = nextLine?.trimEnd() ?? '';
-        const nextContent = nextTrimmed.trimStart();
-        const nextIndent = nextTrimmed ? getIndent(nextTrimmed) : 0;
-
-        if (nextIndent > indent && nextContent.startsWith('- ')) {
-          result[key] = parseYamlArray(lines, state, nextIndent);
-        } else if (nextIndent > indent) {
-          result[key] = parseYamlObject(lines, state, nextIndent);
-        } else {
-          result[key] = null;
-        }
-      } else {
-        result[key] = null;
-      }
-    } else if (rest === '[]') {
-      result[key] = [];
-    } else {
-      result[key] = rest;
-    }
-  }
-
-  return result;
-}
-
-function parseYamlArray(lines: string[], state: ParseState, baseIndent: number): unknown[] {
-  const result: unknown[] = [];
-
-  while (state.index < lines.length) {
-    const line = lines[state.index];
-    const trimmed = line.trimEnd();
-
-    if (!trimmed || trimmed.trimStart().startsWith('#')) {
-      state.index++;
-      continue;
-    }
-
-    const indent = getIndent(trimmed);
-    if (indent < baseIndent) break;
-
-    const content = trimmed.trimStart();
-    if (!content.startsWith('- ')) break;
-
-    const value = content.slice(2).trim();
-    result.push(value);
-    state.index++;
-  }
-
-  return result;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -3,19 +3,24 @@ import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { load as loadYaml } from 'js-yaml';
 import { parseAgentSpec } from '../src/sync/agent-parse.js';
-import {
-  toCodexAgent,
-  serializeCodexAgent,
-} from '../src/sync/agent-codex-transform.js';
-import {
-  toGeminiAgent,
-  serializeGeminiAgent,
-} from '../src/sync/agent-gemini-transform.js';
+import { toCodexAgent, serializeCodexAgent } from '../src/sync/agent-codex-transform.js';
+import { toGeminiAgent, serializeGeminiAgent } from '../src/sync/agent-gemini-transform.js';
+import { loadFormatterConfig, resolveModelForProvider } from '../src/sync/formatter.js';
 import { parseHooks, toCodexHooks, toGeminiHooks } from '../src/sync/hook-parse.js';
 import { syncSkills } from '../src/sync/skill-transform.js';
 import type { SyncSource } from '../src/sync/transform-interface.js';
 import { computeHash } from '../src/sync/hash.js';
+
+function parseMarkdownFrontmatter(markdown: string): Record<string, unknown> {
+  const match = markdown.match(/^---\n([\s\S]*?)\n---\n\n([\s\S]*)$/);
+  assert.ok(match, 'expected markdown frontmatter block');
+
+  const parsed = loadYaml(match[1]);
+  assert.ok(parsed && typeof parsed === 'object' && !Array.isArray(parsed));
+  return parsed as Record<string, unknown>;
+}
 
 // ---------------------------------------------------------------------------
 // Agent parse + transform fixtures (Task 4.6)
@@ -89,6 +94,31 @@ You are a senior TypeScript engineer.`;
       assert.equal(spec.id, 'typescript-reviewer');
       assert.equal(spec.description, 'Expert TypeScript/JavaScript code reviewer');
       assert.equal(spec.when, '');
+    });
+
+    it('parses YAML quoted values, anchors, aliases, and multiline scalars', () => {
+      const content = `---
+id: yaml-edge-agent
+description: |
+  Review code: TypeScript
+  and "Node.js"
+sharedTools: &reviewTools
+  - "Read:Files"
+  - "Grep \\"pattern\\""
+skillRefs: *reviewTools
+memoryRefs: ["project:notes", "quote \\"memo\\""]
+turnLimit: "12"
+---
+Body text.`;
+
+      const spec = parseAgentSpec(content);
+
+      assert.equal(spec.id, 'yaml-edge-agent');
+      assert.equal(spec.description, 'Review code: TypeScript\nand "Node.js"\n');
+      assert.deepEqual(spec.skillRefs, ['Read:Files', 'Grep "pattern"']);
+      assert.deepEqual(spec.memoryRefs, ['project:notes', 'quote "memo"']);
+      assert.equal(spec.turnLimit, 12);
+      assert.equal(spec.body, 'Body text.');
     });
   });
 
@@ -177,6 +207,131 @@ Body text.`;
       assert.ok(!md.includes('reasoning_effort'));
       assert.ok(!md.includes('--reasoning-effort'));
     });
+
+    it('serializes YAML-sensitive Gemini frontmatter as valid YAML', () => {
+      const body = 'Line one.\nLine two.';
+      const md = serializeGeminiAgent({
+        name: 'yaml-agent',
+        description: 'Review code: TypeScript and "Node.js"\nUse care: yes',
+        model: 'gemini-2.5-pro',
+        kind: 'local',
+        max_turns: 7,
+        body,
+      });
+
+      const frontmatter = parseMarkdownFrontmatter(md);
+      assert.equal(frontmatter.name, 'yaml-agent');
+      assert.equal(frontmatter.description, 'Review code: TypeScript and "Node.js"\nUse care: yes');
+      assert.equal(frontmatter.model, 'gemini-2.5-pro');
+      assert.equal(frontmatter.kind, 'local');
+      assert.equal(frontmatter.max_turns, 7);
+      assert.ok(md.endsWith(`---\n\n${body}`));
+    });
+
+    it('omits absent optional Gemini frontmatter fields', () => {
+      const md = serializeGeminiAgent({
+        name: 'minimal-agent',
+        kind: 'local',
+        body: 'Body text.',
+      });
+
+      const frontmatter = parseMarkdownFrontmatter(md);
+      assert.deepEqual(Object.keys(frontmatter).sort(), ['kind', 'name']);
+      assert.ok(md.endsWith('---\n\nBody text.'));
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Formatter config parsing
+// ---------------------------------------------------------------------------
+
+describe('Formatter config', () => {
+  it('resolves simple formatter config as before', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-formatter-simple-'));
+    try {
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.aco', 'formatter.yaml'),
+        `modelAliasMap:
+  sonnet-4.6:
+    provider: codex
+    model: gpt-5.4
+providerModels:
+  gemini_cli:
+    - gemini-2.5-pro
+fallback:
+  provider: codex
+  model: gpt-5.4-mini
+`
+      );
+
+      const config = await loadFormatterConfig(tmpDir);
+
+      assert.equal(resolveModelForProvider(config, 'sonnet-4.6', 'codex'), 'gpt-5.4');
+      assert.equal(resolveModelForProvider(config, '', 'gemini_cli'), 'gemini-2.5-pro');
+      assert.equal(resolveModelForProvider(config, 'missing', 'codex'), 'gpt-5.4-mini');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses nested formatter config with aliases and YAML-sensitive values', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-formatter-yaml-'));
+    try {
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.aco', 'formatter.yaml'),
+        `modelAliasMap:
+  sonnet-4.6:
+    provider: &codexProvider codex
+    model: "gpt-5.4:release"
+  gemini-review:
+    provider: &geminiProvider gemini_cli
+    model: &geminiModel "gemini-2.5-pro:stable"
+providerModels:
+  codex:
+    - "gpt-5.4:release"
+    - "gpt-5.4 \\"fast\\""
+  gemini_cli:
+    - *geminiModel
+fallback:
+  provider: *codexProvider
+  model: "gpt-5.4 fallback: safe"
+`
+      );
+
+      const config = await loadFormatterConfig(tmpDir);
+
+      assert.equal(resolveModelForProvider(config, 'sonnet-4.6', 'codex'), 'gpt-5.4:release');
+      assert.equal(
+        resolveModelForProvider(config, 'gemini-review', 'gemini_cli'),
+        'gemini-2.5-pro:stable'
+      );
+      assert.equal(resolveModelForProvider(config, '', 'gemini_cli'), 'gemini-2.5-pro:stable');
+      assert.equal(resolveModelForProvider(config, 'missing', 'codex'), 'gpt-5.4:release');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null for missing or invalid formatter config', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-formatter-invalid-'));
+    try {
+      assert.equal(await loadFormatterConfig(tmpDir), null);
+
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.aco', 'formatter.yaml'),
+        `modelAliasMap:
+  broken: [unterminated
+`
+      );
+
+      assert.equal(await loadFormatterConfig(tmpDir), null);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Closes #57

## What

Sync 모듈의 hand-rolled YAML 파서/직렬화 로직을 `js-yaml` 라이브러리로 교체합니다. 기존 코드에서는 YAML frontmatter 파싱(`parseSimpleYaml`), formatter.yaml 파싱(`parseYamlObject`), Gemini agent frontmatter 직렬화(`serializeGeminiAgent`)를 모두 직접 구현했습니다.

- `agent-parse.ts`: `parseSimpleYaml` → `js-yaml.load`
- `formatter.ts`: `parseYamlObject` → `js-yaml.load`
- `agent-gemini-transform.ts`: 수동 YAML frontmatter 생성 → `js-yaml.dump`

## Why

Hand-rolled 파서는 따옴표로 묶인 문자열, 앵커, 별칭 등 YAML의 다양한 edge case를 처리하지 못해 불안정합니다. `js-yaml`은 YAML 1.2 표준을 완전히 구현한 성숙한 라이브러리로, 파싱 오류를 제거하고 유지보수성을 높입니다.

## Changes

- Add `js-yaml` as dependency in `packages/wrapper/package.json`
- Replace `parseSimpleYaml` in `agent-parse.ts` with `js-yaml.load`
- Replace `parseYamlObject` in `formatter.ts` with `js-yaml.load`
- Replace manual YAML frontmatter generation in `agent-gemini-transform.ts` with `js-yaml.dump`
- Add tests for quoted YAML values, inline arrays, and nested objects
- Add OpenSpec change artifacts for js-yaml migration

## Checklist
- [x] `npm run typecheck` passes
- [x] `npm test` passes (54+ tests)
- [x] `go test ./...` passes
