### PR TITLE
feat(wrapper): expose provider runtime context during sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,48 @@ node packages/wrapper/dist/cli.js sync --check
 aco cancel --session <id>
 ```
 
+`aco run`은 provider 실행 전에 실행 콘텍스트 대시보드를 stderr에 출력합니다.
+
+```text
+🛰️  aco Runtime Session
+
+✨ Active
+  Provider: gemini
+  Command: review
+  Session ID: f3f2d9...b1
+  Permission: default
+  Working Dir: /path/to/repo
+  Branch: main
+  Prompt Template: /path/to/repo/.claude/aco/prompts/gemini/review.md
+  Auth: ready (oauth)
+
+🧩 Exposed
+  Providers: gemini
+  Agents: reviewer,planner
+  Hooks: PostToolUse
+  Config: settings.json
+  Shared Skills: review-skill
+```
+
+CI/`NO_COLOR`에서는 ANSI 없이 평문 출력됩니다.
+
+`aco status`는 저장된 세션 메타데이터를 이용해 같은 runtime 요약도 보여줍니다.
+
+```text
+Session:    f3f2d9...b1
+Provider:   gemini
+Command:    review
+Status:     done
+Started:    2026-04-24T00:00:00.000Z
+Runtime:
+  Branch:    main
+  Prompt:    /path/to/repo/.claude/aco/prompts/gemini/review.md
+  Auth:      ready (oauth)
+  Agents:    reviewer,planner
+  Hooks:     PostToolUse
+  Skills:    review-skill
+```
+
 ## 이 저장소가 다루는 범위
 
 Claude Code 하네스를 repo-local 자산으로 관리하면서도, 실제 실행은 외부 AI CLI와 연결하려면 다음 관심사를 함께 다뤄야 합니다.

--- a/docs/guides/runbook.md
+++ b/docs/guides/runbook.md
@@ -48,6 +48,8 @@ npm install -g @pureliture/ai-cli-orch-wrapper
 ```bash
 aco provider setup gemini
 aco provider setup codex
+aco run gemini review
+aco status --session <id>
 ```
 
 Gemini CLI: `npm install -g @google/gemini-cli`
@@ -64,6 +66,14 @@ Codex CLI: `npm install -g @openai/codex`
 
 Codex OAuth 파일에 만료 시간이 있고 만료된 경우에는 `codex login`을 실행한다. headless 또는
 CI 환경에서는 Gemini에 `GEMINI_API_KEY`, Codex에 `OPENAI_API_KEY`를 우선 사용한다.
+
+`aco run <provider> <command>`는 provider 실행 전에 runtime dashboard를 stderr에 출력한다. TTY에서 실행하면 ANSI 색/이모지가 붙으며, CI 또는 `NO_COLOR` 설정 시에는 순수 텍스트로 출력되어 로그/스크립트 파이프에서 안정적이다.
+
+대시보드에는 다음 정보가 포함된다.
+
+- Active: provider, command, session id, permission profile, branch, prompt template
+- Exposed: provider agents, shared skills, hook/settings files
+- Auth: `ready`/`not ready`와 method (`api-key`, `oauth`, `cli-fallback`, `missing`)
 
 ### 설치 후 slash command가 보이지 않는 경우
 

--- a/openspec/changes/expose-runtime-context-dashboard/.openspec.yaml
+++ b/openspec/changes/expose-runtime-context-dashboard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/expose-runtime-context-dashboard/design.md
+++ b/openspec/changes/expose-runtime-context-dashboard/design.md
@@ -1,0 +1,123 @@
+## Context
+
+The current `aco` runtime already has the core signals needed for a useful runtime dashboard:
+
+- Provider registry knows the available provider keys.
+- Providers expose `isAvailable()` and `checkAuth()`.
+- `aco run` creates a session record before invoking the provider.
+- `aco sync` and generated target surfaces define where Codex and Gemini agents, skills, and hooks live.
+
+What is missing is a session-native display layer. `aco pack status` can show installed/authenticated providers, but `aco run` does not show a visible activation indicator or the surrounding runtime context. Users therefore cannot easily see whether Codex or Gemini is active, which prompt/session is being used, or which generated context surfaces are exposed to that provider.
+
+The design should keep the colorful, high-signal feel of Claude Octopus style provider activation while preserving `aco` contracts: provider-neutral abstractions, safe auth handling, and clean provider stdout.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Show a visually distinct runtime dashboard when a provider-backed `aco` session starts.
+- Use emoji, color, bold labels, separators, and compact status chips in interactive terminals.
+- Show plain, deterministic output in non-interactive environments.
+- Distinguish active runtime facts from exposed context surfaces.
+- Inspect Codex/Gemini agents, shared skills, and hooks without claiming they were selected by the provider unless `aco` directly selected them.
+- Persist non-secret runtime metadata for later `aco status` display.
+- Update README and relevant docs with the post-change runtime dashboard output so users can see the expected TUI/plain output behavior.
+- Avoid leaking API keys, OAuth tokens, auth file contents, full prompts, or command stdin content.
+- Keep provider stdout suitable for callers and sentinel/meta parsing.
+
+**Non-Goals:**
+- Implement provider-internal telemetry for whether Codex or Gemini actually selected a skill during its own reasoning.
+- Build a full terminal UI framework.
+- Add multi-provider orchestration or consensus workflows.
+- Change provider auth setup semantics.
+- Change the provider invocation contract or supported CLI flags.
+
+## Decisions
+
+### 1. Render the dashboard to stderr, not provider stdout
+
+**Decision:** `aco run` SHALL print the decorative runtime dashboard to stderr by default. Provider stdout remains reserved for provider output and existing meta/sentinel contracts.
+
+**Rationale:** The dashboard is for humans. Provider stdout may be consumed by scripts, stored as raw output, or parsed for sentinel lines. Mixing decorative UI into stdout would make automation brittle.
+
+**Alternative considered:** Print the banner to stdout before provider output. Rejected because it would pollute raw provider output and session result logs.
+
+### 2. Store structured runtime metadata separately from decorative rendering
+
+**Decision:** Runtime inspection SHALL produce a structured object first, then render it as colorful TTY output or plain text depending on environment. The same non-secret object SHALL be persisted in the session record or a session-local metadata file.
+
+**Rationale:** Rendering and data capture have different consumers. Separating them keeps `aco status` and tests stable while allowing the human-facing dashboard to evolve.
+
+**Alternative considered:** Build the dashboard as formatted strings only. Rejected because it would make status reuse and testing fragile.
+
+### 3. Use active versus exposed sections
+
+**Decision:** The dashboard SHALL separate:
+
+- `Active`: facts `aco` directly controls in the current run, such as provider, command, session id, permission profile, cwd, branch, prompt template, and auth status.
+- `Exposed`: context surfaces available to the selected provider or host, such as `.codex/agents`, `.gemini/agents`, `.agents/skills`, `.codex/hooks.json`, and `.gemini/settings.json`.
+
+**Rationale:** `aco` can prove which provider it invoked, but it cannot always prove which generated agent, skill, or hook the downstream provider internally used. The distinction prevents false claims while still giving users the desired visibility.
+
+**Alternative considered:** Show all discovered agents/skills/hooks as active. Rejected because it overstates what the runtime knows.
+
+### 4. Extend provider auth results with safe detail
+
+**Decision:** Provider auth inspection SHOULD include safe method details such as `api-key`, `oauth`, `cli-fallback`, or `missing`, plus a version or binary path when available. It MUST NOT include secret values or auth file contents.
+
+**Rationale:** Users want to know whether the ready state comes from OAuth, an API key, or a fallback probe. That is useful operational context and can be exposed safely if values are redacted.
+
+**Alternative considered:** Keep `AuthResult` as only `{ ok, hint }`. Rejected because it forces the dashboard to infer too much from provider-specific checks.
+
+### 5. Keep color and emoji opt-in by terminal capability
+
+**Decision:** The renderer SHALL use colorful emoji-enhanced output only when stderr is a TTY and neither `NO_COLOR` nor `CI` is set. Non-TTY output SHALL be plain text and stable enough for logs.
+
+**Rationale:** Interactive users get the intended visual identity. CI, logs, and scripted usage avoid ANSI control sequences and noisy decoration.
+
+**Alternative considered:** Always print colorful output. Rejected because it degrades logs and can break simple parsers.
+
+### 6. Avoid a new rendering dependency initially
+
+**Decision:** Use a small local ANSI helper for color/bold/dim rendering instead of adding a dependency for the initial version.
+
+**Rationale:** The needed styling is small, and avoiding a dependency keeps the wrapper package simple. A dependency can be introduced later if layout needs grow.
+
+**Alternative considered:** Add a terminal UI package. Rejected for v1 because the dashboard is a compact status panel, not an interactive UI.
+
+### 7. Treat dashboard examples as part of the user contract
+
+**Decision:** Implementation SHALL include a documentation pass over root `README.md`, `packages/wrapper/README.md`, and relevant files under `docs/` to add or update representative runtime dashboard output examples where they help users understand the feature.
+
+**Rationale:** The dashboard is a user-facing terminal experience, not only an internal metadata change. Without documented examples, users cannot easily tell whether the colorful TTY output, plain non-TTY output, active/exposed sections, and stderr/stdout separation are intentional.
+
+**Alternative considered:** Rely only on tests and code behavior. Rejected because this feature is primarily experienced through CLI output, so the expected output should be visible in user documentation.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| Dashboard implies provider-internal skill usage that `aco` cannot verify | Separate `Active` and `Exposed`, and use precise labels |
+| Auth method detection leaks sensitive data | Store only method names, booleans, hints, versions, and redacted paths |
+| Decorative output breaks automation | Render to stderr, disable color in non-TTY/CI/NO_COLOR, preserve provider stdout |
+| Extra filesystem inspection slows startup | Keep inspection shallow and bounded to known directories/files |
+| Provider auth checks add latency to `aco run` | Reuse existing fast-path checks and avoid slow provider execution where possible |
+| Session metadata format churn breaks consumers | Add optional fields and preserve existing `TaskRecord` fields |
+| Documented output examples drift from implementation | Add documentation update tasks after renderer behavior is finalized |
+
+## Migration Plan
+
+1. Add a runtime inspection helper that collects provider, auth, session, git, prompt, agent, skill, and hook metadata without secrets.
+2. Extend provider auth results with optional safe fields for method, version, and binary path.
+3. Add a renderer that emits colorful stderr output for TTY and plain output for non-TTY.
+4. Persist runtime metadata in the session record or a session-local metadata file.
+5. Update `aco status` and `aco pack status` to reuse the same structured inspection where appropriate.
+6. Review root `README.md`, `packages/wrapper/README.md`, and relevant `docs/` pages; add updated TUI/plain output examples where needed.
+7. Add unit tests for auth method detection, metadata redaction, active/exposed classification, TTY rendering, and non-TTY fallback.
+
+Rollback is straightforward: disable dashboard rendering while leaving existing provider execution and session storage behavior intact.
+
+## Open Questions
+
+- Should the dashboard be enabled by default for every `aco run`, or gated by `--runtime-dashboard` until the visual design settles?
+- Should users get a `--no-runtime-dashboard` flag in addition to environment controls?
+- Should `aco status` show the full exposed surface summary or only active session facts by default?

--- a/openspec/changes/expose-runtime-context-dashboard/proposal.md
+++ b/openspec/changes/expose-runtime-context-dashboard/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+`aco` already checks Codex and Gemini CLI installation/authentication, but that information is only surfaced through setup/status commands. During a real provider run, users cannot quickly see which provider is active, what runtime context is being used, or which agent/skill/hook surfaces are exposed to Codex and Gemini.
+
+Claude Octopus sets a useful precedent: provider activation should feel visible, colorful, and session-native rather than hidden behind plain setup diagnostics. This change brings that runtime presence to `aco` while preserving provider-neutral behavior and avoiding secret leakage.
+
+## What Changes
+
+- Add a colorful TTY runtime dashboard shown when `aco` starts a provider-backed session.
+- Show active execution context, including provider, command, session id, permission profile, working directory or branch, prompt template, and auth state.
+- Show exposed Codex/Gemini context surfaces, including generated agents, shared skills, and configured hooks, while clearly distinguishing exposed surfaces from surfaces proven active in the current run.
+- Keep the dashboard safe for automation: use plain text or suppress decorative styling in non-TTY, `CI`, or `NO_COLOR` environments.
+- Persist the same non-secret runtime metadata in the session record so `aco status` can summarize the session after launch.
+- Preserve provider stdout and sentinel/meta contracts by avoiding decorative HUD output in provider stdout streams.
+- Review README and docs surfaces after implementation and add representative before/after command output or TUI examples wherever users need to understand the new dashboard.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-context-dashboard`: Defines the terminal dashboard, runtime metadata, active-versus-exposed context distinction, and safe display behavior for provider-backed `aco` sessions.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected runtime paths: `packages/wrapper/src/cli.ts`, `packages/wrapper/src/session/store.ts`, `packages/wrapper/src/providers/`, and likely a new small runtime/context inspection helper.
+- Affected setup/status paths: `packages/installer/src/commands/pack-install.ts` and `aco pack status` output may share provider/context inspection formatting.
+- Affected documentation paths: root `README.md`, `packages/wrapper/README.md`, and relevant `docs/` references or guides.
+- Affected tests: provider auth tests, session record tests, and new dashboard rendering/context inspection tests.
+- No breaking CLI argument changes are expected.
+- No provider auth secrets, API key values, OAuth token contents, or full prompt bodies should be displayed or persisted.

--- a/openspec/changes/expose-runtime-context-dashboard/specs/runtime-context-dashboard/spec.md
+++ b/openspec/changes/expose-runtime-context-dashboard/specs/runtime-context-dashboard/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Runtime dashboard SHALL be shown for provider-backed sessions
+The system SHALL show a runtime dashboard when `aco` starts a provider-backed session so users can see which provider is active and what execution context is being used.
+
+#### Scenario: Interactive provider run shows colorful dashboard
+- **WHEN** a user runs `aco run <provider> <command>` in an interactive terminal
+- **THEN** the system SHALL display a visually distinct runtime dashboard before provider output begins
+- **AND** the dashboard SHALL include emoji-enhanced provider activation, status indicators, and compact runtime facts
+
+#### Scenario: Provider run identifies active session
+- **WHEN** the runtime dashboard is displayed for a provider run
+- **THEN** it SHALL show the active provider, command, session id, permission profile, working directory or branch, and prompt template path when known
+
+### Requirement: Dashboard SHALL distinguish active runtime from exposed context
+The system SHALL distinguish context that is active in the current `aco` run from context surfaces merely exposed to Codex or Gemini.
+
+#### Scenario: Active context is displayed
+- **WHEN** `aco` directly invokes a provider for a command
+- **THEN** the dashboard SHALL list the provider, command, session id, permission profile, and prompt template under an active runtime section
+
+#### Scenario: Exposed context surfaces are displayed
+- **WHEN** Codex or Gemini target context files exist in the working tree
+- **THEN** the dashboard SHALL summarize exposed agents, shared skills, and hooks under a separate exposed context section
+- **AND** it SHALL NOT claim that exposed agents, skills, or hooks were selected unless `aco` directly selected them
+
+#### Scenario: No exposed context exists
+- **WHEN** no generated agents, shared skills, or hook configuration are found for the selected provider
+- **THEN** the dashboard SHALL show a concise empty or unavailable state instead of failing the provider run
+
+### Requirement: Provider readiness SHALL include safe auth and install details
+The system SHALL expose safe provider readiness details in the runtime dashboard without revealing secrets.
+
+#### Scenario: Auth method is known
+- **WHEN** provider auth succeeds through an API key, OAuth credentials, or CLI fallback
+- **THEN** the dashboard SHALL show a safe auth method label such as `api-key`, `oauth`, or `cli-fallback`
+- **AND** it SHALL NOT show API key values, OAuth tokens, or auth file contents
+
+#### Scenario: Provider is missing or unauthenticated
+- **WHEN** provider installation or authentication is missing
+- **THEN** the dashboard or setup/status output SHALL show a concise not-ready state and the existing remediation hint
+- **AND** it SHALL NOT expose sensitive environment variable values or credential file contents
+
+#### Scenario: Provider version is available
+- **WHEN** a provider binary version can be read without requiring interactive auth
+- **THEN** the dashboard MAY show the provider version or binary path as non-secret diagnostic context
+
+### Requirement: Dashboard output SHALL preserve provider stdout contracts
+The runtime dashboard SHALL avoid polluting provider stdout so callers can continue to consume raw provider output and sentinel or meta lines.
+
+#### Scenario: Dashboard renders before provider output
+- **WHEN** `aco run` renders a runtime dashboard
+- **THEN** decorative dashboard output SHALL be written to stderr or another non-provider-output channel
+- **AND** provider stdout SHALL remain reserved for provider output and existing meta/sentinel contracts
+
+#### Scenario: Session output log is written
+- **WHEN** provider output is tee'd to a session output log
+- **THEN** the log SHALL preserve provider output without decorative dashboard lines unless the log is explicitly documented as including runtime UI
+
+### Requirement: Dashboard formatting SHALL adapt to terminal environment
+The system SHALL render colorful output for interactive terminals and stable plain output for automation environments.
+
+#### Scenario: TTY supports decoration
+- **WHEN** stderr is a TTY and neither `NO_COLOR` nor `CI` is set
+- **THEN** the dashboard SHALL use ANSI styling and emoji-enhanced labels for provider activation and status
+
+#### Scenario: Decoration is disabled
+- **WHEN** stderr is not a TTY or `NO_COLOR` or `CI` is set
+- **THEN** the dashboard SHALL use plain text without ANSI color sequences
+- **AND** the output SHALL remain readable in logs
+
+### Requirement: Session metadata SHALL persist non-secret runtime context
+The system SHALL persist non-secret runtime dashboard metadata so later status commands can summarize the session.
+
+#### Scenario: Session is created
+- **WHEN** `aco` creates a provider session
+- **THEN** it SHALL persist non-secret runtime metadata including provider, command, permission profile, auth readiness, active prompt template, and exposed context counts or names
+
+#### Scenario: User checks session status later
+- **WHEN** the user runs `aco status` for a session with runtime metadata
+- **THEN** the status output SHALL include a concise summary of the active runtime context
+- **AND** it SHALL omit secrets and full prompt content
+
+### Requirement: Documentation SHALL show the changed runtime output
+The system SHALL update user-facing documentation with representative command output or TUI examples after the dashboard behavior is implemented.
+
+#### Scenario: README surfaces are reviewed
+- **WHEN** the runtime dashboard implementation is complete
+- **THEN** the implementer SHALL review root `README.md` and `packages/wrapper/README.md`
+- **AND** update the files where the new runtime dashboard, provider status output, active/exposed distinction, or plain-output fallback needs to be explained
+
+#### Scenario: Docs surfaces are reviewed
+- **WHEN** the runtime dashboard implementation is complete
+- **THEN** the implementer SHALL review relevant files under `docs/`
+- **AND** add or update examples of the changed TUI or command output where those docs describe `aco run`, provider setup/status, session status, or Codex/Gemini runtime context
+
+#### Scenario: Documentation examples avoid secrets
+- **WHEN** documentation includes dashboard or command output examples
+- **THEN** the examples SHALL use redacted or fake values for auth, paths, session ids, and provider details where needed
+- **AND** the examples SHALL NOT include real API keys, OAuth tokens, or user-specific credential contents

--- a/openspec/changes/expose-runtime-context-dashboard/tasks.md
+++ b/openspec/changes/expose-runtime-context-dashboard/tasks.md
@@ -1,0 +1,44 @@
+## 1. Provider Readiness Metadata
+
+- [x] 1.1 Extend `AuthResult` with optional non-secret fields for auth method, provider version, and binary path.
+- [x] 1.2 Update Codex auth detection to report `api-key`, `oauth`, `cli-fallback`, or `missing` without exposing credential values.
+- [x] 1.3 Update Gemini auth detection to report `api-key`, `oauth`, `cli-fallback`, or `missing` without exposing credential values.
+- [x] 1.4 Add tests for provider auth method detection and redaction behavior.
+
+## 2. Runtime Context Inspection
+
+- [x] 2.1 Add runtime context types for active session facts and exposed provider surfaces.
+- [x] 2.2 Collect active runtime facts in `aco run`: provider, command, session id, permission profile, cwd, branch, prompt template path, and auth readiness.
+- [x] 2.3 Inspect Codex exposed surfaces from `.codex/agents/*.toml`, `.agents/skills/*/SKILL.md`, `.codex/hooks.json`, and `.codex/config.toml`.
+- [x] 2.4 Inspect Gemini exposed surfaces from `.gemini/agents/*.md`, `.agents/skills/*/SKILL.md`, and `.gemini/settings.json`.
+- [x] 2.5 Classify discovered data as `active` or `exposed` and avoid marking provider-internal selections as active.
+
+## 3. Dashboard Rendering
+
+- [x] 3.1 Add a small ANSI/formatting helper that supports color, bold, dim, and plain-text fallback without a new dependency.
+- [x] 3.2 Render an emoji-enhanced colorful runtime dashboard to stderr when stderr is a TTY and `NO_COLOR`/`CI` are unset.
+- [x] 3.3 Render stable plain text without ANSI sequences for non-TTY, `NO_COLOR`, and `CI` environments.
+- [x] 3.4 Ensure dashboard output does not enter provider stdout or provider output logs.
+
+## 4. Session Persistence And Status
+
+- [x] 4.1 Persist non-secret runtime metadata in `task.json` or a session-local metadata file.
+- [x] 4.2 Update `aco status` to show a concise runtime context summary when metadata is present.
+- [x] 4.3 Update `aco pack status` or shared status helpers to reuse provider readiness formatting where practical.
+- [x] 4.4 Preserve compatibility with existing session records that do not contain runtime metadata.
+
+## 5. Tests And Documentation
+
+- [x] 5.1 Add runtime context discovery tests for Codex agents, Gemini agents, shared skills, and hooks.
+- [x] 5.2 Add dashboard renderer tests for colorful TTY mode and plain automation mode.
+- [x] 5.3 Add session store/status tests for runtime metadata persistence and backward compatibility.
+- [x] 5.4 Review root `README.md` and `packages/wrapper/README.md`; add or update representative runtime dashboard and command output examples where needed.
+- [x] 5.5 Review relevant `docs/` pages; add or update examples for changed `aco run`, provider status, session status, and Codex/Gemini runtime context output where needed.
+- [x] 5.6 Document the active versus exposed distinction, TTY versus plain output behavior, stderr/stdout placement, and secret redaction rules.
+
+## 6. Validation
+
+- [x] 6.1 Run `npm test --workspace=packages/wrapper`.
+- [ ] 6.2 Run `npm run typecheck --workspace=packages/wrapper`.
+- [x] 6.3 Run `git diff --check`.
+- [ ] 6.4 Manually smoke `aco run` in a TTY-like environment to verify dashboard placement and provider stdout preservation.

--- a/packages/wrapper/README.md
+++ b/packages/wrapper/README.md
@@ -12,6 +12,31 @@ aco pack setup
 aco pack status
 aco provider setup gemini
 aco provider setup codex
+aco result
+aco status
+```
+
+Provider run starts with a compact runtime dashboard on stderr so you can see the active session and exposed context.
+
+```text
+🛰️  aco Runtime Session
+
+✨ Active
+  Provider: gemini
+  Command: review
+  Session ID: f3f2d9...b1
+  Permission: default
+  Working Dir: /path/to/repo
+  Branch: main
+  Prompt Template: /path/to/repo/.claude/aco/prompts/gemini/review.md
+  Auth: ready (cli-fallback, vgemini-cli 1.2.3, bin gemini)
+
+🧩 Exposed
+  Providers: gemini
+  Agents: reviewer
+  Hooks: PostToolUse
+  Config: settings.json
+  Shared Skills: review-skill
 ```
 
 ## Provider Auth

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "prepack": "node -e \"const fs = require('fs'); const path = require('path'); const src = path.resolve(process.cwd(), '../../templates'); const dest = path.resolve(process.cwd(), 'templates'); fs.rmSync(dest, { recursive: true, force: true }); fs.mkdirSync(dest, { recursive: true }); fs.cpSync(src, dest, { recursive: true });\"",
-    "test": "node --require tsx/cjs --test tests/providers.test.ts tests/session.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts",
+    "test": "node --require tsx/cjs --test tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts",
     "test:smoke": "tsx tests/smoke.ts",
     "typecheck": "tsc --noEmit",
     "format:check": "prettier --check \"src/**/*.ts\""

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -17,6 +17,10 @@ import {
 import { providerRegistry } from './providers/registry.js';
 import { sessionStore } from './session/store.js';
 import type { PermissionProfile } from './providers/interface.js';
+import { getCachedProviderAuth } from './providers/auth-cache.js';
+import { collectRuntimeContext } from './runtime/context.js';
+import { renderRuntimeDashboard } from './runtime/dashboard.js';
+import { formatAuthStatus } from './runtime/auth-display.js';
 import { runSync } from './sync/sync-engine.js';
 
 const execFileAsync = promisify(execFile);
@@ -186,8 +190,25 @@ async function cmdRun(args: string[]): Promise<void> {
   } else if (existsSync(globalPromptPath)) {
     prompt = await readFile(globalPromptPath, 'utf8');
   }
+  const promptTemplatePath = existsSync(cwdPromptPath)
+    ? cwdPromptPath
+    : existsSync(globalPromptPath)
+      ? globalPromptPath
+      : undefined;
 
   const session = await sessionStore.create(providerKey, command, undefined, permissionProfile);
+  const auth = await getCachedProviderAuth(provider);
+  const runtimeContext = await collectRuntimeContext({
+    provider: providerKey,
+    command,
+    sessionId: session.id,
+    permissionProfile,
+    promptTemplatePath,
+    auth,
+  });
+  await sessionStore.update(session.id, { runtimeContext });
+  process.stderr.write(renderRuntimeDashboard(runtimeContext) + '\n');
+
   const tee = sessionStore.createOutputTee(session.id);
   let hasOutput = false;
   let runError: unknown;
@@ -267,6 +288,32 @@ async function cmdStatus(args: string[]): Promise<void> {
     console.log(`Started:    ${record.startedAt}`);
     if (record.endedAt) console.log(`Ended:      ${record.endedAt}`);
     if (record.permissionProfile) console.log(`Permission: ${record.permissionProfile}`);
+    if (record.runtimeContext) {
+      const active = record.runtimeContext.active;
+      const exposed = record.runtimeContext.exposed;
+      console.log('Runtime:');
+      console.log(`  Branch:    ${active.branch ?? '(none)'}`);
+      console.log(`  Prompt:    ${active.promptTemplatePath ?? '(default)'}`);
+      console.log(`  Auth:      ${formatAuthStatus(active.auth)}`);
+      console.log(
+        `  Agents:    ${
+          exposed.providerAgents.length > 0 ? exposed.providerAgents.join(', ') : '(none)'
+        }`
+      );
+      console.log(
+        `  Hooks:     ${
+          exposed.providerHooks.length > 0 ? exposed.providerHooks.join(', ') : '(none)'
+        }`
+      );
+      if (exposed.providerConfigFiles.length > 0) {
+        console.log(`  Config:    ${exposed.providerConfigFiles.join(', ')}`);
+      }
+      console.log(
+        `  Skills:    ${
+          exposed.sharedSkills.length > 0 ? exposed.sharedSkills.join(', ') : '(none)'
+        }`
+      );
+    }
   } catch {
     console.error(`Session not found: ${sessionId}`);
     process.exit(EXIT_ERROR);

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -196,7 +196,7 @@ async function cmdRun(args: string[]): Promise<void> {
   }
 
   const session = await sessionStore.create(providerKey, command, undefined, permissionProfile);
-  const auth = await getCachedProviderAuth(provider);
+  const auth = await getCachedProviderAuth(provider, { skipCache: true });
   const runtimeContext = await collectRuntimeContext({
     provider: providerKey,
     command,

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -185,16 +185,15 @@ async function cmdRun(args: string[]): Promise<void> {
     `${command}.md`
   );
   let prompt = `You are a code reviewer. Perform a ${command} for the following content.`;
+  let promptTemplatePath: string | undefined;
+
   if (existsSync(cwdPromptPath)) {
     prompt = await readFile(cwdPromptPath, 'utf8');
+    promptTemplatePath = cwdPromptPath;
   } else if (existsSync(globalPromptPath)) {
     prompt = await readFile(globalPromptPath, 'utf8');
+    promptTemplatePath = globalPromptPath;
   }
-  const promptTemplatePath = existsSync(cwdPromptPath)
-    ? cwdPromptPath
-    : existsSync(globalPromptPath)
-      ? globalPromptPath
-      : undefined;
 
   const session = await sessionStore.create(providerKey, command, undefined, permissionProfile);
   const auth = await getCachedProviderAuth(provider);

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -6,6 +6,8 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { providerRegistry } from '../providers/registry.js';
 import { runSync } from '../sync/sync-engine.js';
+import { formatAuthStatus } from '../runtime/auth-display.js';
+import { getCachedProviderAuth } from '../providers/auth-cache.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -158,12 +160,11 @@ export async function packStatus(options: { global?: boolean } = {}): Promise<vo
   for (const key of providerRegistry.keys()) {
     const provider = providerRegistry.get(key)!;
     const available = provider.isAvailable();
-    const auth = available ? await provider.checkAuth() : { ok: false, hint: provider.installHint };
+    const auth = available
+      ? await getCachedProviderAuth(provider)
+      : { ok: false, hint: provider.installHint };
     const avIcon = available ? '✓' : '✗';
-    const authIcon = auth.ok ? '✓' : '✗';
-    console.log(
-      `  ${key}: installed ${avIcon}  auth ${authIcon}${auth.ok ? '' : `  → ${auth.hint}`}`
-    );
+    console.log(`  ${key}: installed ${avIcon}  auth ${formatAuthStatus(auth)}`);
   }
 }
 

--- a/packages/wrapper/src/commands/pack-install.ts
+++ b/packages/wrapper/src/commands/pack-install.ts
@@ -161,7 +161,7 @@ export async function packStatus(options: { global?: boolean } = {}): Promise<vo
     const provider = providerRegistry.get(key)!;
     const available = provider.isAvailable();
     const auth = available
-      ? await getCachedProviderAuth(provider)
+      ? await getCachedProviderAuth(provider, { skipCache: true })
       : { ok: false, hint: provider.installHint };
     const avIcon = available ? '✓' : '✗';
     console.log(`  ${key}: installed ${avIcon}  auth ${formatAuthStatus(auth)}`);

--- a/packages/wrapper/src/providers/auth-cache.ts
+++ b/packages/wrapper/src/providers/auth-cache.ts
@@ -1,0 +1,65 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import type { AuthResult } from './interface.js';
+import type { IProvider } from './interface.js';
+
+const AUTH_CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_PATH = resolve(homedir(), '.aco', 'provider-auth-cache.json');
+
+type AuthCacheRecord = {
+  checkedAt: number;
+  provider: string;
+  auth: AuthResult;
+};
+
+type AuthCache = Record<string, AuthCacheRecord>;
+
+function readCache(): Promise<AuthCache> {
+  return readFile(CACHE_PATH, 'utf8')
+    .then((raw) => {
+      const parsed = JSON.parse(raw) as AuthCache;
+      return parsed ?? {};
+    })
+    .catch(() => ({}));
+}
+
+async function writeCache(cache: AuthCache): Promise<void> {
+  await mkdir(dirname(CACHE_PATH), { recursive: true });
+  await writeFile(CACHE_PATH, JSON.stringify(cache, null, 2), { mode: 0o600 });
+}
+
+function isFresh(entry: AuthCacheRecord | undefined, now: number, ttlMs: number): boolean {
+  if (!entry) return false;
+  return now - entry.checkedAt < ttlMs;
+}
+
+export interface GetCachedAuthOptions {
+  ttlMs?: number;
+}
+
+export async function getCachedProviderAuth(
+  provider: IProvider,
+  options: GetCachedAuthOptions = {}
+): Promise<AuthResult> {
+  const { ttlMs = AUTH_CACHE_TTL_MS } = options;
+  const now = Date.now();
+
+  const cache = await readCache();
+  const key = provider.key;
+  const entry = cache[key];
+
+  if (isFresh(entry, now, ttlMs) && entry.provider === provider.key) {
+    return entry.auth;
+  }
+
+  const auth = await provider.checkAuth();
+  cache[key] = {
+    provider: provider.key,
+    checkedAt: now,
+    auth,
+  };
+
+  await writeCache(cache).catch(() => undefined);
+  return auth;
+}

--- a/packages/wrapper/src/providers/auth-cache.ts
+++ b/packages/wrapper/src/providers/auth-cache.ts
@@ -36,20 +36,21 @@ function isFresh(entry: AuthCacheRecord | undefined, now: number, ttlMs: number)
 
 export interface GetCachedAuthOptions {
   ttlMs?: number;
+  skipCache?: boolean;
 }
 
 export async function getCachedProviderAuth(
   provider: IProvider,
   options: GetCachedAuthOptions = {}
 ): Promise<AuthResult> {
-  const { ttlMs = AUTH_CACHE_TTL_MS } = options;
+  const { ttlMs = AUTH_CACHE_TTL_MS, skipCache = false } = options;
   const now = Date.now();
 
   const cache = await readCache();
   const key = provider.key;
   const entry = cache[key];
 
-  if (isFresh(entry, now, ttlMs) && entry.provider === provider.key) {
+  if (!skipCache && isFresh(entry, now, ttlMs) && entry.provider === provider.key) {
     return entry.auth;
   }
 

--- a/packages/wrapper/src/providers/codex.ts
+++ b/packages/wrapper/src/providers/codex.ts
@@ -20,13 +20,20 @@ export class CodexProvider implements IProvider {
   }
 
   async checkAuth(): Promise<AuthResult> {
-    if (!this.isAvailable()) {
-      return { ok: false, hint: this.installHint };
+    const available = this.isAvailable();
+    const binaryPath = which('codex');
+
+    if (!available || !binaryPath) {
+      return { ok: false, method: 'missing', hint: this.installHint };
     }
+
+    const versionHint = {
+      binaryPath,
+    };
 
     // 1. Fast path: Environment variables
     if (process.env.OPENAI_API_KEY) {
-      return { ok: true };
+      return { ok: true, method: 'api-key', ...versionHint };
     }
 
     // 2. Fast path: Local OAuth token file with expiration check
@@ -44,11 +51,13 @@ export class CodexProvider implements IProvider {
           if (expiresAt < now) {
             return {
               ok: false,
+              method: 'missing',
               hint: 'Codex OAuth token expired. Run: codex login',
+              ...versionHint,
             };
           }
         }
-        return { ok: true };
+        return { ok: true, method: 'oauth', ...versionHint };
       } catch (e) {
         console.warn(
           'Failed to parse Codex auth file:',
@@ -62,11 +71,13 @@ export class CodexProvider implements IProvider {
 
     // 3. Fallback: CLI execution
     try {
-      await execFileAsync('codex', ['--version'], { timeout: AUTH_CHECK_TIMEOUT_MS });
-      return { ok: true };
+      const version = await readVersion('codex');
+      return { ok: true, method: 'cli-fallback', version, ...versionHint };
     } catch {
       return {
         ok: false,
+        method: 'missing',
+        ...versionHint,
         hint: 'codex login OR export OPENAI_API_KEY="..."',
       };
     }
@@ -93,5 +104,18 @@ export class CodexProvider implements IProvider {
     const combined = content ? `${prompt}\n\n${content}` : prompt;
     const args = [...this.buildArgs(command, options), combined];
     yield* spawnStream(binary, args, { processName: 'codex', stdin: 'pipe' }, options);
+  }
+}
+
+async function readVersion(binary: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(binary, ['--version'], {
+      timeout: AUTH_CHECK_TIMEOUT_MS,
+    });
+    const output = typeof stdout === 'string' ? stdout.trim() : '';
+    if (!output) return undefined;
+    return output.split('\n')[0].trim();
+  } catch {
+    return undefined;
   }
 }

--- a/packages/wrapper/src/providers/codex.ts
+++ b/packages/wrapper/src/providers/codex.ts
@@ -1,15 +1,10 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { which } from '../util/which.js';
 import { spawnStream } from '../util/spawn-stream.js';
 import type { AuthResult, InvokeOptions, IProvider, PermissionProfile } from './interface.js';
-
-const execFileAsync = promisify(execFile);
-
-const AUTH_CHECK_TIMEOUT_MS = 5_000;
+import { readVersion } from '../util/read-version.js';
 
 export class CodexProvider implements IProvider {
   readonly key = 'codex';
@@ -105,18 +100,5 @@ export class CodexProvider implements IProvider {
     const combined = content ? `${prompt}\n\n${content}` : prompt;
     const args = [...this.buildArgs(command, options), combined];
     yield* spawnStream(binary, args, { processName: 'codex', stdin: 'pipe' }, options);
-  }
-}
-
-async function readVersion(binary: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync(binary, ['--version'], {
-      timeout: AUTH_CHECK_TIMEOUT_MS,
-    });
-    const output = typeof stdout === 'string' ? stdout.trim() : '';
-    if (!output) return undefined;
-    return output.split('\n')[0].trim();
-  } catch {
-    return undefined;
   }
 }

--- a/packages/wrapper/src/providers/codex.ts
+++ b/packages/wrapper/src/providers/codex.ts
@@ -72,6 +72,7 @@ export class CodexProvider implements IProvider {
     // 3. Fallback: CLI execution
     try {
       const version = await readVersion('codex');
+      if (version === undefined) throw new Error('probe failed');
       return { ok: true, method: 'cli-fallback', version, ...versionHint };
     } catch {
       return {

--- a/packages/wrapper/src/providers/gemini.ts
+++ b/packages/wrapper/src/providers/gemini.ts
@@ -20,13 +20,20 @@ export class GeminiProvider implements IProvider {
   }
 
   async checkAuth(): Promise<AuthResult> {
-    if (!this.isAvailable()) {
-      return { ok: false, hint: this.installHint };
+    const available = this.isAvailable();
+    const binaryPath = which('gemini');
+
+    if (!available || !binaryPath) {
+      return { ok: false, method: 'missing', hint: this.installHint };
     }
+
+    const versionHint = {
+      binaryPath,
+    };
 
     // 1. Fast path: Environment variables
     if (process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) {
-      return { ok: true };
+      return { ok: true, method: 'api-key', ...versionHint };
     }
 
     // 2. Fast path: Local OAuth credentials file
@@ -38,7 +45,7 @@ export class GeminiProvider implements IProvider {
       const raw = await readFile(credsPath, 'utf8');
       try {
         JSON.parse(raw);
-        return { ok: true };
+        return { ok: true, method: 'oauth', ...versionHint };
       } catch (e) {
         console.warn(
           'Failed to parse Gemini auth file:',
@@ -52,11 +59,13 @@ export class GeminiProvider implements IProvider {
 
     // 3. Fallback: CLI execution
     try {
-      await execFileAsync('gemini', ['--version'], { timeout: AUTH_CHECK_TIMEOUT_MS });
-      return { ok: true };
+      const version = await readVersion('gemini');
+      return { ok: true, method: 'cli-fallback', version, ...versionHint };
     } catch {
       return {
         ok: false,
+        method: 'missing',
+        ...versionHint,
         hint: 'gemini auth login OR export GEMINI_API_KEY="..."',
       };
     }
@@ -82,5 +91,18 @@ export class GeminiProvider implements IProvider {
 
     const args = [...this.buildArgs(command, options), `${prompt}\n\n${content}`];
     yield* spawnStream(binary, args, { processName: 'gemini', stdin: 'pipe' }, options);
+  }
+}
+
+async function readVersion(binary: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(binary, ['--version'], {
+      timeout: AUTH_CHECK_TIMEOUT_MS,
+    });
+    const output = typeof stdout === 'string' ? stdout.trim() : '';
+    if (!output) return undefined;
+    return output.split('\n')[0].trim();
+  } catch {
+    return undefined;
   }
 }

--- a/packages/wrapper/src/providers/gemini.ts
+++ b/packages/wrapper/src/providers/gemini.ts
@@ -1,15 +1,10 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { stat, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { which } from '../util/which.js';
 import { spawnStream } from '../util/spawn-stream.js';
 import type { AuthResult, InvokeOptions, IProvider, PermissionProfile } from './interface.js';
-
-const execFileAsync = promisify(execFile);
-
-const AUTH_CHECK_TIMEOUT_MS = 5_000;
+import { readVersion } from '../util/read-version.js';
 
 export class GeminiProvider implements IProvider {
   readonly key = 'gemini';
@@ -92,18 +87,5 @@ export class GeminiProvider implements IProvider {
 
     const args = [...this.buildArgs(command, options), `${prompt}\n\n${content}`];
     yield* spawnStream(binary, args, { processName: 'gemini', stdin: 'pipe' }, options);
-  }
-}
-
-async function readVersion(binary: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync(binary, ['--version'], {
-      timeout: AUTH_CHECK_TIMEOUT_MS,
-    });
-    const output = typeof stdout === 'string' ? stdout.trim() : '';
-    if (!output) return undefined;
-    return output.split('\n')[0].trim();
-  } catch {
-    return undefined;
   }
 }

--- a/packages/wrapper/src/providers/gemini.ts
+++ b/packages/wrapper/src/providers/gemini.ts
@@ -60,6 +60,7 @@ export class GeminiProvider implements IProvider {
     // 3. Fallback: CLI execution
     try {
       const version = await readVersion('gemini');
+      if (version === undefined) throw new Error('probe failed');
       return { ok: true, method: 'cli-fallback', version, ...versionHint };
     } catch {
       return {

--- a/packages/wrapper/src/providers/interface.ts
+++ b/packages/wrapper/src/providers/interface.ts
@@ -1,7 +1,12 @@
 export type PermissionProfile = 'default' | 'restricted' | 'unrestricted';
 
+export type AuthMethod = 'api-key' | 'oauth' | 'cli-fallback' | 'missing';
+
 export interface AuthResult {
   ok: boolean;
+  method?: AuthMethod;
+  version?: string;
+  binaryPath?: string;
   hint?: string;
 }
 

--- a/packages/wrapper/src/runtime/auth-display.ts
+++ b/packages/wrapper/src/runtime/auth-display.ts
@@ -1,0 +1,35 @@
+import { basename } from 'node:path';
+import type { AuthResult } from '../providers/interface.js';
+
+function appendMethod(parts: string[], value?: string): void {
+  if (!value) return;
+  parts.push(value);
+}
+
+function appendVersion(parts: string[], value?: string): void {
+  if (!value) return;
+  parts.push(`v${value}`);
+}
+
+function appendBinaryPath(parts: string[], value?: string): void {
+  if (!value) return;
+  const base = basename(value);
+  if (!base) return;
+  parts.push(`bin ${base}`);
+}
+
+function formatReadyLabel(auth: AuthResult): string {
+  const parts: string[] = [];
+  appendMethod(parts, auth.method);
+  appendVersion(parts, auth.version);
+  appendBinaryPath(parts, auth.binaryPath);
+  return parts.length > 0 ? `ready (${parts.join(', ')})` : 'ready';
+}
+
+function formatNotReadyLabel(auth: AuthResult): string {
+  return auth.hint ? `not ready (${auth.hint})` : 'not ready';
+}
+
+export function formatAuthStatus(auth: AuthResult): string {
+  return auth.ok ? formatReadyLabel(auth) : formatNotReadyLabel(auth);
+}

--- a/packages/wrapper/src/runtime/context.ts
+++ b/packages/wrapper/src/runtime/context.ts
@@ -1,0 +1,220 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { join, basename, extname, resolve } from 'node:path';
+import type { PermissionProfile } from '../providers/interface.js';
+import type { AuthResult } from '../providers/interface.js';
+import type { RuntimeContext } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+export interface RuntimeContextInput {
+  provider: string;
+  command: string;
+  sessionId: string;
+  permissionProfile: PermissionProfile;
+  promptTemplatePath?: string;
+  auth: AuthResult;
+  cwd?: string;
+}
+
+function normalizeList(values: string[]): string[] {
+  return [
+    ...new Set(
+      values
+        .filter(Boolean)
+        .map((value) => value.trim())
+        .filter(Boolean)
+    ),
+  ].sort();
+}
+
+function toNames(files: string[]): string[] {
+  return normalizeList(files.map((value) => basename(value, extname(value))));
+}
+
+async function listFilesByExt(baseDir: string, ext: string): Promise<string[]> {
+  try {
+    const entries = await readdir(baseDir, { withFileTypes: true });
+    const files = entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(ext))
+      .map((entry) => join(baseDir, entry.name));
+    return toNames(files);
+  } catch {
+    return [];
+  }
+}
+
+async function listSharedSkills(workspace: string): Promise<string[]> {
+  const skillsBase = join(workspace, '.agents', 'skills');
+  try {
+    const entries = await readdir(skillsBase, { withFileTypes: true });
+    const names: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const marker = join(skillsBase, entry.name, 'SKILL.md');
+      try {
+        await stat(marker);
+      } catch {
+        continue;
+      }
+      names.push(entry.name);
+    }
+    return normalizeList(names);
+  } catch {
+    return [];
+  }
+}
+
+async function collectHookNames(filePath: string): Promise<string[]> {
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const names = new Set<string>();
+
+    if (Array.isArray(parsed)) {
+      for (const item of parsed) {
+        if (
+          item &&
+          typeof item === 'object' &&
+          typeof (item as { event?: unknown }).event === 'string'
+        ) {
+          names.add((item as { event?: string }).event ?? '');
+        }
+      }
+      return normalizeList(Array.from(names));
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) return [];
+
+    const hooks = parsed.hooks as Record<string, unknown> | undefined;
+    if (Array.isArray(hooks)) {
+      for (const item of hooks) {
+        if (typeof item === 'string') {
+          names.add(item);
+          continue;
+        }
+        if (
+          item &&
+          typeof item === 'object' &&
+          typeof (item as { event?: unknown }).event === 'string'
+        ) {
+          names.add((item as { event: string }).event);
+        }
+      }
+      return normalizeList(Array.from(names));
+    }
+
+    if (hooks && typeof hooks === 'object') {
+      for (const event of Object.keys(hooks)) {
+        names.add(event);
+      }
+    }
+
+    return normalizeList(Array.from(names));
+  } catch {
+    return [];
+  }
+}
+
+async function hasFile(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pickProviderExposed(
+  provider: string,
+  workspace: string
+): Promise<{
+  agents: string[];
+  hooks: string[];
+  configFiles: string[];
+}> {
+  const providers =
+    provider === 'codex'
+      ? {
+          agentsDir: join(workspace, '.codex', 'agents'),
+          hooksPath: join(workspace, '.codex', 'hooks.json'),
+          configPath: join(workspace, '.codex', 'config.toml'),
+          ext: '.toml',
+        }
+      : provider === 'gemini'
+        ? {
+            agentsDir: join(workspace, '.gemini', 'agents'),
+            hooksPath: join(workspace, '.gemini', 'settings.json'),
+            configPath: join(workspace, '.gemini', 'settings.json'),
+            ext: '.md',
+          }
+        : null;
+
+  if (!providers) {
+    return Promise.resolve({ agents: [], hooks: [], configFiles: [] });
+  }
+
+  const ext = providers.ext;
+
+  return Promise.all([
+    listFilesByExt(providers.agentsDir, ext),
+    collectHookNames(providers.hooksPath),
+    (async () => {
+      const configFiles: string[] = [];
+      if (await hasFile(providers.configPath)) {
+        configFiles.push(basename(resolve(providers.configPath)));
+      }
+      return configFiles;
+    })(),
+  ]).then(([agents, hooks, configFiles]) => ({
+    agents,
+    hooks,
+    configFiles,
+  }));
+}
+
+async function getBranch(workspace: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync('git', ['branch', '--show-current'], {
+      cwd: workspace,
+      timeout: 2000,
+    });
+    const branch = stdout.trim();
+    if (!branch || branch === 'HEAD') return undefined;
+    return branch;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function collectRuntimeContext(input: RuntimeContextInput): Promise<RuntimeContext> {
+  const workspace = input.cwd ?? process.cwd();
+  const [sharedSkills, providerExposed, branch] = await Promise.all([
+    listSharedSkills(workspace),
+    pickProviderExposed(input.provider, workspace),
+    getBranch(workspace),
+  ]);
+
+  return {
+    active: {
+      provider: input.provider,
+      command: input.command,
+      sessionId: input.sessionId,
+      permissionProfile: input.permissionProfile,
+      cwd: workspace,
+      ...(input.promptTemplatePath !== undefined
+        ? { promptTemplatePath: input.promptTemplatePath }
+        : {}),
+      ...(branch ? { branch } : {}),
+      auth: input.auth,
+    },
+    exposed: {
+      sharedSkills,
+      providerAgents: providerExposed.agents,
+      providerHooks: providerExposed.hooks,
+      providerConfigFiles: providerExposed.configFiles,
+      provider: input.provider,
+    },
+  };
+}

--- a/packages/wrapper/src/runtime/context.ts
+++ b/packages/wrapper/src/runtime/context.ts
@@ -1,3 +1,4 @@
+import { providerRegistry } from '../providers/registry.js';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { readdir, readFile, stat } from 'node:fs/promises';
@@ -191,7 +192,7 @@ async function getBranch(workspace: string): Promise<string | undefined> {
 export async function collectRuntimeContext(input: RuntimeContextInput): Promise<RuntimeContext> {
   const workspace = input.cwd ?? process.cwd();
   const [sharedSkills, providerExposed, branch] = await Promise.all([
-    listSharedSkills(workspace),
+    providerRegistry.get(input.provider) ? listSharedSkills(workspace) : Promise.resolve([]),
     pickProviderExposed(input.provider, workspace),
     getBranch(workspace),
   ]);

--- a/packages/wrapper/src/runtime/context.ts
+++ b/packages/wrapper/src/runtime/context.ts
@@ -163,7 +163,7 @@ function pickProviderExposed(
     (async () => {
       const configFiles: string[] = [];
       if (await hasFile(providers.configPath)) {
-        configFiles.push(basename(resolve(providers.configPath)));
+        configFiles.push(basename(providers.configPath));
       }
       return configFiles;
     })(),

--- a/packages/wrapper/src/runtime/dashboard.ts
+++ b/packages/wrapper/src/runtime/dashboard.ts
@@ -1,0 +1,102 @@
+import type { RuntimeContext } from './types.js';
+import { formatAuthStatus } from './auth-display.js';
+
+interface RenderStyle {
+  header: (value: string) => string;
+  label: (value: string) => string;
+  value: (value: string) => string;
+  dim: (value: string) => string;
+}
+
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const CYAN = '\x1b[36m';
+const GREEN = '\x1b[32m';
+const RESET = '\x1b[0m';
+
+const DEFAULT_MAX_LIST = 16;
+
+function isColorEnabled(forceColor?: boolean): boolean {
+  if (forceColor === true) return true;
+  if (forceColor === false) return false;
+  if (!process.stderr.isTTY) return false;
+  if (process.env.NO_COLOR !== undefined) return false;
+  if (process.env.CI) return false;
+  return true;
+}
+
+function makeStyle(enableColor: boolean): RenderStyle {
+  if (!enableColor) {
+    return {
+      header: (value) => value,
+      label: (value) => value,
+      value: (value) => value,
+      dim: (value) => value,
+    };
+  }
+  return {
+    header: (value) => `${BOLD}${CYAN}${value}${RESET}`,
+    label: (value) => `${BOLD}${value}${RESET}`,
+    value: (value) => `${GREEN}${value}${RESET}`,
+    dim: (value) => `${DIM}${value}${RESET}`,
+  };
+}
+
+function formatValue(value: string | string[] | undefined): string {
+  if (!value) return '—';
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 'none';
+    return value.slice(0, DEFAULT_MAX_LIST).join(', ');
+  }
+  return value;
+}
+
+export interface RuntimeDashboardOptions {
+  color?: boolean;
+}
+
+export function renderRuntimeDashboard(
+  context: RuntimeContext,
+  options: RuntimeDashboardOptions = {}
+): string {
+  const color = isColorEnabled(options.color);
+  const style = makeStyle(color);
+
+  const authSummary = formatAuthStatus(context.active.auth);
+
+  const lines = [
+    style.header('🛰️  aco Runtime Session'),
+    '',
+    style.label('✨ Active'),
+    `  ${style.label('Provider')}: ${style.value(context.active.provider)}`,
+    `  ${style.label('Command')}: ${style.value(context.active.command)}`,
+    `  ${style.label('Session ID')}: ${style.value(context.active.sessionId)}`,
+    `  ${style.label('Permission')}: ${style.value(context.active.permissionProfile)}`,
+    `  ${style.label('Working Dir')}: ${style.value(context.active.cwd)}`,
+    `  ${style.label('Branch')}: ${style.value(formatValue(context.active.branch))}`,
+    `  ${style.label('Prompt Template')}: ${style.value(formatValue(context.active.promptTemplatePath))}`,
+    `  ${style.label('Auth')}: ${style.value(authSummary)}`,
+  ];
+  const sharedText = formatValue(context.exposed.sharedSkills);
+  const providerAgents = formatValue(context.exposed.providerAgents);
+  const providerHooks = formatValue(context.exposed.providerHooks);
+  const providerConfig = formatValue(context.exposed.providerConfigFiles);
+
+  lines.push(
+    '',
+    style.label('🧩 Exposed'),
+    `  ${style.label('Providers')}: ${style.value(context.exposed.provider)}`,
+    `  ${style.label('Agents')}: ${style.value(providerAgents)}`,
+    `  ${style.label('Hooks')}: ${style.value(providerHooks)}`,
+    `  ${style.label('Config')}: ${style.value(providerConfig)}`,
+    `  ${style.label('Shared Skills')}: ${style.value(sharedText)}`
+  );
+
+  if (color && !context.active.auth.ok) {
+    lines.push('', `${style.dim('⚠️  Provider is not authenticated; run: aco provider setup')}`);
+  } else if (color) {
+    lines.push('', `${style.dim('✅ Session context loaded')}`);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/wrapper/src/runtime/types.ts
+++ b/packages/wrapper/src/runtime/types.ts
@@ -1,0 +1,25 @@
+import type { AuthResult, PermissionProfile } from '../providers/interface.js';
+
+export interface RuntimeActiveContext {
+  provider: string;
+  command: string;
+  sessionId: string;
+  permissionProfile: PermissionProfile;
+  cwd: string;
+  branch?: string;
+  promptTemplatePath?: string;
+  auth: AuthResult;
+}
+
+export interface RuntimeExposedContext {
+  sharedSkills: string[];
+  providerAgents: string[];
+  providerHooks: string[];
+  providerConfigFiles: string[];
+  provider: string;
+}
+
+export interface RuntimeContext {
+  active: RuntimeActiveContext;
+  exposed: RuntimeExposedContext;
+}

--- a/packages/wrapper/src/session/store.ts
+++ b/packages/wrapper/src/session/store.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { Transform, type Writable } from 'node:stream';
+import type { RuntimeContext } from '../runtime/types.js';
 
 export type SessionStatus = 'running' | 'done' | 'failed' | 'cancelled';
 
@@ -24,6 +25,7 @@ export interface TaskRecord {
   exitCode?: number;
   /** Execution duration in milliseconds from sentinel metadata. */
   durationMs?: number;
+  runtimeContext?: RuntimeContext;
 }
 
 export class SessionStore {

--- a/packages/wrapper/src/util/read-version.ts
+++ b/packages/wrapper/src/util/read-version.ts
@@ -1,0 +1,21 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export async function readVersion(
+  binary: string,
+  timeout = DEFAULT_TIMEOUT_MS
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(binary, ['--version'], {
+      timeout,
+    });
+    const output = typeof stdout === 'string' ? stdout.trim() : '';
+    if (!output) return undefined;
+    return output.split('\n')[0].trim();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -3,27 +3,46 @@ import assert from 'node:assert/strict';
 import { GeminiProvider } from '../src/providers/gemini';
 import { CodexProvider } from '../src/providers/codex';
 import { ProviderRegistry } from '../src/providers/registry';
+import { getCachedProviderAuth } from '../src/providers/auth-cache';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+
+async function makeFakeBinary(binDir: string, name: string, output: string): Promise<string> {
+  const full = path.join(binDir, name);
+  await fs.writeFile(
+    full,
+    `#!/usr/bin/env sh\nprintf "%s\\n" "${output}"\n`,
+    { mode: 0o755 }
+  );
+  return full;
+}
 
 describe('GeminiProvider', () => {
   let tmpHome: string;
   let originalHome: string | undefined;
   let originalUserProfile: string | undefined;
+  let tmpBin: string;
+  let originalPath: string | undefined;
 
   before(async () => {
     originalHome = process.env.HOME;
     originalUserProfile = process.env.USERPROFILE;
     tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-test-home-'));
+    tmpBin = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-test-bin-gemini-'));
+    await makeFakeBinary(tmpBin, 'gemini', 'gemini-cli 3.0.0');
+    originalPath = process.env.PATH;
+    process.env.PATH = `${tmpBin}${path.delimiter}${originalPath ?? ''}`;
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
   });
 
   after(async () => {
+    process.env.PATH = originalPath;
     process.env.HOME = originalHome;
     process.env.USERPROFILE = originalUserProfile;
     await fs.rm(tmpHome, { recursive: true, force: true });
+    await fs.rm(tmpBin, { recursive: true, force: true });
   });
 
   it('isAvailable() returns true when gemini binary is in PATH', () => {
@@ -58,6 +77,7 @@ describe('GeminiProvider', () => {
     const result = await new TestGemini().checkAuth();
     assert.equal(result.ok, false);
     assert.ok(typeof result.hint === 'string');
+    assert.equal(result.method, 'missing');
   });
 
   it('checkAuth() fast-path: returns ok when GEMINI_API_KEY is set', async () => {
@@ -72,6 +92,10 @@ describe('GeminiProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'api-key');
+      assert.equal(result.binaryPath, `${tmpBin}/gemini`);
+      assert.equal(result.hint, undefined);
+      assert.equal(JSON.stringify(result).includes('test-key'), false);
     } finally {
       if (originalEnv === undefined) {
         delete process.env.GEMINI_API_KEY;
@@ -93,6 +117,9 @@ describe('GeminiProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'api-key');
+      assert.equal(result.binaryPath, `${tmpBin}/gemini`);
+      assert.equal(JSON.stringify(result).includes('test-key'), false);
     } finally {
       if (originalEnv === undefined) {
         delete process.env.GOOGLE_API_KEY;
@@ -116,9 +143,27 @@ describe('GeminiProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'oauth');
+      assert.equal(result.hint, undefined);
+      assert.equal(result.binaryPath, `${tmpBin}/gemini`);
     } finally {
       await fs.rm(credsPath, { force: true });
     }
+  });
+
+  it('checkAuth() fallback: reports cli-fallback via binary version output', async () => {
+    class MockGemini extends GeminiProvider {
+      override isAvailable() {
+        return true;
+      }
+    }
+    const provider = new MockGemini();
+    const result = await provider.checkAuth();
+    assert.strictEqual(result.ok, true);
+    assert.equal(result.method, 'cli-fallback');
+    assert.equal(result.version, 'gemini-cli 3.0.0');
+    assert.equal(result.binaryPath, `${tmpBin}/gemini`);
+    assert.equal(result.hint, undefined);
   });
 
   it('checkAuth() fast-path: returns error when oauth_creds.json is a directory', async () => {
@@ -172,19 +217,27 @@ describe('CodexProvider', () => {
   let tmpHome: string;
   let originalHome: string | undefined;
   let originalUserProfile: string | undefined;
+  let tmpBin: string;
+  let originalPath: string | undefined;
 
   before(async () => {
     originalHome = process.env.HOME;
     originalUserProfile = process.env.USERPROFILE;
     tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-test-home-codex-'));
+    tmpBin = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-test-bin-codex-'));
+    await makeFakeBinary(tmpBin, 'codex', 'codex-cli 1.0.0');
+    originalPath = process.env.PATH;
+    process.env.PATH = `${tmpBin}${path.delimiter}${originalPath ?? ''}`;
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
   });
 
   after(async () => {
+    process.env.PATH = originalPath;
     process.env.HOME = originalHome;
     process.env.USERPROFILE = originalUserProfile;
     await fs.rm(tmpHome, { recursive: true, force: true });
+    await fs.rm(tmpBin, { recursive: true, force: true });
   });
 
   it('isAvailable() returns true when codex binary is in PATH', () => {
@@ -219,6 +272,7 @@ describe('CodexProvider', () => {
     const result = await new TestCodex().checkAuth();
     assert.equal(result.ok, false);
     assert.ok(typeof result.hint === 'string');
+    assert.equal(result.method, 'missing');
   });
 
   it('checkAuth() fast-path: returns ok when OPENAI_API_KEY is set', async () => {
@@ -233,6 +287,8 @@ describe('CodexProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'api-key');
+      assert.equal(result.binaryPath, `${tmpBin}/codex`);
     } finally {
       if (originalEnv === undefined) {
         delete process.env.OPENAI_API_KEY;
@@ -258,6 +314,7 @@ describe('CodexProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'oauth');
     } finally {
       await fs.rm(authPath, { force: true });
     }
@@ -278,6 +335,7 @@ describe('CodexProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, false);
+      assert.equal(result.method, 'missing');
       assert.ok(result.hint?.includes('expired'));
     } finally {
       await fs.rm(authPath, { force: true });
@@ -301,6 +359,7 @@ describe('CodexProvider', () => {
     try {
       const result = await provider.checkAuth();
       assert.strictEqual(result.ok, false);
+      assert.equal(result.method, 'missing');
     } finally {
       process.env.PATH = originalPath;
       await fs.rm(authPath, { force: true });
@@ -395,5 +454,61 @@ describe('ProviderRegistry', () => {
     assert.ok(keys.includes('gemini'));
     assert.ok(keys.includes('codex'));
     assert.equal(keys.length, 2);
+  });
+});
+
+describe('Auth cache', () => {
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+  let tmpHome: string;
+
+  before(async () => {
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-test-auth-cache-'));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+  });
+
+  after(async () => {
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('reuses provider auth result within TTL', async () => {
+    let calls = 0;
+    class CachedGemini extends GeminiProvider {
+      override async checkAuth() {
+        calls++;
+        return { ok: true, method: 'api-key' };
+      }
+    }
+
+    const provider = new CachedGemini();
+    const first = await getCachedProviderAuth(provider, { ttlMs: 5000 });
+    const second = await getCachedProviderAuth(provider, { ttlMs: 5000 });
+
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(calls, 1);
+  });
+
+  it('refreshes provider auth result after TTL', async () => {
+    let calls = 0;
+    class CachedGemini extends GeminiProvider {
+      override async checkAuth() {
+        calls++;
+        return { ok: true, method: 'api-key' };
+      }
+    }
+
+    const provider = new CachedGemini();
+    const first = await getCachedProviderAuth(provider, { ttlMs: 0 });
+    const second = await getCachedProviderAuth(provider, { ttlMs: 0 });
+
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(calls, 2);
   });
 });

--- a/packages/wrapper/tests/runtime-context.test.ts
+++ b/packages/wrapper/tests/runtime-context.test.ts
@@ -1,0 +1,172 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectRuntimeContext } from '../src/runtime/context.js';
+import type { AuthResult } from '../src/providers/interface.js';
+
+function makeAuth(method: AuthResult['method'] = 'api-key'): AuthResult {
+  return {
+    ok: true,
+    method,
+    version: 'test-cli 4.2.0',
+    binaryPath: '/tmp/aco-test/provider',
+  };
+}
+
+async function withWorkspace(run: (workspace: string) => Promise<void>): Promise<void> {
+  const workspace = await mkdtemp(join(tmpdir(), 'aco-runtime-context-'));
+  try {
+    await run(workspace);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+async function ensureCodexArtifacts(workspace: string): Promise<void[]> {
+  await mkdir(join(workspace, '.codex', 'agents'), { recursive: true });
+  return Promise.all([
+    writeFile(join(workspace, '.codex', 'agents', 'reviewer.toml'), 'id = "reviewer"\n'),
+    writeFile(join(workspace, '.codex', 'agents', 'planner.toml'), 'id = "planner"\n'),
+    writeFile(
+      join(workspace, '.codex', 'hooks.json'),
+      JSON.stringify({ hooks: { PostToolUse: [], PreToolUse: [] } }),
+      'utf8'
+    ),
+    writeFile(join(workspace, '.codex', 'config.toml'), '[config]\nlog = true\n'),
+  ]);
+}
+
+async function ensureGeminiArtifacts(workspace: string): Promise<void[]> {
+  await mkdir(join(workspace, '.gemini', 'agents'), { recursive: true });
+  return Promise.all([
+    writeFile(join(workspace, '.gemini', 'agents', 'reviewer.md'), '# reviewer\n'),
+    writeFile(join(workspace, '.gemini', 'agents', 'planner.md'), '# planner\n'),
+    writeFile(
+      join(workspace, '.gemini', 'settings.json'),
+      JSON.stringify({ hooks: [{ event: 'PostToolUse' }, { event: 'UserPromptSubmit' }] }),
+      'utf8'
+    ),
+  ]);
+}
+
+async function ensureSharedSkills(workspace: string): Promise<void[]> {
+  return Promise.all([
+    mkdir(join(workspace, '.agents', 'skills', 'review-skill'), { recursive: true })
+      .then(() =>
+        writeFile(join(workspace, '.agents', 'skills', 'review-skill', 'SKILL.md'), '# review skill\n')
+      ),
+    mkdir(join(workspace, '.agents', 'skills', 'missing-marker'), { recursive: true })
+      .then(() =>
+        writeFile(join(workspace, '.agents', 'skills', 'missing-marker', 'README.md'), '# skipped\n')
+      ),
+    mkdir(join(workspace, '.agents', 'skills', 'planner-skill'), { recursive: true })
+      .then(() =>
+        writeFile(join(workspace, '.agents', 'skills', 'planner-skill', 'SKILL.md'), '# planner skill\n')
+      ),
+  ]);
+}
+
+describe('runtime context collection', () => {
+  it('collects codex active and exposed metadata', async () => {
+    await withWorkspace(async (workspace) => {
+      await Promise.all([ensureCodexArtifacts(workspace), ensureSharedSkills(workspace)]);
+
+      const context = await collectRuntimeContext({
+        provider: 'codex',
+        command: 'review',
+        sessionId: 'session-codex-1',
+        permissionProfile: 'default',
+        promptTemplatePath: join(workspace, '.claude', 'aco', 'prompts', 'codex', 'review.md'),
+        auth: makeAuth('oauth'),
+        cwd: workspace,
+      });
+
+      assert.equal(context.active.provider, 'codex');
+      assert.equal(context.active.command, 'review');
+      assert.equal(context.active.permissionProfile, 'default');
+      assert.equal(context.exposed.provider, 'codex');
+      assert.equal(context.exposed.providerAgents.join(','), 'planner,reviewer');
+      assert.equal(context.exposed.providerHooks.join(','), 'PostToolUse,PreToolUse');
+      assert.equal(context.exposed.providerConfigFiles.join(','), 'config.toml');
+      assert.deepEqual(context.exposed.sharedSkills, ['planner-skill', 'review-skill']);
+    });
+  });
+
+  it('collects gemini exposed metadata from generated target files', async () => {
+    await withWorkspace(async (workspace) => {
+      await Promise.all([ensureGeminiArtifacts(workspace), ensureSharedSkills(workspace)]);
+
+      const context = await collectRuntimeContext({
+        provider: 'gemini',
+        command: 'summarize',
+        sessionId: 'session-gemini-1',
+        permissionProfile: 'restricted',
+        auth: makeAuth('cli-fallback'),
+        cwd: workspace,
+      });
+
+      assert.equal(context.active.provider, 'gemini');
+      assert.equal(context.active.permissionProfile, 'restricted');
+      assert.deepEqual(context.exposed.providerAgents, ['planner', 'reviewer']);
+      assert.deepEqual(context.exposed.providerHooks, ['PostToolUse', 'UserPromptSubmit']);
+      assert.equal(context.exposed.providerConfigFiles.join(','), 'settings.json');
+    });
+  });
+
+  it('captures branch when workspace is a git repo', async () => {
+    await withWorkspace(async (workspace) => {
+      execFileSync('git', ['init', '-b', 'feature-test'], { cwd: workspace });
+
+      const context = await collectRuntimeContext({
+        provider: 'gemini',
+        command: 'review',
+        sessionId: 'session-branch-1',
+        permissionProfile: 'default',
+        auth: makeAuth('api-key'),
+        cwd: workspace,
+      });
+
+      assert.equal(context.active.branch, 'feature-test');
+    });
+  });
+
+  it('returns empty exposed lists when files are missing', async () => {
+    await withWorkspace(async (workspace) => {
+      const context = await collectRuntimeContext({
+        provider: 'codex',
+        command: 'review',
+        sessionId: 'session-empty-1',
+        permissionProfile: 'restricted',
+        auth: makeAuth(),
+        cwd: workspace,
+      });
+
+      assert.equal(context.exposed.providerAgents.length, 0);
+      assert.equal(context.exposed.providerHooks.length, 0);
+      assert.equal(context.exposed.providerConfigFiles.length, 0);
+      assert.equal(context.exposed.sharedSkills.length, 0);
+    });
+  });
+
+  it('returns empty exposed lists for unknown providers', async () => {
+    await withWorkspace(async (workspace) => {
+      const context = await collectRuntimeContext({
+        provider: 'unknown-provider',
+        command: 'review',
+        sessionId: 'session-unknown-1',
+        permissionProfile: 'default',
+        auth: makeAuth(),
+        cwd: workspace,
+      });
+
+      assert.equal(context.exposed.provider, 'unknown-provider');
+      assert.equal(context.exposed.providerAgents.length, 0);
+      assert.equal(context.exposed.providerHooks.length, 0);
+      assert.equal(context.exposed.providerConfigFiles.length, 0);
+      assert.equal(context.exposed.sharedSkills.length, 0);
+    });
+  });
+});

--- a/packages/wrapper/tests/runtime-dashboard.test.ts
+++ b/packages/wrapper/tests/runtime-dashboard.test.ts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { renderRuntimeDashboard } from '../src/runtime/dashboard.js';
+import type { RuntimeContext } from '../src/runtime/types.js';
+
+function buildContext(overrides: Partial<RuntimeContext> = {}): RuntimeContext {
+  return {
+    active: {
+      provider: 'gemini',
+      command: 'review',
+      sessionId: 'session-1234',
+      permissionProfile: 'default',
+      cwd: '/tmp/project',
+      promptTemplatePath: '/tmp/project/.claude/aco/prompts/gemini/review.md',
+      auth: {
+        ok: true,
+        method: 'oauth',
+      },
+      ...overrides.active,
+    },
+    exposed: {
+      sharedSkills: ['review-skill', 'planner-skill'],
+      providerAgents: ['planner', 'reviewer'],
+      providerHooks: ['PreToolUse', 'PostToolUse'],
+      providerConfigFiles: ['settings.json'],
+      provider: 'gemini',
+      ...overrides.exposed,
+    },
+  };
+}
+
+describe('runtime dashboard rendering', () => {
+  it('renders colorful output in TTY mode when color is forced', () => {
+    const output = renderRuntimeDashboard(buildContext(), { color: true });
+
+    assert.ok(output.includes('\x1b['));
+    assert.ok(output.includes('🛰️  aco Runtime Session'));
+    assert.ok(output.includes('✨ Active'));
+    assert.ok(output.includes('🧩 Exposed'));
+    assert.ok(/Auth/.test(output));
+    assert.ok(output.includes('oauth'));
+    assert.ok(output.includes('Session ID'));
+    assert.ok(output.includes('Providers'));
+  });
+
+  it('renders plain text output when color is disabled', () => {
+    const output = renderRuntimeDashboard(buildContext(), { color: false });
+    assert.equal(output.includes('\x1b['), false);
+    assert.ok(output.includes('Runtime Session'));
+    assert.ok(output.includes('Active'));
+    assert.ok(output.includes('Exposed'));
+  });
+
+  it('falls back to plain text for CI environment by default', () => {
+    const originalCI = process.env.CI;
+    const originalNoColor = process.env.NO_COLOR;
+    process.env.CI = '1';
+    delete process.env.NO_COLOR;
+
+    try {
+      const output = renderRuntimeDashboard(buildContext());
+      assert.equal(output.includes('\x1b['), false);
+    } finally {
+      if (originalCI === undefined) {
+        delete process.env.CI;
+      } else {
+        process.env.CI = originalCI;
+      }
+
+      if (originalNoColor === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = originalNoColor;
+      }
+    }
+  });
+});

--- a/packages/wrapper/tests/session.test.ts
+++ b/packages/wrapper/tests/session.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { SessionStore } from '../src/session/store';
+import type { RuntimeContext } from '../src/runtime/types.js';
 
 async function makeStore() {
   const dir = await mkdtemp(join(tmpdir(), 'aco-test-'));
@@ -65,6 +66,56 @@ describe('SessionStore', () => {
     const updated = await store.read(record.id);
     assert.equal(updated.pid, 5678);
     assert.equal(updated.status, 'running');
+  });
+
+  it('update() stores runtimeContext metadata', async () => {
+    const { store } = await makeStore();
+    const record = await store.create('gemini', 'review');
+
+    const runtimeContext: RuntimeContext = {
+      active: {
+        provider: 'gemini',
+        command: 'review',
+        sessionId: record.id,
+        permissionProfile: 'default',
+        cwd: '/tmp/project',
+        branch: 'main',
+        auth: { ok: true, method: 'api-key' },
+      },
+      exposed: {
+        sharedSkills: ['planner', 'review'],
+        providerAgents: ['planner'],
+        providerHooks: ['PostToolUse'],
+        providerConfigFiles: ['settings.json'],
+        provider: 'gemini',
+      },
+    };
+
+    await store.update(record.id, { runtimeContext });
+    const read = await store.read(record.id);
+
+    assert.deepEqual(read.runtimeContext, runtimeContext);
+  });
+
+  it('read() is backward compatible when runtimeContext is missing', async () => {
+    const { store, dir } = await makeStore();
+    const id = 'legacy-session-id';
+
+    const legacyRecord = {
+      id,
+      provider: 'codex',
+      command: 'review',
+      status: 'done',
+      startedAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+    };
+
+    const sessionDir = join(dir, id);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'task.json'), JSON.stringify(legacyRecord, null, 2));
+
+    const read = await store.read(id);
+    assert.equal(read.runtimeContext, undefined);
+    assert.equal(read.id, id);
   });
 
   it('latestId() returns the most recent session', async () => {


### PR DESCRIPTION
Closes #75

## What
Codex/Gemini 런타임 세션 시작 시 인증 상태와 현재 세션 정보를 한 화면에 보여주고, 같은 메타데이터를 세션 기록에 저장해 `aco status`에서도 런타임 요약을 확인할 수 있게 했습니다.

## Why
사용자는 `aco run` 실행 즉시 어떤 provider가 활성화됐는지, 어떤 권한/프롬프트/워크스페이스 맥락에서 실행되는지, 그리고 어떤 인증 경로로 준비되었는지를 바로 확인해야 합니다. 또한 대시보드가 stdout을 오염하지 않아 기존 provider 출력 파이프라인과 호환되어야 합니다.

## Changes
- provider auth 결과 타입을 `method`, `version`, `binaryPath`까지 확장하고, 시크릿을 노출하지 않는 범위에서 `api-key`, `oauth`, `cli-fallback`, `missing` 상태를 노출하도록 정리했습니다.
- Gemini/Codex auth 판별을 fast-path 중심으로 정리하고, `--version` fallback 결과를 저장해 런타임 노출에 반영했습니다.
- auth 캐시 `~/.aco/provider-auth-cache.json`을 추가해 provider 인증 재검사 비용을 줄였습니다.
- provider별 runtime context 수집(`runtime/context.ts`)과 대시보드 렌더링(`runtime/dashboard.ts`, `runtime/auth-display.ts`)을 추가해 `aco run` 시작 시 stderr에 알록달록/이모지 강화 출력(TTY) 또는 평문 출력(CI/NO_COLOR)을 보여줍니다.
- 세션 레코드(`task.json`)에 `runtimeContext`를 저장하고 `aco status`에서 요약 정보를 출력하도록 확장했습니다.
- `pack status`에서 인증 표시를 `formatAuthStatus` 기반으로 정렬해 인증 메타를 일관되게 보여줍니다.
- `openspec/changes/expose-runtime-context-dashboard/*`와 `README.md`, `packages/wrapper/README.md`, `docs/guides/runbook.md`에 요구사항/설명/출력 예시를 보강했습니다.
- runtime 노출 테스트와 auth cache, runtime context/session 메타 저장 테스트를 추가했습니다.

## Checklist
- [x] Unknown provider에 대해 예외 없이 빈 exposed 목록을 반환하고 에러를 발생시키지 않습니다.
- [x] TTY/CI/`NO_COLOR` 환경에서 대시보드 스타일 동작이 분기됩니다.
- [x] `aco run`에서는 대시보드가 stderr로 출력되어 provider stdout 계약을 유지합니다.
- [x] 세션 기록은 기존 필드를 깨지지 않도록 backward-compatible 합니다.
- [x] PR는 type:task, area:wrapper 라벨 정책만 동기화합니다.
