### PR TITLE
chore(wrapper): extract readVersion to common util

### DIFF
--- a/packages/wrapper/src/providers/codex.ts
+++ b/packages/wrapper/src/providers/codex.ts
@@ -1,15 +1,10 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { which } from '../util/which.js';
 import { spawnStream } from '../util/spawn-stream.js';
 import type { AuthResult, InvokeOptions, IProvider, PermissionProfile } from './interface.js';
-
-const execFileAsync = promisify(execFile);
-
-const AUTH_CHECK_TIMEOUT_MS = 5_000;
+import { readVersion } from '../util/read-version.js';
 
 export class CodexProvider implements IProvider {
   readonly key = 'codex';
@@ -105,18 +100,5 @@ export class CodexProvider implements IProvider {
     const combined = content ? `${prompt}\n\n${content}` : prompt;
     const args = [...this.buildArgs(command, options), combined];
     yield* spawnStream(binary, args, { processName: 'codex', stdin: 'pipe' }, options);
-  }
-}
-
-async function readVersion(binary: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync(binary, ['--version'], {
-      timeout: AUTH_CHECK_TIMEOUT_MS,
-    });
-    const output = typeof stdout === 'string' ? stdout.trim() : '';
-    if (!output) return undefined;
-    return output.split('\n')[0].trim();
-  } catch {
-    return undefined;
   }
 }

--- a/packages/wrapper/src/providers/gemini.ts
+++ b/packages/wrapper/src/providers/gemini.ts
@@ -1,15 +1,10 @@
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
 import { stat, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { which } from '../util/which.js';
 import { spawnStream } from '../util/spawn-stream.js';
 import type { AuthResult, InvokeOptions, IProvider, PermissionProfile } from './interface.js';
-
-const execFileAsync = promisify(execFile);
-
-const AUTH_CHECK_TIMEOUT_MS = 5_000;
+import { readVersion } from '../util/read-version.js';
 
 export class GeminiProvider implements IProvider {
   readonly key = 'gemini';
@@ -92,18 +87,5 @@ export class GeminiProvider implements IProvider {
 
     const args = [...this.buildArgs(command, options), `${prompt}\n\n${content}`];
     yield* spawnStream(binary, args, { processName: 'gemini', stdin: 'pipe' }, options);
-  }
-}
-
-async function readVersion(binary: string): Promise<string | undefined> {
-  try {
-    const { stdout } = await execFileAsync(binary, ['--version'], {
-      timeout: AUTH_CHECK_TIMEOUT_MS,
-    });
-    const output = typeof stdout === 'string' ? stdout.trim() : '';
-    if (!output) return undefined;
-    return output.split('\n')[0].trim();
-  } catch {
-    return undefined;
   }
 }

--- a/packages/wrapper/src/util/read-version.ts
+++ b/packages/wrapper/src/util/read-version.ts
@@ -1,0 +1,18 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const AUTH_CHECK_TIMEOUT_MS = 5_000;
+
+export async function readVersion(binary: string): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync(binary, ['--version'], {
+      timeout: AUTH_CHECK_TIMEOUT_MS,
+    });
+    const output = typeof stdout === 'string' ? stdout.trim() : '';
+    if (!output) return undefined;
+    return output.split('\n')[0].trim();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/wrapper/src/util/read-version.ts
+++ b/packages/wrapper/src/util/read-version.ts
@@ -2,12 +2,15 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const AUTH_CHECK_TIMEOUT_MS = 5_000;
+const DEFAULT_TIMEOUT_MS = 5_000;
 
-export async function readVersion(binary: string): Promise<string | undefined> {
+export async function readVersion(
+  binary: string,
+  timeout = DEFAULT_TIMEOUT_MS
+): Promise<string | undefined> {
   try {
     const { stdout } = await execFileAsync(binary, ['--version'], {
-      timeout: AUTH_CHECK_TIMEOUT_MS,
+      timeout,
     });
     const output = typeof stdout === 'string' ? stdout.trim() : '';
     if (!output) return undefined;


### PR DESCRIPTION
Closes #79

### What
`CodexProvider`와 `GeminiProvider`에 중복으로 정의되어 있던 `readVersion` 함수를 공통 유틸리티 파일로 추출했습니다.

### Why
PR #77의 리뷰 피드백 후속 조치입니다. 중복 코드를 제거하여 유지보수성을 높이기 위함입니다.

### Changes
* `packages/wrapper/src/util/read-version.ts` 생성 및 `readVersion` 함수 이동
* `CodexProvider`에서 기존 함수 제거 및 유틸리티 임포트 적용
* `GeminiProvider`에서 기존 함수 제거 및 유틸리티 임포트 적용

### Checklist
* [x] 빌드 및 타입 체크(`npm run typecheck`) 성공을 확인했습니다.
* [x] 유닛 테스트(`npm test`) 성공을 확인했습니다.
