### PR TITLE
feat(wrapper): wrapper surface에 codex provider 추가

### DIFF
--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -23,7 +23,11 @@ const execFileAsync = promisify(execFile);
 
 const VERSION = loadVersion();
 const EXIT_ERROR = 1;
-const VALID_PERMISSION_PROFILES: PermissionProfile[] = ['default', 'restricted', 'unrestricted'];
+const VALID_PERMISSION_PROFILES: PermissionProfile[] = [
+  'default',
+  'restricted',
+  'unrestricted',
+];
 
 async function main(): Promise<void> {
   const [, , subcommand, ...rest] = process.argv;
@@ -145,7 +149,8 @@ async function cmdRun(args: string[]): Promise<void> {
     process.exit(EXIT_ERROR);
   }
 
-  const permissionProfile = parseFlag<PermissionProfile>(args, '--permission-profile') ?? 'default';
+  const permissionProfile =
+    parseFlag<PermissionProfile>(args, '--permission-profile') ?? 'default';
   if (!VALID_PERMISSION_PROFILES.includes(permissionProfile)) {
     console.error(
       `Invalid --permission-profile '${permissionProfile}'. Valid values: default|restricted|unrestricted`
@@ -184,7 +189,12 @@ async function cmdRun(args: string[]): Promise<void> {
     prompt = await readFile(globalPromptPath, 'utf8');
   }
 
-  const session = await sessionStore.create(providerKey, command, undefined, permissionProfile);
+  const session = await sessionStore.create(
+    providerKey,
+    command,
+    undefined,
+    permissionProfile
+  );
   const tee = sessionStore.createOutputTee(session.id);
   let hasOutput = false;
   let runError: unknown;
@@ -298,6 +308,7 @@ async function cmdCancel(args: string[]): Promise<void> {
     try {
       process.kill(record.pid, 'SIGTERM');
     } catch {
+      // The process may have already exited.
     }
   }
 

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -121,9 +121,6 @@ async function cmdProvider(args: string[]): Promise<void> {
   await providerSetup(providerName);
 }
 
-// ---------------------------------------------------------------------------
-// aco run <provider> <command> [--input <text>] [--permission-profile <profile>]
-// ---------------------------------------------------------------------------
 async function cmdRun(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.error(
@@ -157,7 +154,6 @@ async function cmdRun(args: string[]): Promise<void> {
   }
   const inputFlag = parseFlag(args, '--input') ?? '';
 
-  // Read stdin if not a TTY and no --input flag
   let content = inputFlag;
   if (!content && !process.stdin.isTTY) {
     const chunks: Buffer[] = [];
@@ -165,7 +161,6 @@ async function cmdRun(args: string[]): Promise<void> {
     content = Buffer.concat(chunks).toString();
   }
 
-  // Load prompt: prefer cwd-local override, fall back to global ~/.claude
   const cwdPromptPath = join(
     process.cwd(),
     '.claude',
@@ -199,7 +194,6 @@ async function cmdRun(args: string[]): Promise<void> {
       permissionProfile,
       sessionId: session.id,
       onPid: (pid) => {
-        // Fire-and-forget pid update so the session can be cancelled
         sessionStore.update(session.id, { pid }).catch((err: unknown) => {
           console.warn(
             'Failed to record process PID:',
@@ -236,9 +230,6 @@ async function cmdRun(args: string[]): Promise<void> {
   await sessionStore.markDone(session.id);
 }
 
-// ---------------------------------------------------------------------------
-// aco result [--session <id>]
-// ---------------------------------------------------------------------------
 async function cmdResult(args: string[]): Promise<void> {
   const sessionId = parseFlag(args, '--session') ?? sessionStore.latestId();
   if (!sessionId) {
@@ -256,9 +247,6 @@ async function cmdResult(args: string[]): Promise<void> {
   process.stdout.write(output);
 }
 
-// ---------------------------------------------------------------------------
-// aco status [--session <id>]
-// ---------------------------------------------------------------------------
 async function cmdStatus(args: string[]): Promise<void> {
   const sessionId = parseFlag(args, '--session') ?? sessionStore.latestId();
   if (!sessionId) {
@@ -281,9 +269,6 @@ async function cmdStatus(args: string[]): Promise<void> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// aco cancel [--session <id>]
-// ---------------------------------------------------------------------------
 async function cmdCancel(args: string[]): Promise<void> {
   const sessionId = parseFlag(args, '--session') ?? sessionStore.latestId();
   if (!sessionId) {
@@ -313,7 +298,6 @@ async function cmdCancel(args: string[]): Promise<void> {
     try {
       process.kill(record.pid, 'SIGTERM');
     } catch {
-      // The process may have already exited — safe to ignore
     }
   }
 
@@ -321,9 +305,6 @@ async function cmdCancel(args: string[]): Promise<void> {
   console.log(`Session ${sessionId} cancelled.`);
 }
 
-// ---------------------------------------------------------------------------
-// aco sync [--check] [--dry-run] [--force]
-// ---------------------------------------------------------------------------
 async function cmdSync(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.error(
@@ -395,7 +376,6 @@ async function findRepoRoot(startDir: string): Promise<string | null> {
     });
     return stdout.trim();
   } catch {
-    // Not a git repo or git not available — walk up to find CLAUDE.md
     let dir = startDir;
     while (true) {
       if (existsSync(join(dir, 'CLAUDE.md'))) return dir;
@@ -406,9 +386,6 @@ async function findRepoRoot(startDir: string): Promise<string | null> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 function parseFlag<T extends string = string>(args: string[], flag: string): T | undefined {
   const idx = args.indexOf(flag);
   if (idx === -1 || idx + 1 >= args.length) return undefined;
@@ -438,7 +415,7 @@ function printUsage(): void {
   aco pack uninstall [--global]
   aco pack status [--global]
   aco pack setup [--global] [--force]
-  aco provider setup <gemini>`);
+  aco provider setup <name>`);
 }
 
 async function endWritable(stream: Writable): Promise<void> {

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -23,11 +23,7 @@ const execFileAsync = promisify(execFile);
 
 const VERSION = loadVersion();
 const EXIT_ERROR = 1;
-const VALID_PERMISSION_PROFILES: PermissionProfile[] = [
-  'default',
-  'restricted',
-  'unrestricted',
-];
+const VALID_PERMISSION_PROFILES: PermissionProfile[] = ['default', 'restricted', 'unrestricted'];
 
 async function main(): Promise<void> {
   const [, , subcommand, ...rest] = process.argv;
@@ -125,6 +121,9 @@ async function cmdProvider(args: string[]): Promise<void> {
   await providerSetup(providerName);
 }
 
+// ---------------------------------------------------------------------------
+// aco run <provider> <command> [--input <text>] [--permission-profile <profile>]
+// ---------------------------------------------------------------------------
 async function cmdRun(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.error(
@@ -149,8 +148,7 @@ async function cmdRun(args: string[]): Promise<void> {
     process.exit(EXIT_ERROR);
   }
 
-  const permissionProfile =
-    parseFlag<PermissionProfile>(args, '--permission-profile') ?? 'default';
+  const permissionProfile = parseFlag<PermissionProfile>(args, '--permission-profile') ?? 'default';
   if (!VALID_PERMISSION_PROFILES.includes(permissionProfile)) {
     console.error(
       `Invalid --permission-profile '${permissionProfile}'. Valid values: default|restricted|unrestricted`
@@ -189,12 +187,7 @@ async function cmdRun(args: string[]): Promise<void> {
     prompt = await readFile(globalPromptPath, 'utf8');
   }
 
-  const session = await sessionStore.create(
-    providerKey,
-    command,
-    undefined,
-    permissionProfile
-  );
+  const session = await sessionStore.create(providerKey, command, undefined, permissionProfile);
   const tee = sessionStore.createOutputTee(session.id);
   let hasOutput = false;
   let runError: unknown;
@@ -204,6 +197,7 @@ async function cmdRun(args: string[]): Promise<void> {
       permissionProfile,
       sessionId: session.id,
       onPid: (pid) => {
+        // Fire-and-forget pid update so the session can be cancelled
         sessionStore.update(session.id, { pid }).catch((err: unknown) => {
           console.warn(
             'Failed to record process PID:',
@@ -308,7 +302,7 @@ async function cmdCancel(args: string[]): Promise<void> {
     try {
       process.kill(record.pid, 'SIGTERM');
     } catch {
-      // The process may have already exited.
+      // The process may have already exited — safe to ignore
     }
   }
 

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -53,7 +53,13 @@ export async function packInstall(options: PackInstallOptions = {}): Promise<voi
 
   const installedFiles: string[] = [];
   await copyTree(commandsSrc, commandsDest, options.force ?? false, 'command', installedFiles);
-  await copyTree(promptsSrc, promptsDest, options.force ?? false, 'prompt template', installedFiles);
+  await copyTree(
+    promptsSrc,
+    promptsDest,
+    options.force ?? false,
+    'prompt template',
+    installedFiles
+  );
 
   const manifestPath = MANIFEST_PATH(targetBase);
   let existingFiles: string[] = [];
@@ -117,7 +123,9 @@ export async function packUninstall(options: { global?: boolean } = {}): Promise
       console.log(`  removed ${manifestPath}`);
     }
   } else {
-    console.warn('  [warn] No aco install manifest found. Pack may not have been installed via this tool.');
+    console.warn(
+      '  [warn] No aco install manifest found. Pack may not have been installed via this tool.'
+    );
   }
 
   console.log('✓ Pack uninstalled.');
@@ -149,10 +157,14 @@ export async function packStatus(options: { global?: boolean } = {}): Promise<vo
   for (const key of providerRegistry.keys()) {
     const provider = providerRegistry.get(key)!;
     const available = provider.isAvailable();
-    const auth = available ? await provider.checkAuth() : { ok: false, hint: provider.installHint };
+    const auth = available
+      ? await provider.checkAuth()
+      : { ok: false, hint: provider.installHint };
     const avIcon = available ? '✓' : '✗';
     const authIcon = auth.ok ? '✓' : '✗';
-    console.log(`  ${key}: installed ${avIcon}  auth ${authIcon}${auth.ok ? '' : `  → ${auth.hint}`}`);
+    console.log(
+      `  ${key}: installed ${avIcon}  auth ${authIcon}${auth.ok ? '' : `  → ${auth.hint}`}`
+    );
   }
 }
 
@@ -173,11 +185,17 @@ export async function packSetup(options: PackInstallOptions = {}): Promise<void>
   console.log('\n--- Context Sync ---');
   const repoRoot = process.cwd();
   try {
-    const result = await runSync(repoRoot, { dryRun: false, check: false, force: false });
+    const result = await runSync(repoRoot, {
+      dryRun: false,
+      check: false,
+      force: false,
+    });
     const { created, updated, removed, skipped, warnings, conflicts } = result;
     const manifestPath = join(repoRoot, '.aco', 'sync-manifest.json');
 
-    console.log(`  created: ${created}  updated: ${updated}  removed: ${removed}  skipped: ${skipped}`);
+    console.log(
+      `  created: ${created}  updated: ${updated}  removed: ${removed}  skipped: ${skipped}`
+    );
     if (warnings > 0) {
       console.log(`  warnings: ${warnings} — see manifest for details: ${manifestPath}`);
     }
@@ -229,7 +247,13 @@ export async function providerSetup(name: string): Promise<void> {
   console.log(`${name}: installed ✓  auth: ok ✓`);
 }
 
-async function copyTree(src: string, dest: string, force: boolean, kind: string, manifest: string[]): Promise<void> {
+async function copyTree(
+  src: string,
+  dest: string,
+  force: boolean,
+  kind: string,
+  manifest: string[]
+): Promise<void> {
   if (!existsSync(src)) {
     console.warn(`  [warn] template source not found: ${src}`);
     return;
@@ -265,20 +289,26 @@ async function collectFiles(dir: string, out: string[]): Promise<void> {
 
 async function placeWrapperBinary(binaryName: string): Promise<void> {
   try {
-    const { stdout } = await execFileAsync(binaryName, ['--version'], { timeout: BINARY_CHECK_TIMEOUT_MS });
+    const { stdout } = await execFileAsync(binaryName, ['--version'], {
+      timeout: BINARY_CHECK_TIMEOUT_MS,
+    });
     const versionOutput = typeof stdout === 'string' ? stdout.trim().toLowerCase() : '';
     if (versionOutput.startsWith('aco ')) {
       console.log(`  binary: '${binaryName}' already in PATH ✓`);
       return;
     }
-    console.warn(`  [warn] Found '${binaryName}' in PATH, but '--version' output did not look like ${PUBLIC_PACKAGE_NAME}. Proceeding to install ${PUBLIC_PACKAGE_NAME} globally.`);
+    console.warn(
+      `  [warn] Found '${binaryName}' in PATH, but '--version' output did not look like ${PUBLIC_PACKAGE_NAME}. Proceeding to install ${PUBLIC_PACKAGE_NAME} globally.`
+    );
   } catch {
     // Not found in PATH — proceed to global npm install
   }
 
   try {
     console.log(`  binary: installing ${PUBLIC_PACKAGE_NAME} globally …`);
-    await execFileAsync('npm', ['install', '-g', PUBLIC_PACKAGE_NAME], { timeout: NPM_INSTALL_TIMEOUT_MS });
+    await execFileAsync('npm', ['install', '-g', PUBLIC_PACKAGE_NAME], {
+      timeout: NPM_INSTALL_TIMEOUT_MS,
+    });
     console.log(`  binary: '${binaryName}' installed globally ✓`);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -20,14 +20,11 @@ function findTemplatesDir(startDir: string): string {
   const devPath = join(monorepoRoot, 'templates');
   const prodPath = join(packageRoot, 'templates');
 
-  // In development (not inside node_modules), prioritize the monorepo root templates
   const isDev = !startDir.split(sep).includes('node_modules');
   if (isDev && existsSync(devPath)) {
     return devPath;
   }
 
-  // Fall back to the package-root location so validation reports the expected
-  // production path when templates are missing from an installed package.
   return prodPath;
 }
 
@@ -56,13 +53,7 @@ export async function packInstall(options: PackInstallOptions = {}): Promise<voi
 
   const installedFiles: string[] = [];
   await copyTree(commandsSrc, commandsDest, options.force ?? false, 'command', installedFiles);
-  await copyTree(
-    promptsSrc,
-    promptsDest,
-    options.force ?? false,
-    'prompt template',
-    installedFiles
-  );
+  await copyTree(promptsSrc, promptsDest, options.force ?? false, 'prompt template', installedFiles);
 
   const manifestPath = MANIFEST_PATH(targetBase);
   let existingFiles: string[] = [];
@@ -126,9 +117,7 @@ export async function packUninstall(options: { global?: boolean } = {}): Promise
       console.log(`  removed ${manifestPath}`);
     }
   } else {
-    console.warn(
-      '  [warn] No aco install manifest found. Pack may not have been installed via this tool.'
-    );
+    console.warn('  [warn] No aco install manifest found. Pack may not have been installed via this tool.');
   }
 
   console.log('✓ Pack uninstalled.');
@@ -163,9 +152,7 @@ export async function packStatus(options: { global?: boolean } = {}): Promise<vo
     const auth = available ? await provider.checkAuth() : { ok: false, hint: provider.installHint };
     const avIcon = available ? '✓' : '✗';
     const authIcon = auth.ok ? '✓' : '✗';
-    console.log(
-      `  ${key}: installed ${avIcon}  auth ${authIcon}${auth.ok ? '' : `  → ${auth.hint}`}`
-    );
+    console.log(`  ${key}: installed ${avIcon}  auth ${authIcon}${auth.ok ? '' : `  → ${auth.hint}`}`);
   }
 }
 
@@ -190,9 +177,7 @@ export async function packSetup(options: PackInstallOptions = {}): Promise<void>
     const { created, updated, removed, skipped, warnings, conflicts } = result;
     const manifestPath = join(repoRoot, '.aco', 'sync-manifest.json');
 
-    console.log(
-      `  created: ${created}  updated: ${updated}  removed: ${removed}  skipped: ${skipped}`
-    );
+    console.log(`  created: ${created}  updated: ${updated}  removed: ${removed}  skipped: ${skipped}`);
     if (warnings > 0) {
       console.log(`  warnings: ${warnings} — see manifest for details: ${manifestPath}`);
     }
@@ -213,7 +198,10 @@ export async function packSetup(options: PackInstallOptions = {}): Promise<void>
     }
   }
 
-  console.log('\nNext step: aco provider setup gemini');
+  console.log('\nNext steps:');
+  for (const key of providerRegistry.keys()) {
+    console.log(`  aco provider setup ${key}`);
+  }
 }
 
 export async function providerSetup(name: string): Promise<void> {
@@ -241,13 +229,7 @@ export async function providerSetup(name: string): Promise<void> {
   console.log(`${name}: installed ✓  auth: ok ✓`);
 }
 
-async function copyTree(
-  src: string,
-  dest: string,
-  force: boolean,
-  kind: string,
-  manifest: string[]
-): Promise<void> {
+async function copyTree(src: string, dest: string, force: boolean, kind: string, manifest: string[]): Promise<void> {
   if (!existsSync(src)) {
     console.warn(`  [warn] template source not found: ${src}`);
     return;
@@ -283,26 +265,20 @@ async function collectFiles(dir: string, out: string[]): Promise<void> {
 
 async function placeWrapperBinary(binaryName: string): Promise<void> {
   try {
-    const { stdout } = await execFileAsync(binaryName, ['--version'], {
-      timeout: BINARY_CHECK_TIMEOUT_MS,
-    });
+    const { stdout } = await execFileAsync(binaryName, ['--version'], { timeout: BINARY_CHECK_TIMEOUT_MS });
     const versionOutput = typeof stdout === 'string' ? stdout.trim().toLowerCase() : '';
     if (versionOutput.startsWith('aco ')) {
       console.log(`  binary: '${binaryName}' already in PATH ✓`);
       return;
     }
-    console.warn(
-      `  [warn] Found '${binaryName}' in PATH, but '--version' output did not look like ${PUBLIC_PACKAGE_NAME}. Proceeding to install ${PUBLIC_PACKAGE_NAME} globally.`
-    );
+    console.warn(`  [warn] Found '${binaryName}' in PATH, but '--version' output did not look like ${PUBLIC_PACKAGE_NAME}. Proceeding to install ${PUBLIC_PACKAGE_NAME} globally.`);
   } catch {
     // Not found in PATH — proceed to global npm install
   }
 
   try {
     console.log(`  binary: installing ${PUBLIC_PACKAGE_NAME} globally …`);
-    await execFileAsync('npm', ['install', '-g', PUBLIC_PACKAGE_NAME], {
-      timeout: NPM_INSTALL_TIMEOUT_MS,
-    });
+    await execFileAsync('npm', ['install', '-g', PUBLIC_PACKAGE_NAME], { timeout: NPM_INSTALL_TIMEOUT_MS });
     console.log(`  binary: '${binaryName}' installed globally ✓`);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -20,6 +20,7 @@ function findTemplatesDir(startDir: string): string {
   const devPath = join(monorepoRoot, 'templates');
   const prodPath = join(packageRoot, 'templates');
 
+  // In development (not inside node_modules), prioritize the monorepo root templates
   const isDev = !startDir.split(sep).includes('node_modules');
   if (isDev && existsSync(devPath)) {
     return devPath;
@@ -157,9 +158,7 @@ export async function packStatus(options: { global?: boolean } = {}): Promise<vo
   for (const key of providerRegistry.keys()) {
     const provider = providerRegistry.get(key)!;
     const available = provider.isAvailable();
-    const auth = available
-      ? await provider.checkAuth()
-      : { ok: false, hint: provider.installHint };
+    const auth = available ? await provider.checkAuth() : { ok: false, hint: provider.installHint };
     const avIcon = available ? '✓' : '✗';
     const authIcon = auth.ok ? '✓' : '✗';
     console.log(

--- a/packages/wrapper/src/providers/codex.ts
+++ b/packages/wrapper/src/providers/codex.ts
@@ -8,12 +8,12 @@ const execFileAsync = promisify(execFile);
 
 const AUTH_CHECK_TIMEOUT_MS = 5_000;
 
-export class GeminiProvider implements IProvider {
-  readonly key = 'gemini';
-  readonly installHint = 'npm install -g @google/gemini-cli';
+export class CodexProvider implements IProvider {
+  readonly key = 'codex';
+  readonly installHint = 'npm install -g @openai/codex';
 
   isAvailable(): boolean {
-    return which('gemini') !== null;
+    return which('codex') !== null;
   }
 
   async checkAuth(): Promise<AuthResult> {
@@ -21,20 +21,20 @@ export class GeminiProvider implements IProvider {
       return { ok: false, hint: this.installHint };
     }
     try {
-      await execFileAsync('gemini', ['--version'], { timeout: AUTH_CHECK_TIMEOUT_MS });
+      await execFileAsync('codex', ['--version'], { timeout: AUTH_CHECK_TIMEOUT_MS });
       return { ok: true };
     } catch {
-      return { ok: false, hint: 'gemini auth login  # or run `gemini` interactively' };
+      return { ok: false, hint: 'codex login' };
     }
   }
 
   buildArgs(command: string, options?: InvokeOptions): string[] {
     const profile: PermissionProfile = options?.permissionProfile ?? 'default';
-    const base = ['-p'];
+    const args = ['exec', '--skip-git-repo-check'];
     if (profile !== 'restricted') {
-      base.unshift('--yolo');
+      args.push('--full-auto');
     }
-    return base;
+    return args;
   }
 
   async *invoke(
@@ -43,10 +43,11 @@ export class GeminiProvider implements IProvider {
     content: string,
     options?: InvokeOptions
   ): AsyncIterable<string> {
-    const binary = which('gemini');
-    if (!binary) throw new Error('gemini CLI not found in PATH');
+    const binary = which('codex');
+    if (!binary) throw new Error('codex CLI not found in PATH');
 
-    const args = [...this.buildArgs(command, options), `${prompt}\n\n${content}`];
-    yield* spawnStream(binary, args, { processName: 'gemini', stdin: 'pipe' }, options);
+    const combined = content ? `${prompt}\n\n${content}` : prompt;
+    const args = [...this.buildArgs(command, options), combined];
+    yield* spawnStream(binary, args, { processName: 'codex', stdin: 'pipe' }, options);
   }
 }

--- a/packages/wrapper/src/providers/gemini.ts
+++ b/packages/wrapper/src/providers/gemini.ts
@@ -50,3 +50,47 @@ export class GeminiProvider implements IProvider {
     yield* spawnStream(binary, args, { processName: 'gemini', stdin: 'pipe' }, options);
   }
 }
+
+export class CodexProvider implements IProvider {
+  readonly key = 'codex';
+  readonly installHint = 'npm install -g @openai/codex';
+
+  isAvailable(): boolean {
+    return which('codex') !== null;
+  }
+
+  async checkAuth(): Promise<AuthResult> {
+    if (!this.isAvailable()) {
+      return { ok: false, hint: this.installHint };
+    }
+    try {
+      await execFileAsync('codex', ['--version'], { timeout: AUTH_CHECK_TIMEOUT_MS });
+      return { ok: true };
+    } catch {
+      return { ok: false, hint: 'codex login' };
+    }
+  }
+
+  buildArgs(command: string, options?: InvokeOptions): string[] {
+    const profile: PermissionProfile = options?.permissionProfile ?? 'default';
+    const args = ['exec', '--skip-git-repo-check'];
+    if (profile !== 'restricted') {
+      args.push('--full-auto');
+    }
+    return args;
+  }
+
+  async *invoke(
+    command: string,
+    prompt: string,
+    content: string,
+    options?: InvokeOptions
+  ): AsyncIterable<string> {
+    const binary = which('codex');
+    if (!binary) throw new Error('codex CLI not found in PATH');
+
+    const combined = content ? `${prompt}\n\n${content}` : prompt;
+    const args = [...this.buildArgs(command, options), combined];
+    yield* spawnStream(binary, args, { processName: 'codex', stdin: 'ignore' }, options);
+  }
+}

--- a/packages/wrapper/src/providers/registry.ts
+++ b/packages/wrapper/src/providers/registry.ts
@@ -1,5 +1,6 @@
 import type { IProvider } from './interface.js';
-import { CodexProvider, GeminiProvider } from './gemini.js';
+import { GeminiProvider } from './gemini.js';
+import { CodexProvider } from './codex.js';
 
 export class ProviderRegistry {
   private readonly providers = new Map<string, IProvider>();

--- a/packages/wrapper/src/providers/registry.ts
+++ b/packages/wrapper/src/providers/registry.ts
@@ -1,12 +1,14 @@
 import type { IProvider } from './interface.js';
-import { GeminiProvider } from './gemini.js';
+import { CodexProvider, GeminiProvider } from './gemini.js';
 
 export class ProviderRegistry {
   private readonly providers = new Map<string, IProvider>();
 
   constructor() {
     const geminiProvider = new GeminiProvider();
+    const codexProvider = new CodexProvider();
     this.register('gemini', geminiProvider);
+    this.register('codex', codexProvider);
   }
 
   register(key: string, provider: IProvider): void {

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { CodexProvider, GeminiProvider } from '../src/providers/gemini';
+import { GeminiProvider } from '../src/providers/gemini';
+import { CodexProvider } from '../src/providers/codex';
 import { ProviderRegistry } from '../src/providers/registry';
 
 describe('GeminiProvider', () => {

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -74,6 +74,60 @@ describe('CodexProvider', () => {
     assert.equal(result.ok, false);
     assert.ok(typeof result.hint === 'string');
   });
+
+  describe('buildArgs()', () => {
+    it('includes --full-auto when profile is "default"', () => {
+      const provider = new CodexProvider();
+      const args = provider.buildArgs('test', { permissionProfile: 'default' });
+      assert.ok(args.includes('--full-auto'));
+    });
+
+    it('omits --full-auto when profile is "restricted"', () => {
+      const provider = new CodexProvider();
+      const args = provider.buildArgs('test', { permissionProfile: 'restricted' });
+      assert.ok(!args.includes('--full-auto'));
+    });
+
+    it('includes --skip-git-repo-check', () => {
+      const provider = new CodexProvider();
+      const args = provider.buildArgs('test');
+      assert.ok(args.includes('--skip-git-repo-check'));
+    });
+  });
+
+  describe('invoke()', () => {
+    it('combines prompt and content with double newline', async () => {
+      let capturedArgs: string[] = [];
+      class MockCodex extends CodexProvider {
+        // @ts-ignore - access private/protected for testing
+        async *invoke(command: string, prompt: string, content: string) {
+          const combined = content ? `${prompt}\n\n${content}` : prompt;
+          capturedArgs.push(combined);
+          yield '';
+        }
+      }
+      const provider = new MockCodex();
+      const iter = provider.invoke('test', 'Hello', 'World');
+      await iter.next();
+      assert.equal(capturedArgs[0], 'Hello\n\nWorld');
+    });
+
+    it('uses only prompt when content is empty', async () => {
+      let capturedArgs: string[] = [];
+      class MockCodex extends CodexProvider {
+        // @ts-ignore
+        async *invoke(command: string, prompt: string, content: string) {
+          const combined = content ? `${prompt}\n\n${content}` : prompt;
+          capturedArgs.push(combined);
+          yield '';
+        }
+      }
+      const provider = new MockCodex();
+      const iter = provider.invoke('test', 'Hello', '');
+      await iter.next();
+      assert.equal(capturedArgs[0], 'Hello');
+    });
+  });
 });
 
 describe('ProviderRegistry', () => {

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -1,19 +1,20 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { GeminiProvider } from '../src/providers/gemini';
+import { CodexProvider, GeminiProvider } from '../src/providers/gemini';
 import { ProviderRegistry } from '../src/providers/registry';
 
 describe('GeminiProvider', () => {
   it('isAvailable() returns true when gemini binary is in PATH', () => {
     const provider = new GeminiProvider();
-    // isAvailable result depends on actual PATH — just verify it returns boolean
     const result = provider.isAvailable();
     assert.equal(typeof result, 'boolean');
   });
 
   it('isAvailable() returns false when gemini is absent', () => {
     class TestGemini extends GeminiProvider {
-      override isAvailable() { return false; }
+      override isAvailable() {
+        return false;
+      }
     }
     assert.equal(new TestGemini().isAvailable(), false);
   });
@@ -28,9 +29,47 @@ describe('GeminiProvider', () => {
 
   it('checkAuth() returns { ok: false } when not available', async () => {
     class TestGemini extends GeminiProvider {
-      override isAvailable() { return false; }
+      override isAvailable() {
+        return false;
+      }
     }
     const result = await new TestGemini().checkAuth();
+    assert.equal(result.ok, false);
+    assert.ok(typeof result.hint === 'string');
+  });
+});
+
+describe('CodexProvider', () => {
+  it('isAvailable() returns true when codex binary is in PATH', () => {
+    const provider = new CodexProvider();
+    const result = provider.isAvailable();
+    assert.equal(typeof result, 'boolean');
+  });
+
+  it('isAvailable() returns false when codex is absent', () => {
+    class TestCodex extends CodexProvider {
+      override isAvailable() {
+        return false;
+      }
+    }
+    assert.equal(new TestCodex().isAvailable(), false);
+  });
+
+  it('key is "codex"', () => {
+    assert.equal(new CodexProvider().key, 'codex');
+  });
+
+  it('installHint is non-empty string', () => {
+    assert.ok(new CodexProvider().installHint.length > 0);
+  });
+
+  it('checkAuth() returns { ok: false } when not available', async () => {
+    class TestCodex extends CodexProvider {
+      override isAvailable() {
+        return false;
+      }
+    }
+    const result = await new TestCodex().checkAuth();
     assert.equal(result.ok, false);
     assert.ok(typeof result.hint === 'string');
   });
@@ -42,6 +81,13 @@ describe('ProviderRegistry', () => {
     const provider = registry.get('gemini');
     assert.ok(provider !== undefined);
     assert.equal(provider.key, 'gemini');
+  });
+
+  it('get("codex") returns CodexProvider', () => {
+    const registry = new ProviderRegistry();
+    const provider = registry.get('codex');
+    assert.ok(provider !== undefined);
+    assert.equal(provider.key, 'codex');
   });
 
   it('get("unknown") returns undefined', () => {
@@ -56,10 +102,11 @@ describe('ProviderRegistry', () => {
     assert.equal(registry.get('my-provider'), custom);
   });
 
-  it('keys() includes gemini', () => {
+  it('keys() includes gemini and codex', () => {
     const registry = new ProviderRegistry();
     const keys = registry.keys();
     assert.ok(keys.includes('gemini'));
-    assert.equal(keys.length, 1);
+    assert.ok(keys.includes('codex'));
+    assert.equal(keys.length, 2);
   });
 });


### PR DESCRIPTION
Closes #64

## What

Node wrapper 표면에서도 `codex` provider를 인식하도록 정리했습니다. 이제 wrapper provider registry에 `codex`가 등록되고, provider setup/status 흐름과 관련 테스트도 `gemini`뿐 아니라 `codex`까지 함께 다룹니다.

## Why

현재 문서에서는 `gemini`와 `codex`를 주요 provider로 안내하고 있지만, 실제 `packages/wrapper` 표면은 `gemini` 중심으로 동작하고 있었습니다. 이 PR은 문서와 실제 wrapper 사용 흐름의 간극을 줄이고, codex provider를 동일한 운영 경로에서 다룰 수 있도록 맞추기 위한 변경입니다.

## Changes

- `packages/wrapper/src/providers/gemini.ts` 업데이트 — 기존 Gemini provider 패턴을 재사용해 `CodexProvider` 구현 추가
- `packages/wrapper/src/providers/registry.ts` 업데이트 — `gemini`, `codex`를 모두 registry에 등록
- `packages/wrapper/src/commands/pack-install.ts` 업데이트 — `pack setup` 출력에서 등록된 모든 provider에 대한 setup 안내를 노출
- `packages/wrapper/src/cli.ts` 업데이트 — help 문구를 고정 provider 이름이 아닌 `<name>` 기준으로 일반화
- `packages/wrapper/tests/providers.test.ts` 업데이트 — codex provider 및 registry 동작 테스트 추가

## Checklist
- [ ] npm test passes
- [ ] manual smoke test
- [x] docs updated if needed