### PR TITLE
fix(review): resolve pending review followups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build --workspace=packages/wrapper
+      - run: npm run test:scripts
       - run: npm test --workspace=packages/wrapper
 
   go-build:

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ temp/
 .omc/
 .omx/
 *.cao_backup
-reference/
+/reference/
 .claude/worktrees/
 .codex/worktrees/
 .gemini/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ temp/
 .omc/
 .omx/
 *.cao_backup
+reference/
 .claude/worktrees/
 .codex/worktrees/
 .gemini/worktrees/

--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ node packages/wrapper/dist/cli.js provider setup codex
 아닙니다.
 
 Codex OAuth 토큰에 `expires_at` 값이 있고 만료된 경우에는 `codex login`을 다시 실행해야 합니다.
-Headless/CI 환경에서는 Gemini에 `GEMINI_API_KEY` 또는 `GOOGLE_API_KEY`, Codex에
-`OPENAI_API_KEY`를 설정할 수 있습니다.
+Headless/CI 환경에서는 Gemini delegate/runtime 경로에 `GEMINI_API_KEY`, Codex에
+`OPENAI_API_KEY`를 설정합니다. `GOOGLE_API_KEY`는 Node wrapper의 local readiness
+heuristic에서만 Gemini credential로 인식되며, Go delegate runtime allowlist에는 전달되지
+않습니다.
 
 ## CLI 개요
 
@@ -353,7 +355,7 @@ npx @pureliture/ai-cli-orch-wrapper provider setup gemini
 npx @pureliture/ai-cli-orch-wrapper provider setup codex
 ```
 
-Headless/CI 환경에서는 Gemini에 `GEMINI_API_KEY` 또는 `GOOGLE_API_KEY`, Codex에 `OPENAI_API_KEY`를 설정할 수 있습니다. Codex OAuth를 쓰는 로컬 환경에서 토큰이 만료되면 `codex login`을 다시 실행합니다.
+Headless/CI 환경에서는 Gemini delegate/runtime 경로에 `GEMINI_API_KEY`, Codex에 `OPENAI_API_KEY`를 설정합니다. `GOOGLE_API_KEY`는 Node wrapper의 local readiness heuristic에서만 Gemini credential로 인식됩니다. Codex OAuth를 쓰는 로컬 환경에서 토큰이 만료되면 `codex login`을 다시 실행합니다.
 
 ### slash command가 보이지 않는 경우
 

--- a/docs/contract/go-node-boundary.md
+++ b/docs/contract/go-node-boundary.md
@@ -78,6 +78,12 @@ Node.js 래퍼가 전적으로 담당하는 레이어:
 | Gemini   | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `~/.gemini/oauth_creds.json` | `gemini --version` |
 | Codex    | `OPENAI_API_KEY`, `~/.codex/auth.json`                           | `codex --version`  |
 
+Gemini의 `GOOGLE_API_KEY`는 Node.js 래퍼의 local readiness fast-path에서만 허용되는
+credential source다. 이 검사는 호출 프로세스의 `process.env`와 로컬 credential 파일을 읽어
+setup UX를 빠르게 만드는 휴리스틱이며, Go delegate runtime이 provider child process에 전달하는
+환경 변수 계약이 아니다. Go delegate runtime의 headless Gemini key는 allowlist에 포함된
+`GEMINI_API_KEY`이고, `GOOGLE_API_KEY`는 의도적으로 전달하지 않는다.
+
 Codex의 `~/.codex/auth.json`에 `expires_at` 숫자 값이 있으면 현재 시각과 비교해 만료 여부를
 판정한다. 그 외 provider별 remote 인증 성공 여부는 이 fast-path 검사만으로 보장하지 않는다.
 
@@ -155,7 +161,7 @@ type Provider interface {
 | 설치 힌트      | `InstallHint()`           | `installHint` field        |
 | 인증 체크      | `CheckAuth(ctx)`          | `checkAuth()`              |
 | 인자 구성      | `BuildArgs(...) []string` | `buildArgs(...) string[]`  |
-| 바이너리명     | `Binary()`                | 각 Provider 내 lookup 호출 |
+| 실행 파일 해석 | `Binary()`                | 각 provider method에서 `which()`로 해석한 경로를 `spawnStream()`/`spawn()`에 전달 (`IProvider` member 아님) |
 | 가용성         | `IsAvailable()`           | `isAvailable()`            |
 | 인증 실패 분류 | `IsAuthFailure()`         | 없음 (Go만)                |
 

--- a/openspec/changes/resolve-review-followups-85/.openspec.yaml
+++ b/openspec/changes/resolve-review-followups-85/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/resolve-review-followups-85/design.md
+++ b/openspec/changes/resolve-review-followups-85/design.md
@@ -1,0 +1,110 @@
+## Context
+
+Issue #85 is a post-merge review-follow-up bundle. The source PRs are already merged, so the implementation must target current `origin/main`, not the historical PR branches.
+
+The unresolved review threads fall into three states:
+
+- Still actionable code or documentation gaps: Project setup/export validation, Go/Node boundary wording, provider version probing, duplicate cleanup output filtering, and directory hashing.
+- Already fixed on current main: `loadSyncConfig()` already handles empty/comment-only YAML through `js-yaml`, and duplicate cleanup warnings already carry structured `cleanupTargets`.
+- Operational cleanup: the original review threads need concise replies and resolved-state updates after the branch demonstrates either a fix or an already-fixed confirmation.
+
+Local repository state also has `reference/` as a separate cloned reference repository. It should remain available locally, but it should not appear as work in this repository.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Land one current-main follow-up branch for issue #85.
+- Prevent Project setup scripts from emitting blank or incomplete canonical field IDs as successful setup output.
+- Make `docs/contract/go-node-boundary.md` accurately describe the intentional Go runtime versus Node wrapper environment/auth differences.
+- Treat successful provider version probes as readiness evidence even when version text is absent from stdout or appears on stderr.
+- Keep sync duplicate cleanup idempotent within a single run after cleaning a target path.
+- Make skill directory hashing detect relative path changes and binary byte changes.
+- Add targeted regression coverage for executable behavior changes.
+- Add `reference/` to `.gitignore`.
+- Reply to and resolve all 11 original review threads with either the landed fix or already-fixed confirmation.
+
+**Non-Goals:**
+
+- Reopen or rewrite merged PRs #70, #76, #77, #83, or #84.
+- Add new GitHub Project fields, labels, or workflow concepts.
+- Change provider auth semantics beyond the local `--version` fallback readiness probe.
+- Replace the sync manifest format or introduce a new cleanup command.
+- Delete local `reference/` data.
+
+## Decisions
+
+### 1. Treat #85 as a current-main repair, not stacked PR cleanup
+
+Implement against the `feat/85-resolve-pending-review-threads-across-prs-70-76-77-83-and-84` branch created from `origin/main`. Review threads tied to behavior that is already fixed on current main should receive a reply explaining the current-main evidence and then be resolved; they should not force redundant code churn.
+
+### 2. Fail fast before printing or writing incomplete Project IDs
+
+Both setup scripts should validate the complete canonical Project field set before printing shell exports or mutating `docs/reference/project-board.md`.
+
+The required set is:
+
+- Project number and Project node ID
+- Status field ID and `Backlog`, `Ready`, `In Progress`, `In Review`, `Done` option IDs
+- Priority field ID and `P0`, `P1`, `P2` option IDs
+
+If any required value is missing, the scripts should exit non-zero with a concrete diagnostic instead of producing copy-pasteable empty exports.
+
+### 3. Document environment differences as an intentional boundary
+
+The Go runtime passes only allowlisted environment variables to provider processes. The Node wrapper currently invokes provider CLIs through provider implementations and does not apply the Go allowlist to that path.
+
+`GOOGLE_API_KEY` is therefore valid as a Node Gemini auth source but intentionally not listed as a Go delegate runtime allowlist entry. Documentation should state this plainly so users do not interpret it as a typo.
+
+### 4. Preserve version text when available but separate readiness from text presence
+
+`readVersion()` currently returns `undefined` when stdout is empty, even if the process exits successfully. The follow-up should distinguish two facts:
+
+- whether the probe process exited successfully;
+- what human-readable version text, if any, was discovered.
+
+The smallest compatible implementation is to let `readVersion()` consider stderr as a fallback source and, if the process exits 0 with no usable text, return a stable non-empty probe-success marker or otherwise expose probe success to callers without making `checkAuth()` fail.
+
+### 5. Remove cleaned duplicate paths from the same run's output plan
+
+During `--clean-duplicates`, any target path removed from disk and manifest state must also be excluded from `plan.outputs` before the write loop. Otherwise a planned `created` or `updated` directory output can recreate the duplicate during the same sync run.
+
+This filtering should be path-based and should not affect unrelated outputs.
+
+### 6. Hash directory layout and bytes, not decoded text only
+
+Skill directory hash inputs should include each file's relative path plus raw bytes. This makes the hash change when:
+
+- a file is renamed while content stays identical;
+- two files contain different non-UTF-8 byte sequences that would otherwise be lossy when decoded as UTF-8.
+
+The implementation can hash each file as `relative-path + NUL + bytes` and then hash a sorted list of per-file digests, preserving deterministic output without loading the entire directory into one concatenated string.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Some review threads are already fixed, causing redundant edits | Treat current-main evidence as sufficient and resolve those threads with a reply |
+| Setup scripts become too strict for partially configured Projects | Fail-fast diagnostics tell users exactly which canonical field or option is missing |
+| Empty version text loses useful display information | Keep actual stdout/stderr version text when available and use probe-success only as a fallback |
+| Directory hashing changes can mark existing synced skill targets stale once | Accept one refresh because the new hash is more accurate and safer |
+| Cleanup output filtering could remove legitimate planned outputs with the same path | Filter only paths that were actually cleaned in the current duplicate cleanup step |
+| Resolving review threads is a live GitHub mutation | Perform it only after tests pass and replies explain the landed change or already-fixed state |
+
+## Migration Plan
+
+1. Update `.gitignore` with `reference/`.
+2. Implement and test script validation for Project setup/export IDs.
+3. Update boundary documentation and verify it matches Go and Node implementation facts.
+4. Implement provider version probe fallback handling with targeted provider or utility tests.
+5. Implement sync duplicate cleanup output filtering and directory hash improvements with targeted sync tests.
+6. Run focused tests first, then `git diff --check`; run broader wrapper checks if the touched areas warrant it.
+7. Reply to and resolve the 11 original review threads.
+8. Create the PR for #85 and move the issue/PR Project state through the normal workflow.
+
+Rollback is file-based: revert the branch changes and leave the existing merged PR behavior in place. No data migration or dependency rollback is expected.
+
+## Open Questions
+
+- Should a successful version probe with no output display a generic version such as `unknown`, or should provider status omit the version while still marking `cli-fallback` as ready?
+- Should `scripts/setup-github-project.sh` attempt to repair an existing Priority field with missing options, or only fail with a clear diagnostic? The safer first step is fail-fast diagnostics.

--- a/openspec/changes/resolve-review-followups-85/proposal.md
+++ b/openspec/changes/resolve-review-followups-85/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Issue #85 consolidates unresolved review threads left on merged PRs #70, #76, #77, #83, and #84. The comments point at a small set of still-actionable hardening gaps across Project setup scripts, Go/Node boundary documentation, provider readiness probes, sync cleanup/hash behavior, and local reference workspace hygiene.
+
+This change creates one bounded follow-up so the fixes can land on current `origin/main`, be tested together, and then be replied to and resolved on the original review threads.
+
+## What Changes
+
+- Harden GitHub Project setup/export scripts so missing canonical Status/Priority fields or option IDs cannot be reported as successful setup output.
+- Clarify `docs/contract/go-node-boundary.md` where Go runtime environment allowlisting intentionally differs from Node wrapper auth sources, especially `GOOGLE_API_KEY`, and describe Node provider binary handling in terms of the actual implementation.
+- Adjust provider version probing so a successful `--version` process with empty stdout or stderr-only output does not make an otherwise available provider look unauthenticated or missing.
+- Complete sync hardening follow-ups from PR #83 and #84:
+  - distinguish already-fixed `sync.yaml` handling and cleanup target structure from remaining work;
+  - prevent `--clean-duplicates` from recreating cleaned outputs in the same run;
+  - make directory hashes sensitive to relative file paths and raw bytes, not only UTF-8 text content.
+- Add regression tests for every behavior change that can be exercised locally.
+- Reply to and resolve all 11 original unresolved review threads once the relevant fix or "already fixed on main" confirmation is complete.
+- Ignore local `reference/` checkouts so external reference clones do not appear as repository work.
+
+## Capabilities
+
+### New Capabilities
+
+- `review-followup-hardening`: Batch hardening contract for #85 review follow-up work across PM scripts, boundary docs, provider readiness probing, sync duplicate cleanup/hash behavior, review thread closure, and local reference ignore rules.
+
+### Modified Capabilities
+
+- None. This follow-up tightens implementation and documentation around already-planned surfaces rather than introducing a new public CLI command or changing a released CLI contract.
+
+## Impact
+
+- Affected scripts: `scripts/setup-github-project.sh`, `scripts/setup-project-ids.sh`.
+- Affected wrapper code: `packages/wrapper/src/util/read-version.ts`, `packages/wrapper/src/providers/*`, `packages/wrapper/src/sync/sync-engine.ts`, `packages/wrapper/src/sync/skill-transform.ts`, and related sync/provider tests.
+- Affected docs: `docs/contract/go-node-boundary.md`, `README.md`.
+- Affected validation wiring: `package.json`, `.github/workflows/ci.yml`, `test/scripts/project-id-validation.test.sh`.
+- Affected repository hygiene: `.gitignore` gains `reference/`.
+- External side effects after implementation: the original review threads on PR #70, #76, #77, #83, and #84 receive replies and resolved-state updates.
+- No dependency or lockfile change is expected.

--- a/openspec/changes/resolve-review-followups-85/specs/review-followup-hardening/spec.md
+++ b/openspec/changes/resolve-review-followups-85/specs/review-followup-hardening/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Project setup scripts reject incomplete canonical IDs
+The system SHALL prevent GitHub Project setup and ID export scripts from reporting success when any canonical Project field or option ID required by the GitHub Kanban workflow is missing.
+
+#### Scenario: Existing Priority field is missing canonical options
+- **WHEN** `scripts/setup-github-project.sh` finds an existing `Priority` field
+- **AND** one or more of `P0`, `P1`, or `P2` option IDs cannot be resolved
+- **THEN** the script SHALL exit non-zero before printing shell export commands
+- **AND** the script SHALL NOT update `docs/reference/project-board.md` with blank Priority option IDs
+
+#### Scenario: Project ID export is incomplete
+- **WHEN** `scripts/setup-project-ids.sh` resolves the selected Project
+- **AND** any required Status or Priority field or option ID is empty
+- **THEN** the script SHALL exit non-zero before printing the shell export block
+- **AND** the error output SHALL identify that canonical Status/Priority fields or options are incomplete
+
+### Requirement: Go and Node provider boundary documentation is explicit
+The system SHALL document intentional differences between Go delegate runtime environment allowlisting and Node wrapper provider authentication or process execution behavior.
+
+#### Scenario: GOOGLE_API_KEY appears in Node auth sources but not Go allowlist
+- **WHEN** `docs/contract/go-node-boundary.md` lists Node Gemini auth sources
+- **THEN** the document SHALL explain that `GOOGLE_API_KEY` is accepted by the Node wrapper auth fast path
+- **AND** the document SHALL explain that the Go delegate runtime allowlist intentionally does not pass `GOOGLE_API_KEY`
+- **AND** the document SHALL identify `GEMINI_API_KEY` as the Go delegate runtime headless Gemini key
+
+#### Scenario: Node provider binary handling is described
+- **WHEN** the document compares Go and Node provider interfaces
+- **THEN** the Node.js binary handling row SHALL describe the actual provider implementation behavior
+- **AND** the wording SHALL NOT imply an `IProvider` binary lookup member that does not exist
+
+### Requirement: Provider version probes distinguish process success from version text
+The system SHALL treat a successful provider `--version` process as readiness evidence even if the version text is absent from stdout.
+
+#### Scenario: Version output appears on stderr
+- **WHEN** a provider CLI exits 0 for `--version`
+- **AND** stdout is empty
+- **AND** stderr contains non-empty version text
+- **THEN** provider readiness fallback SHALL succeed
+- **AND** the reported version text SHALL use the first non-empty stderr line
+
+#### Scenario: Version probe exits successfully without text
+- **WHEN** a provider CLI exits 0 for `--version`
+- **AND** stdout and stderr contain no usable version text
+- **THEN** provider readiness fallback SHALL succeed
+- **AND** the provider SHALL NOT be reported as missing or unauthenticated only because version text is empty
+
+### Requirement: Sync duplicate cleanup is idempotent within one run
+The system SHALL prevent `aco sync --clean-duplicates` from recreating a duplicate target path that it cleaned earlier in the same sync run.
+
+#### Scenario: Cleaned target is also present in planned outputs
+- **WHEN** duplicate cleanup removes a target path from disk
+- **AND** the same target path exists in the current sync plan outputs as `created` or `updated`
+- **THEN** the write phase SHALL NOT copy that target path again during the same run
+- **AND** the final manifest SHALL NOT retain that target path as an ACO-owned generated target
+
+### Requirement: Skill directory hashes include relative paths and raw bytes
+The system SHALL compute skill directory hashes from both each file's relative path and raw byte content.
+
+#### Scenario: File rename changes directory hash
+- **WHEN** a skill directory contains a file with unchanged byte content
+- **AND** that file is renamed or moved to a different relative path
+- **THEN** the skill directory hash SHALL change
+- **AND** `aco sync` SHALL plan an update instead of treating the target as skipped
+
+#### Scenario: Non-UTF-8 byte differences change directory hash
+- **WHEN** two skill directory files contain different raw bytes that cannot be safely represented as UTF-8 text
+- **THEN** the skill directory hash SHALL reflect the byte difference
+- **AND** `aco sync` SHALL NOT collapse those files into the same text-normalized hash input
+
+### Requirement: Review follow-up completion includes original thread closure
+The system SHALL complete issue #85 by updating each original unresolved review thread with a concise result and resolving it when the fix or already-fixed confirmation is complete.
+
+#### Scenario: Review thread required a new change
+- **WHEN** a review thread from PR #70, #76, #77, #83, or #84 is fixed by the #85 branch
+- **THEN** the thread SHALL receive a reply summarizing the change and validation
+- **AND** the thread SHALL be marked resolved
+
+#### Scenario: Review thread was already fixed on current main
+- **WHEN** a review thread's requested behavior is already present on current `origin/main`
+- **THEN** the thread SHALL receive a reply identifying the current-main evidence
+- **AND** the thread SHALL be marked resolved without redundant code churn
+
+### Requirement: Local reference checkout is ignored
+The repository SHALL ignore local `reference/` checkouts used for external source inspection.
+
+#### Scenario: Reference repository is present locally
+- **WHEN** a developer has a local `reference/` directory in the repository root
+- **THEN** Git SHALL treat `reference/` as ignored repository-local workspace state
+- **AND** the directory SHALL NOT appear as untracked work in normal status output after the ignore rule is present

--- a/openspec/changes/resolve-review-followups-85/tasks.md
+++ b/openspec/changes/resolve-review-followups-85/tasks.md
@@ -1,0 +1,48 @@
+## 1. Repository Hygiene
+
+- [x] 1.1 Add `reference/` to `.gitignore` without deleting the local reference checkout.
+- [x] 1.2 Confirm the issue #85 worktree stays clean except for intended files.
+
+## 2. Already Fixed, Reply/Resolve Only
+
+- [x] 2.1 Confirm PR #83 `sync-config.ts` empty/comment-only/null YAML handling is already fixed on current main with existing tests.
+- [x] 2.2 Reply to the PR #83 `sync-config.ts` review thread with current-main evidence and resolve it without code churn.
+- [x] 2.3 Confirm PR #83 `duplicate-detector.ts` cleanup target directory handling and structured `cleanupTargets` are already fixed on current main.
+- [x] 2.4 Reply to the PR #83 `duplicate-detector.ts` cleanup target review thread with current-main evidence and resolve it without code churn.
+
+## 3. Code/Doc/Test Required
+
+- [x] 3.1 Update `scripts/setup-github-project.sh` so missing Project, Status, or Priority IDs fail before success/export output.
+- [x] 3.2 Update `scripts/setup-project-ids.sh` so incomplete canonical IDs exit non-zero before printing the shell export block.
+- [x] 3.3 Add targeted shell or fixture coverage for missing Priority option IDs and incomplete export output.
+- [x] 3.4 Update `docs/contract/go-node-boundary.md` to explain why Node Gemini auth can use `GOOGLE_API_KEY` while the Go runtime allowlist passes `GEMINI_API_KEY`.
+- [x] 3.5 Replace the Node.js `바이너리명` wording with implementation-accurate language for provider-local `which()`/spawn behavior.
+- [x] 3.6 Check related docs for conflicting `GOOGLE_API_KEY` or binary lookup wording and update only if needed.
+- [x] 3.7 Update `readVersion()` or its callers so stderr-only successful `--version` output is accepted.
+- [x] 3.8 Ensure successful empty-output probes do not make `GeminiProvider.checkAuth()` or `CodexProvider.checkAuth()` report `missing`.
+- [x] 3.9 Add targeted provider or utility tests for stderr-only and empty-output successful probes.
+- [x] 3.10 Update `--clean-duplicates` handling so cleaned target paths are removed from the same run's `plan.outputs` before the write loop.
+- [x] 3.11 Add a regression test showing a cleaned duplicate target is not recreated during the same `aco sync --clean-duplicates --force-clean` run.
+- [x] 3.12 Update skill directory hashing to include relative paths and raw bytes.
+- [x] 3.13 Add regression tests for same-content file rename and non-UTF-8 byte differences.
+
+## 4. Review Thread Mapping And Closure
+
+- [x] 4.1 Fetch the 11 unresolved review threads for PR #70, #76, #77, #83, and #84 and map each to fixed, already-fixed, or blocked.
+- [x] 4.2 Map PR #70 Project setup/export script threads to tasks 3.1 through 3.3.
+- [x] 4.3 Map PR #76 Go/Node boundary doc threads to tasks 3.4 through 3.6.
+- [x] 4.4 Map PR #77 provider readiness probe thread to tasks 3.7 through 3.9.
+- [x] 4.5 Map PR #84 `sync-engine.ts` output recreation thread to tasks 3.10 and 3.11.
+- [x] 4.6 Map PR #83 `skill-transform.ts` relative-path hash thread to tasks 3.12 and 3.13.
+- [x] 4.7 Map PR #84 `skill-transform.ts` byte-hash thread to tasks 3.12 and 3.13.
+- [x] 4.8 Reply to each fixed thread with the implementation and validation summary.
+- [x] 4.9 Reply to each already-fixed thread with current-main evidence and avoid redundant code churn.
+- [x] 4.10 Resolve all completed review threads through the GitHub review thread API.
+
+## 5. Validation
+
+- [x] 5.1 Run targeted tests for changed script, provider, and sync behavior.
+- [x] 5.2 Run `openspec validate resolve-review-followups-85 --type change --strict`.
+- [x] 5.3 Run `git diff --check`.
+- [x] 5.4 Run broader wrapper checks such as `npm run typecheck --workspace=packages/wrapper` or `npm test --workspace=packages/wrapper` if touched code warrants it.
+- [x] 5.5 Update issue #85 or PR body with final validation results when creating the PR.

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
   ],
   "scripts": {
     "build": "npm run build --workspace=packages/wrapper",
-    "test": "npm test --workspace=packages/wrapper",
+    "test": "npm run test:scripts && npm test --workspace=packages/wrapper",
     "test:smoke": "npm run test:smoke --workspace=packages/wrapper --if-present",
     "test:fixtures": "npx tsx test/fixtures/harness.ts",
+    "test:scripts": "bash test/scripts/project-id-validation.test.sh",
     "typecheck": "npm run typecheck --workspace=packages/wrapper",
     "format:check": "prettier --check \"packages/*/src/**/*.ts\"",
     "release": "npm run build && changeset publish"

--- a/packages/wrapper/src/sync/skill-transform.ts
+++ b/packages/wrapper/src/sync/skill-transform.ts
@@ -1,10 +1,12 @@
 import { existsSync } from 'node:fs';
 import { join, basename, dirname, normalize, relative, isAbsolute } from 'node:path';
+import { createHash } from 'node:crypto';
 import type {
   SyncSource,
   SyncOutput,
   SyncWarning,
   SyncManifest,
+  ManifestTargetRecord,
   AssetOwner,
   AssetKind,
   SyncConfig,
@@ -85,10 +87,7 @@ export async function syncSkills(
       if (!stillExistsAndEligible) {
         // Only auto-remove if manifest records it as ACO-owned and hash matches
         if (record.owner === 'aco') {
-          const match =
-            record.hashFormat === 'legacy-v1'
-              ? await legacySkillHashMatches(targetPath, record.hash)
-              : await hashMatches(targetPath, record.hash);
+          const match = await manifestSkillHashMatches(targetPath, record);
           if (match) {
             const stat = await lstat(targetPath);
             if (stat.isSymbolicLink()) {
@@ -237,8 +236,14 @@ async function computeDirHash(dirPath: string): Promise<string> {
       entry.name
     );
     try {
-      const content = await readFile(fullPath, 'utf8');
-      fileHashes.push(computeHash(content));
+      const content = await readFile(fullPath);
+      const relativePath = relative(dirPath, fullPath).replace(/\\/g, '/');
+      const fileHash = createHash('sha256')
+        .update(relativePath, 'utf8')
+        .update('\0')
+        .update(content)
+        .digest('hex');
+      fileHashes.push(fileHash);
     } catch (err: unknown) {
       const e = err as Error & { code?: string };
       if (e.code === 'ENOENT') continue; // race condition: file removed during read
@@ -249,9 +254,59 @@ async function computeDirHash(dirPath: string): Promise<string> {
   return computeHash(fileHashes.join('\n'));
 }
 
+async function computePrePathDirHash(dirPath: string): Promise<string> {
+  const entries = await readdir(dirPath, { recursive: true, withFileTypes: true });
+  const fileHashes: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (typeof entry.isSymbolicLink === 'function' && entry.isSymbolicLink()) continue;
+    const fullPath = join(
+      entry.parentPath ?? (entry as { path?: string }).path ?? dirPath,
+      entry.name
+    );
+    try {
+      const content = await readFile(fullPath, 'utf8');
+      fileHashes.push(computeHash(content));
+    } catch (err: unknown) {
+      const e = err as Error & { code?: string };
+      if (e.code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+  fileHashes.sort();
+  return computeHash(fileHashes.join('\n'));
+}
+
+async function manifestSkillHashMatches(
+  targetPath: string,
+  record: ManifestTargetRecord
+): Promise<boolean> {
+  if (record.hashFormat === 'legacy-v1') {
+    return legacySkillHashMatches(targetPath, record.hash);
+  }
+  if (await hashMatches(targetPath, record.hash)) {
+    return true;
+  }
+  if (!record.hashFormat) {
+    return prePathDirectoryHashMatches(targetPath, record.hash);
+  }
+  return false;
+}
+
 async function hashMatches(targetPath: string, expectedHash: string): Promise<boolean> {
   try {
     return (await computeDirHash(targetPath)) === expectedHash;
+  } catch {
+    return false;
+  }
+}
+
+async function prePathDirectoryHashMatches(
+  targetPath: string,
+  expectedHash: string
+): Promise<boolean> {
+  try {
+    return (await computePrePathDirHash(targetPath)) === expectedHash;
   } catch {
     return false;
   }

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -168,6 +168,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
     const cleanable = duplicateWarnings.filter((w) => w.severity === 'warning');
     const cleanedOwned: string[] = [];
     const cleanedForced: string[] = [];
+    const cleanedPaths = new Set<string>();
     for (const warning of cleanable) {
       const targets = warning.cleanupTargets;
       if (targets && targets.length > 0) {
@@ -185,6 +186,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
             }
             try {
               await rm(targetPath, { recursive: true, force: true });
+              cleanedPaths.add(normalize(targetPath));
               if (isOwned) {
                 cleanedOwned.push(targetPath);
               } else {
@@ -217,6 +219,11 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
     for (const path of cleanedForced) {
       delete plan.manifest.targetHashes[path];
       delete plan.manifest.targets[path];
+    }
+    if (cleanedPaths.size > 0) {
+      plan.outputs = plan.outputs.filter(
+        (output) => !cleanedPaths.has(normalize(output.targetPath))
+      );
     }
 
     // Record removals in manifest
@@ -272,6 +279,9 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
         }
       } else if (output.kind === 'directory' && output.sourcePath) {
         await mkdir(dirname(output.targetPath), { recursive: true });
+        if (output.action === 'updated') {
+          await rm(output.targetPath, { recursive: true, force: true });
+        }
         await cp(output.sourcePath, output.targetPath, { recursive: true, force: true });
       }
     }
@@ -356,6 +366,7 @@ async function computeTransformPlan(
         owner: o.owner ?? 'aco',
         kind: o.assetKind ?? 'shared-skill',
         source: o.sourcePath,
+        hashFormat: o.kind === 'directory' ? 'directory' : undefined,
       };
     }
   }

--- a/packages/wrapper/src/util/read-version.ts
+++ b/packages/wrapper/src/util/read-version.ts
@@ -4,17 +4,23 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 const DEFAULT_TIMEOUT_MS = 5_000;
 
+function firstNonEmptyLine(output: string | Buffer): string | undefined {
+  const text = typeof output === 'string' ? output : output.toString('utf8');
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+}
+
 export async function readVersion(
   binary: string,
   timeout = DEFAULT_TIMEOUT_MS
 ): Promise<string | undefined> {
   try {
-    const { stdout } = await execFileAsync(binary, ['--version'], {
+    const { stdout, stderr } = await execFileAsync(binary, ['--version'], {
       timeout,
     });
-    const output = typeof stdout === 'string' ? stdout.trim() : '';
-    if (!output) return undefined;
-    return output.split('\n')[0].trim();
+    return firstNonEmptyLine(stdout) ?? firstNonEmptyLine(stderr) ?? '';
   } catch {
     return undefined;
   }

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -4,19 +4,95 @@ import { GeminiProvider } from '../src/providers/gemini';
 import { CodexProvider } from '../src/providers/codex';
 import { ProviderRegistry } from '../src/providers/registry';
 import { getCachedProviderAuth } from '../src/providers/auth-cache';
+import { readVersion } from '../src/util/read-version';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-async function makeFakeBinary(binDir: string, name: string, output: string): Promise<string> {
+interface FakeBinaryOptions {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}
+
+async function makeFakeBinary(
+  binDir: string,
+  name: string,
+  output: string | FakeBinaryOptions
+): Promise<string> {
   const full = path.join(binDir, name);
+  const options = typeof output === 'string' ? { stdout: `${output}\n` } : output;
   await fs.writeFile(
     full,
-    `#!/usr/bin/env sh\nprintf "%s\\n" "${output}"\n`,
+    `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(options.stdout ?? '')});\nprocess.stderr.write(${JSON.stringify(options.stderr ?? '')});\nprocess.exit(${options.exitCode ?? 0});\n`,
     { mode: 0o755 }
   );
   return full;
 }
+
+async function withoutProviderAuthEnv<T>(fn: () => Promise<T>): Promise<T> {
+  const keys = ['GEMINI_API_KEY', 'GOOGLE_API_KEY', 'OPENAI_API_KEY'];
+  const original: Record<string, string | undefined> = {};
+  for (const key of keys) {
+    original[key] = process.env[key];
+    delete process.env[key];
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const key of keys) {
+      if (original[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original[key];
+      }
+    }
+  }
+}
+
+describe('readVersion()', () => {
+  let tmpBin: string;
+
+  before(async () => {
+    tmpBin = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-test-version-bin-'));
+  });
+
+  after(async () => {
+    await fs.rm(tmpBin, { recursive: true, force: true });
+  });
+
+  it('returns the first non-empty stdout line when stdout is available', async () => {
+    const binary = await makeFakeBinary(tmpBin, 'stdout-version', {
+      stdout: '\n  cli 1.2.3  \nignored\n',
+      stderr: 'stderr 9.9.9\n',
+    });
+
+    assert.equal(await readVersion(binary), 'cli 1.2.3');
+  });
+
+  it('falls back to the first non-empty stderr line', async () => {
+    const binary = await makeFakeBinary(tmpBin, 'stderr-version', {
+      stderr: '\n  cli 4.5.6  \nignored\n',
+    });
+
+    assert.equal(await readVersion(binary), 'cli 4.5.6');
+  });
+
+  it('returns an empty string when a successful probe has no version text', async () => {
+    const binary = await makeFakeBinary(tmpBin, 'empty-version', {});
+
+    assert.equal(await readVersion(binary), '');
+  });
+
+  it('returns undefined when the version probe fails', async () => {
+    const binary = await makeFakeBinary(tmpBin, 'failed-version', {
+      stdout: 'cli 0.0.0\n',
+      exitCode: 1,
+    });
+
+    assert.equal(await readVersion(binary), undefined);
+  });
+});
 
 describe('GeminiProvider', () => {
   let tmpHome: string;
@@ -158,12 +234,74 @@ describe('GeminiProvider', () => {
       }
     }
     const provider = new MockGemini();
-    const result = await provider.checkAuth();
+    const result = await withoutProviderAuthEnv(() => provider.checkAuth());
     assert.strictEqual(result.ok, true);
     assert.equal(result.method, 'cli-fallback');
     assert.equal(result.version, 'gemini-cli 3.0.0');
     assert.equal(result.binaryPath, `${tmpBin}/gemini`);
     assert.equal(result.hint, undefined);
+  });
+
+  it('checkAuth() fallback: reports stderr-only version output', async () => {
+    class MockGemini extends GeminiProvider {
+      override isAvailable() {
+        return true;
+      }
+    }
+    await makeFakeBinary(tmpBin, 'gemini', {
+      stderr: '\n  gemini-cli 3.1.0  \nignored\n',
+    });
+
+    try {
+      const result = await withoutProviderAuthEnv(() => new MockGemini().checkAuth());
+      assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'cli-fallback');
+      assert.equal(result.version, 'gemini-cli 3.1.0');
+      assert.equal(result.binaryPath, `${tmpBin}/gemini`);
+      assert.equal(result.hint, undefined);
+    } finally {
+      await makeFakeBinary(tmpBin, 'gemini', 'gemini-cli 3.0.0');
+    }
+  });
+
+  it('checkAuth() fallback: stays ready when the version probe has no output', async () => {
+    class MockGemini extends GeminiProvider {
+      override isAvailable() {
+        return true;
+      }
+    }
+    await makeFakeBinary(tmpBin, 'gemini', {});
+
+    try {
+      const result = await withoutProviderAuthEnv(() => new MockGemini().checkAuth());
+      assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'cli-fallback');
+      assert.equal(result.version, '');
+      assert.equal(result.binaryPath, `${tmpBin}/gemini`);
+      assert.equal(result.hint, undefined);
+    } finally {
+      await makeFakeBinary(tmpBin, 'gemini', 'gemini-cli 3.0.0');
+    }
+  });
+
+  it('checkAuth() fallback: returns missing when the version probe fails', async () => {
+    class MockGemini extends GeminiProvider {
+      override isAvailable() {
+        return true;
+      }
+    }
+    await makeFakeBinary(tmpBin, 'gemini', {
+      stderr: 'permission denied\n',
+      exitCode: 1,
+    });
+
+    try {
+      const result = await withoutProviderAuthEnv(() => new MockGemini().checkAuth());
+      assert.strictEqual(result.ok, false);
+      assert.equal(result.method, 'missing');
+    } finally {
+      await makeFakeBinary(tmpBin, 'gemini', 'gemini-cli 3.0.0');
+    }
   });
 
   it('checkAuth() fast-path: returns error when oauth_creds.json is a directory', async () => {
@@ -363,6 +501,41 @@ describe('CodexProvider', () => {
     } finally {
       process.env.PATH = originalPath;
       await fs.rm(authPath, { force: true });
+    }
+  });
+
+  it('checkAuth() fallback: reports cli-fallback via binary version output', async () => {
+    class MockCodex extends CodexProvider {
+      override isAvailable() {
+        return true;
+      }
+    }
+
+    const result = await withoutProviderAuthEnv(() => new MockCodex().checkAuth());
+    assert.strictEqual(result.ok, true);
+    assert.equal(result.method, 'cli-fallback');
+    assert.equal(result.version, 'codex-cli 1.0.0');
+    assert.equal(result.binaryPath, `${tmpBin}/codex`);
+    assert.equal(result.hint, undefined);
+  });
+
+  it('checkAuth() fallback: stays ready when the version probe has no output', async () => {
+    class MockCodex extends CodexProvider {
+      override isAvailable() {
+        return true;
+      }
+    }
+    await makeFakeBinary(tmpBin, 'codex', {});
+
+    try {
+      const result = await withoutProviderAuthEnv(() => new MockCodex().checkAuth());
+      assert.strictEqual(result.ok, true);
+      assert.equal(result.method, 'cli-fallback');
+      assert.equal(result.version, '');
+      assert.equal(result.binaryPath, `${tmpBin}/codex`);
+      assert.equal(result.hint, undefined);
+    } finally {
+      await makeFakeBinary(tmpBin, 'codex', 'codex-cli 1.0.0');
     }
   });
 

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, rm, rename } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { load as loadYaml } from 'js-yaml';
@@ -15,6 +15,15 @@ import { matchesGlob, isIncluded, isExcluded, loadSyncConfig } from '../src/sync
 import { detectDuplicates } from '../src/sync/duplicate-detector.js';
 import type { SyncSource, SyncConfig, SyncOutput } from '../src/sync/transform-interface.js';
 import { computeHash } from '../src/sync/hash.js';
+
+function computePrePathDirectoryHash(contents: string[]): string {
+  return computeHash(
+    contents
+      .map((content) => computeHash(content))
+      .sort()
+      .join('\n')
+  );
+}
 
 function parseMarkdownFrontmatter(markdown: string): Record<string, unknown> {
   const match = markdown.match(/^---\n([\s\S]*?)\n---\n\n([\s\S]*)$/);
@@ -734,6 +743,7 @@ describe('Skill Sync', () => {
       assert.ok(record, 'Manifest should record the target');
       assert.equal(record.owner, 'aco');
       assert.equal(record.kind, 'shared-skill');
+      assert.equal(record.hashFormat, 'directory');
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
@@ -849,6 +859,61 @@ describe('Skill Sync', () => {
     }
   });
 
+  it('removes stale v2 skill targets that still use pre-path directory hashes', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-stale-v2-prepath-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '');
+
+      const targetDir = join(tmpDir, '.agents', 'skills', 'prepath-skill');
+      await mkdir(join(targetDir, 'references'), { recursive: true });
+      const skillContent = '---\nname: prepath-skill\n---\n\n# Prepath Skill';
+      const referenceContent = 'same content';
+      await writeFile(join(targetDir, 'SKILL.md'), skillContent);
+      await writeFile(join(targetDir, 'references', 'guide.md'), referenceContent);
+
+      const oldDirHash = computePrePathDirectoryHash([skillContent, referenceContent]);
+      const acoDir = join(tmpDir, '.aco');
+      await mkdir(acoDir, { recursive: true });
+      const prePathManifest = {
+        version: '2',
+        generatedAt: new Date().toISOString(),
+        sourceHashes: {},
+        targetHashes: {
+          [targetDir]: oldDirHash,
+        },
+        targets: {
+          [targetDir]: {
+            hash: oldDirHash,
+            owner: 'aco',
+            kind: 'shared-skill',
+          },
+        },
+        skipped: [],
+        warnings: [],
+      };
+      await writeFile(join(acoDir, 'sync-manifest.json'), JSON.stringify(prePathManifest, null, 2));
+
+      const result = await runSync(tmpDir, { dryRun: false });
+      const removedOutputs = result.outputs.filter((o) => o.targetPath === targetDir);
+      assert.equal(removedOutputs[0]?.action, 'removed');
+      assert.equal(
+        result.outputs.some((o) => o.action === 'conflict'),
+        false,
+        'pre-path hash compatibility should not turn stale cleanup into a conflict'
+      );
+      assert.equal(
+        result.warnings,
+        0,
+        'pre-path hash compatibility should avoid stale hash mismatch warnings'
+      );
+
+      const { existsSync } = await import('node:fs');
+      assert.equal(existsSync(targetDir), false, `Expected ${targetDir} to be removed`);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('computes correct hash based only on files, ignoring directories', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-dirhash-'));
     try {
@@ -889,6 +954,95 @@ describe('Skill Sync', () => {
       );
       assert.equal(skillOutput3?.action, 'updated', 'Modified skill should be updated');
       assert.notEqual(skillOutput3?.hash, hash1, 'Hash should change when file added');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('updates a synced skill when a file is renamed with unchanged content', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-dirhash-rename-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '');
+      const skillDir = join(tmpDir, '.claude', 'skills', 'rename-skill');
+      await mkdir(join(skillDir, 'references'), { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), '---\nname: rename-skill\n---\n\n# Rename');
+      await writeFile(join(skillDir, 'references', 'old.md'), 'same content');
+
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.aco', 'sync.yaml'),
+        'skills:\n  include:\n    - rename-skill\n'
+      );
+
+      const first = await runSync(tmpDir, { dryRun: false });
+      const firstOutput = first.outputs.find((o) =>
+        o.targetPath.includes('.agents/skills/rename-skill')
+      );
+      assert.equal(firstOutput?.action, 'created');
+
+      await rename(join(skillDir, 'references', 'old.md'), join(skillDir, 'references', 'new.md'));
+
+      const second = await runSync(tmpDir, { dryRun: false });
+      const secondOutput = second.outputs.find((o) =>
+        o.targetPath.includes('.agents/skills/rename-skill')
+      );
+      assert.equal(
+        secondOutput?.action,
+        'updated',
+        'same-content rename should change the directory hash'
+      );
+      assert.notEqual(secondOutput?.hash, firstOutput?.hash);
+
+      const { existsSync } = await import('node:fs');
+      const targetDir = join(tmpDir, '.agents', 'skills', 'rename-skill');
+      assert.equal(
+        existsSync(join(targetDir, 'references', 'old.md')),
+        false,
+        'directory update should remove files deleted from the source layout'
+      );
+      assert.equal(
+        existsSync(join(targetDir, 'references', 'new.md')),
+        true,
+        'directory update should copy files added by the source layout'
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('updates a synced skill when non-UTF-8 raw bytes change', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-dirhash-bytes-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '');
+      const skillDir = join(tmpDir, '.claude', 'skills', 'bytes-skill');
+      await mkdir(join(skillDir, 'assets'), { recursive: true });
+      await writeFile(join(skillDir, 'SKILL.md'), '---\nname: bytes-skill\n---\n\n# Bytes');
+      await writeFile(join(skillDir, 'assets', 'payload.bin'), Buffer.from([0xff]));
+
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.aco', 'sync.yaml'),
+        'skills:\n  include:\n    - bytes-skill\n'
+      );
+
+      const first = await runSync(tmpDir, { dryRun: false });
+      const firstOutput = first.outputs.find((o) =>
+        o.targetPath.includes('.agents/skills/bytes-skill')
+      );
+      assert.equal(firstOutput?.action, 'created');
+
+      await writeFile(join(skillDir, 'assets', 'payload.bin'), Buffer.from([0xfe]));
+
+      const second = await runSync(tmpDir, { dryRun: false });
+      const secondOutput = second.outputs.find((o) =>
+        o.targetPath.includes('.agents/skills/bytes-skill')
+      );
+      assert.equal(
+        secondOutput?.action,
+        'updated',
+        'non-UTF-8 byte changes should change the directory hash'
+      );
+      assert.notEqual(secondOutput?.hash, firstOutput?.hash);
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
@@ -1151,6 +1305,61 @@ describe('Skill Sync', () => {
           w.message.includes('Cleaned') || w.message.includes('Force-cleaned')
       );
       assert.ok(cleanupWarnings.length > 0, 'Manifest should record cleanup with a warning entry');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('--clean-duplicates does not recreate cleaned planned outputs in the same run', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-clean-plan-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '');
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      await writeFile(join(tmpDir, '.aco', 'sync.yaml'), 'skills:\n  include:\n    - gh-issue\n');
+
+      const sourceSkillDir = join(tmpDir, '.claude', 'skills', 'gh-issue');
+      await mkdir(sourceSkillDir, { recursive: true });
+      await writeFile(
+        join(sourceSkillDir, 'SKILL.md'),
+        '---\nname: gh-issue\n---\n\n# GH Issue Source'
+      );
+
+      const targetDir = join(tmpDir, '.agents', 'skills', 'gh-issue');
+      await mkdir(targetDir, { recursive: true });
+      await writeFile(
+        join(targetDir, 'SKILL.md'),
+        '---\nname: gh-issue\n---\n\n# Existing Duplicate'
+      );
+
+      await mkdir(join(tmpDir, '.gemini', 'commands'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.gemini', 'commands', 'gh-issue.toml'),
+        '[command]\nname = "gh-issue"'
+      );
+
+      const result = await runSync(tmpDir, {
+        dryRun: false,
+        cleanDuplicates: true,
+        forceClean: true,
+      });
+
+      const { existsSync } = await import('node:fs');
+      assert.equal(
+        existsSync(targetDir),
+        false,
+        'cleaned duplicate target should not be recreated by the write loop'
+      );
+      assert.equal(
+        result.outputs.some((o) => o.targetPath === targetDir),
+        false,
+        'cleaned duplicate target should be removed from the current output plan'
+      );
+
+      const manifest = JSON.parse(
+        await readFile(join(tmpDir, '.aco', 'sync-manifest.json'), 'utf-8')
+      );
+      assert.equal(targetDir in manifest.targets, false);
+      assert.equal(targetDir in manifest.targetHashes, false);
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -8,6 +8,53 @@ set -euo pipefail
 
 OWNER="pureliture"
 TITLE="ai-cli-orch-wrapper PM"
+missing_required_ids=()
+
+is_missing_id() {
+  local value="${1:-}"
+  [[ -z "$value" || "$value" == "null" ]]
+}
+
+require_id() {
+  local label="$1"
+  local value="${2:-}"
+
+  if is_missing_id "$value"; then
+    missing_required_ids+=("$label")
+  fi
+}
+
+validate_required_project_ids() {
+  missing_required_ids=()
+
+  require_id "Project number (PM_PROJECT_NUMBER)" "${PROJECT_NUMBER:-}"
+  require_id "Project node ID (PM_PROJECT_ID)" "${PROJECT_ID:-}"
+  require_id "Status field (PM_STATUS_FIELD_ID)" "${STATUS_FIELD_ID:-}"
+  require_id "Status option Backlog (PM_BACKLOG_OPTION_ID)" "${BACKLOG_ID:-}"
+  require_id "Status option Ready (PM_READY_OPTION_ID)" "${READY_ID:-}"
+  require_id "Status option In Progress (PM_IN_PROGRESS_OPTION_ID)" "${IN_PROGRESS_ID:-}"
+  require_id "Status option In Review (PM_IN_REVIEW_OPTION_ID)" "${IN_REVIEW_ID:-}"
+  require_id "Status option Done (PM_DONE_OPTION_ID)" "${DONE_ID:-}"
+  require_id "Priority field (PM_PRIORITY_FIELD_ID)" "${PRIORITY_FIELD_ID:-}"
+  require_id "Priority option P0 (PM_P0_OPTION_ID)" "${P0_ID:-}"
+  require_id "Priority option P1 (PM_P1_OPTION_ID)" "${P1_ID:-}"
+  require_id "Priority option P2 (PM_P2_OPTION_ID)" "${P2_ID:-}"
+
+  if ((${#missing_required_ids[@]} > 0)); then
+    echo "" >&2
+    echo "ERROR: Incomplete canonical GitHub Project IDs; refusing to print exports or update docs/reference/project-board.md." >&2
+    echo "Missing required IDs:" >&2
+
+    local missing_id
+    for missing_id in "${missing_required_ids[@]}"; do
+      echo "  - ${missing_id}" >&2
+    done
+
+    echo "Canonical Status requires: field ID plus Backlog, Ready, In Progress, In Review, Done option IDs." >&2
+    echo "Canonical Priority requires: field ID plus P0, P1, P2 option IDs." >&2
+    exit 1
+  fi
+}
 
 echo "Setting up GitHub Projects V2 for @${OWNER}..."
 echo ""
@@ -41,7 +88,7 @@ echo "  Status field ID: ${STATUS_FIELD_ID}"
 # Get option IDs
 STATUS_OPTIONS=$(gh project field-list "$PROJECT_NUMBER" \
   --owner "$OWNER" --format json \
-  --jq '.fields[] | select(.name == "Status") | .options[]')
+  --jq '.fields[] | select(.name == "Status") | .options[]?')
 
 BACKLOG_ID=$(echo "$STATUS_OPTIONS" | jq -r 'select(.name == "Backlog") | .id')
 READY_ID=$(echo "$STATUS_OPTIONS" | jq -r 'select(.name == "Ready") | .id')
@@ -77,7 +124,7 @@ echo "  Priority field ID: ${PRIORITY_FIELD_ID}"
 
 PRIORITY_OPTIONS=$(gh project field-list "$PROJECT_NUMBER" \
   --owner "$OWNER" --format json \
-  --jq '.fields[] | select(.name == "Priority") | .options[]')
+  --jq '.fields[] | select(.name == "Priority") | .options[]?')
 
 P0_ID=$(echo "$PRIORITY_OPTIONS" | jq -r 'select(.name == "P0") | .id')
 P1_ID=$(echo "$PRIORITY_OPTIONS" | jq -r 'select(.name == "P1") | .id')
@@ -85,6 +132,8 @@ P2_ID=$(echo "$PRIORITY_OPTIONS" | jq -r 'select(.name == "P2") | .id')
 echo "  P0 option ID: ${P0_ID}"
 echo "  P1 option ID: ${P1_ID}"
 echo "  P2 option ID: ${P2_ID}"
+
+validate_required_project_ids
 
 # ── Size field ──────────────────────────────────────────────────────────────
 echo "── Creating Size field ──"

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -52,7 +52,7 @@ validate_required_project_ids() {
 
     echo "Canonical Status requires: field ID plus Backlog, Ready, In Progress, In Review, Done option IDs." >&2
     echo "Canonical Priority requires: field ID plus P0, P1, P2 option IDs." >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -133,7 +133,7 @@ echo "  P0 option ID: ${P0_ID}"
 echo "  P1 option ID: ${P1_ID}"
 echo "  P2 option ID: ${P2_ID}"
 
-validate_required_project_ids
+validate_required_project_ids || exit $?
 
 # ── Size field ──────────────────────────────────────────────────────────────
 echo "── Creating Size field ──"

--- a/scripts/setup-project-ids.sh
+++ b/scripts/setup-project-ids.sh
@@ -52,7 +52,7 @@ validate_required_project_ids() {
     echo "Canonical Status requires: field ID plus Backlog, Ready, In Progress, In Review, Done option IDs." >&2
     echo "Canonical Priority requires: field ID plus P0, P1, P2 option IDs." >&2
     echo "Compare the project setup with docs/reference/project-board.md." >&2
-    exit 1
+    return 1
   fi
 }
 
@@ -120,7 +120,7 @@ echo "── Priority field options ──"
 printf '%s' "$FIELDS_JSON" |
   jq -r '.fields[] | select(.name == "Priority") | .options[]? | "  \(.name)  [\(.id)]"'
 
-validate_required_project_ids
+validate_required_project_ids || exit $?
 
 echo ""
 echo "── Add to your shell rc (~/.zshrc or ~/.bashrc) ──"

--- a/scripts/setup-project-ids.sh
+++ b/scripts/setup-project-ids.sh
@@ -7,6 +7,54 @@
 set -euo pipefail
 
 OWNER="pureliture"
+missing_required_ids=()
+
+is_missing_id() {
+  local value="${1:-}"
+  [[ -z "$value" || "$value" == "null" ]]
+}
+
+require_id() {
+  local label="$1"
+  local value="${2:-}"
+
+  if is_missing_id "$value"; then
+    missing_required_ids+=("$label")
+  fi
+}
+
+validate_required_project_ids() {
+  missing_required_ids=()
+
+  require_id "Project number (PM_PROJECT_NUMBER)" "${PROJECT_NUMBER:-}"
+  require_id "Project node ID (PM_PROJECT_ID)" "${PROJECT_ID:-}"
+  require_id "Status field (PM_STATUS_FIELD_ID)" "${STATUS_FIELD_ID:-}"
+  require_id "Status option Backlog (PM_BACKLOG_OPTION_ID)" "${BACKLOG_OPTION_ID:-}"
+  require_id "Status option Ready (PM_READY_OPTION_ID)" "${READY_OPTION_ID:-}"
+  require_id "Status option In Progress (PM_IN_PROGRESS_OPTION_ID)" "${IN_PROGRESS_OPTION_ID:-}"
+  require_id "Status option In Review (PM_IN_REVIEW_OPTION_ID)" "${IN_REVIEW_OPTION_ID:-}"
+  require_id "Status option Done (PM_DONE_OPTION_ID)" "${DONE_OPTION_ID:-}"
+  require_id "Priority field (PM_PRIORITY_FIELD_ID)" "${PRIORITY_FIELD_ID:-}"
+  require_id "Priority option P0 (PM_P0_OPTION_ID)" "${P0_OPTION_ID:-}"
+  require_id "Priority option P1 (PM_P1_OPTION_ID)" "${P1_OPTION_ID:-}"
+  require_id "Priority option P2 (PM_P2_OPTION_ID)" "${P2_OPTION_ID:-}"
+
+  if ((${#missing_required_ids[@]} > 0)); then
+    echo "" >&2
+    echo "ERROR: Incomplete canonical GitHub Project IDs; refusing to print the shell export block." >&2
+    echo "Missing required IDs:" >&2
+
+    local missing_id
+    for missing_id in "${missing_required_ids[@]}"; do
+      echo "  - ${missing_id}" >&2
+    done
+
+    echo "Canonical Status requires: field ID plus Backlog, Ready, In Progress, In Review, Done option IDs." >&2
+    echo "Canonical Priority requires: field ID plus P0, P1, P2 option IDs." >&2
+    echo "Compare the project setup with docs/reference/project-board.md." >&2
+    exit 1
+  fi
+}
 
 echo "Fetching GitHub Projects V2 IDs for @${OWNER}..."
 echo ""
@@ -65,20 +113,14 @@ printf '%s' "$FIELDS_JSON" |
 echo ""
 echo "── Status field options ──"
 printf '%s' "$FIELDS_JSON" |
-  jq -r '.fields[] | select(.name == "Status") | .options[] | "  \(.name)  [\(.id)]"'
+  jq -r '.fields[] | select(.name == "Status") | .options[]? | "  \(.name)  [\(.id)]"'
 
 echo ""
 echo "── Priority field options ──"
 printf '%s' "$FIELDS_JSON" |
-  jq -r '.fields[] | select(.name == "Priority") | .options[] | "  \(.name)  [\(.id)]"'
+  jq -r '.fields[] | select(.name == "Priority") | .options[]? | "  \(.name)  [\(.id)]"'
 
-if [[ -z "$STATUS_FIELD_ID" || -z "$BACKLOG_OPTION_ID" || -z "$READY_OPTION_ID" ||
-      -z "$IN_PROGRESS_OPTION_ID" || -z "$IN_REVIEW_OPTION_ID" || -z "$DONE_OPTION_ID" ||
-      -z "$PRIORITY_FIELD_ID" || -z "$P0_OPTION_ID" || -z "$P1_OPTION_ID" || -z "$P2_OPTION_ID" ]]; then
-  echo ""
-  echo "WARN: Missing one or more canonical Status/Priority fields or options." >&2
-  echo "      Compare the project setup with docs/reference/project-board.md." >&2
-fi
+validate_required_project_ids
 
 echo ""
 echo "── Add to your shell rc (~/.zshrc or ~/.bashrc) ──"

--- a/test/scripts/project-id-validation.test.sh
+++ b/test/scripts/project-id-validation.test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/bin" "$TMP_DIR/scripts" "$TMP_DIR/docs/reference"
+cp "$ROOT_DIR/scripts/setup-github-project.sh" "$TMP_DIR/scripts/setup-github-project.sh"
+cp "$ROOT_DIR/scripts/setup-project-ids.sh" "$TMP_DIR/scripts/setup-project-ids.sh"
+chmod +x "$TMP_DIR/scripts/setup-github-project.sh" "$TMP_DIR/scripts/setup-project-ids.sh"
+
+cat > "$TMP_DIR/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+fixture_mode="${GH_FIXTURE_MODE:-missing-priority}"
+args="$*"
+
+emit_status_options() {
+  printf '%s\n' \
+    '{"name":"Backlog","id":"opt_backlog"}' \
+    '{"name":"Ready","id":"opt_ready"}' \
+    '{"name":"In Progress","id":"opt_in_progress"}' \
+    '{"name":"In Review","id":"opt_in_review"}' \
+    '{"name":"Done","id":"opt_done"}'
+}
+
+emit_priority_options() {
+  if [[ "$fixture_mode" == "complete" ]]; then
+    printf '%s\n' \
+      '{"name":"P0","id":"opt_p0"}' \
+      '{"name":"P1","id":"opt_p1"}' \
+      '{"name":"P2","id":"opt_p2"}'
+  else
+    printf '%s\n' '{"name":"P0","id":"opt_p0"}'
+  fi
+}
+
+emit_fields_json() {
+  if [[ "$fixture_mode" == "complete" ]]; then
+    cat <<'JSON'
+{"fields":[{"name":"Status","id":"field_status","type":"SINGLE_SELECT","options":[{"name":"Backlog","id":"opt_backlog"},{"name":"Ready","id":"opt_ready"},{"name":"In Progress","id":"opt_in_progress"},{"name":"In Review","id":"opt_in_review"},{"name":"Done","id":"opt_done"}]},{"name":"Priority","id":"field_priority","type":"SINGLE_SELECT","options":[{"name":"P0","id":"opt_p0"},{"name":"P1","id":"opt_p1"},{"name":"P2","id":"opt_p2"}]}]}
+JSON
+  else
+    cat <<'JSON'
+{"fields":[{"name":"Status","id":"field_status","type":"SINGLE_SELECT","options":[{"name":"Backlog","id":"opt_backlog"},{"name":"Ready","id":"opt_ready"},{"name":"In Progress","id":"opt_in_progress"},{"name":"In Review","id":"opt_in_review"},{"name":"Done","id":"opt_done"}]},{"name":"Priority","id":"field_priority","type":"SINGLE_SELECT","options":[{"name":"P0","id":"opt_p0"}]}]}
+JSON
+  fi
+}
+
+if [[ "${1:-}" != "project" ]]; then
+  echo "unexpected gh command: $args" >&2
+  exit 2
+fi
+
+case "${2:-}" in
+  list)
+    echo "  #3  ai-cli-orch-wrapper PM  [PVT_test]"
+    ;;
+  view)
+    echo "PVT_test"
+    ;;
+  create)
+    echo '{"number":3,"id":"PVT_test"}'
+    ;;
+  field-create)
+    if [[ "$args" == *"--name Status"* ]]; then
+      echo '{"id":"field_status"}'
+    elif [[ "$args" == *"--name Priority"* ]]; then
+      echo '{"id":"field_priority"}'
+    else
+      echo '{"id":"field_other"}'
+    fi
+    ;;
+  field-list)
+    if [[ "$args" == *"--jq"* ]]; then
+      if [[ "$args" == *'select(.name == "Status") | .options'* ]]; then
+        emit_status_options
+      elif [[ "$args" == *'select(.name == "Priority") | .options'* ]]; then
+        emit_priority_options
+      elif [[ "$args" == *'select(.name == "Status") | .id'* ]]; then
+        echo "field_status"
+      elif [[ "$args" == *'select(.name == "Priority") | .id'* ]]; then
+        echo "field_priority"
+      else
+        emit_fields_json
+      fi
+    else
+      emit_fields_json
+    fi
+    ;;
+  link)
+    exit 0
+    ;;
+  *)
+    echo "unexpected gh project command: $args" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$TMP_DIR/bin/gh"
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "Expected to find '$expected' in $file" >&2
+    echo "--- $file ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local unexpected="$2"
+  if grep -Fq "$unexpected" "$file"; then
+    echo "Did not expect to find '$unexpected' in $file" >&2
+    echo "--- $file ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+run_project_ids() {
+  local mode="$1"
+  local name="$2"
+  local out="$TMP_DIR/${name}.out"
+  local err="$TMP_DIR/${name}.err"
+
+  set +e
+  (
+    cd "$TMP_DIR"
+    PATH="$TMP_DIR/bin:$PATH" GH_FIXTURE_MODE="$mode" bash scripts/setup-project-ids.sh <<<"3"
+  ) >"$out" 2>"$err"
+  local status=$?
+  set -e
+
+  echo "$status" >"$TMP_DIR/${name}.status"
+}
+
+run_setup_project() {
+  local mode="$1"
+  local name="$2"
+  local out="$TMP_DIR/${name}.out"
+  local err="$TMP_DIR/${name}.err"
+
+  printf '%s\n' 'PM_P1_OPTION_ID=""' >"$TMP_DIR/docs/reference/project-board.md"
+
+  set +e
+  (
+    cd "$TMP_DIR"
+    PATH="$TMP_DIR/bin:$PATH" GH_FIXTURE_MODE="$mode" bash scripts/setup-github-project.sh
+  ) >"$out" 2>"$err"
+  local status=$?
+  set -e
+
+  echo "$status" >"$TMP_DIR/${name}.status"
+}
+
+run_project_ids "missing-priority" "ids-missing"
+if [[ "$(cat "$TMP_DIR/ids-missing.status")" -eq 0 ]]; then
+  echo "Expected setup-project-ids.sh to fail when Priority options are incomplete" >&2
+  exit 1
+fi
+assert_contains "$TMP_DIR/ids-missing.err" "Priority option P1"
+assert_contains "$TMP_DIR/ids-missing.err" "Priority option P2"
+assert_not_contains "$TMP_DIR/ids-missing.out" "export PM_PROJECT_NUMBER"
+
+run_project_ids "complete" "ids-complete"
+if [[ "$(cat "$TMP_DIR/ids-complete.status")" -ne 0 ]]; then
+  echo "Expected setup-project-ids.sh to print exports when IDs are complete" >&2
+  cat "$TMP_DIR/ids-complete.err" >&2
+  exit 1
+fi
+assert_contains "$TMP_DIR/ids-complete.out" 'export PM_P1_OPTION_ID="opt_p1"'
+
+run_setup_project "missing-priority" "setup-missing"
+if [[ "$(cat "$TMP_DIR/setup-missing.status")" -eq 0 ]]; then
+  echo "Expected setup-github-project.sh to fail before setup success output" >&2
+  exit 1
+fi
+assert_contains "$TMP_DIR/setup-missing.err" "Priority option P1"
+assert_contains "$TMP_DIR/setup-missing.err" "Priority option P2"
+assert_not_contains "$TMP_DIR/setup-missing.out" "Project setup complete"
+assert_not_contains "$TMP_DIR/setup-missing.out" "export PM_PROJECT_NUMBER"
+assert_contains "$TMP_DIR/docs/reference/project-board.md" 'PM_P1_OPTION_ID=""'
+
+echo "project ID validation script tests passed"


### PR DESCRIPTION
Closes #85

## What

PR #70, #76, #77, #83, #84에 남아 있던 unresolved review thread 11개를 현재 `origin/main` 기준 후속 변경으로 정리합니다.

## Why

기존 review thread가 merged PR에 남아 있어 Project setup script, Go/Node boundary docs, provider readiness probe, sync duplicate cleanup/hash 동작의 작은 회귀 가능성이 board와 리뷰 상태에 계속 남아 있었습니다. 이미 current main에서 고정된 항목은 code churn 없이 evidence reply로 닫고, 아직 필요한 항목은 한 브랜치에서 테스트와 함께 보강했습니다.

## Changes

- `scripts/setup-github-project.sh`, `scripts/setup-project-ids.sh`가 canonical Project/Status/Priority ID 누락 시 success/export output 전에 non-zero로 종료하도록 보강했습니다.
- `test/scripts/project-id-validation.test.sh`를 추가하고 `npm test` 및 CI test job에 연결해 shell script regression을 기본 검증선에 포함했습니다.
- `docs/contract/go-node-boundary.md`, `README.md`에서 `GOOGLE_API_KEY`는 Node wrapper local readiness heuristic 전용이고 Go delegate/runtime headless key는 `GEMINI_API_KEY`임을 명확히 했습니다.
- `readVersion()`이 stdout, stderr, empty successful probe를 구분해 Gemini/Codex provider readiness를 오판하지 않도록 했습니다.
- `aco sync --clean-duplicates`가 같은 실행에서 cleaned target을 다시 쓰지 않도록 `plan.outputs`를 정리했습니다.
- skill directory hash에 relative path와 raw bytes를 반영하고, 기존 v2 pre-path hash 및 legacy v1 hash stale cleanup 호환을 유지했습니다.
- directory sync update 시 target을 mirror 복사해 rename/layout 변경 후 삭제된 파일이 `.agents/skills`에 남지 않도록 했습니다.
- OpenSpec change `resolve-review-followups-85`의 proposal/design/spec/tasks를 추가하고 모든 task를 완료 상태로 정리했습니다.
- 원 review thread 11개에 reply를 남기고 resolved 처리했습니다. 재조회 결과 PR #70/#76/#77/#83/#84 모두 unresolved count 0입니다.

## Checklist

- [x] `npm test`
- [x] `npm run typecheck --workspace=packages/wrapper`
- [x] `npm run test:scripts`
- [x] `bash -n scripts/pm-hook.sh scripts/setup-github-labels.sh scripts/setup-github-project.sh scripts/setup-project-ids.sh test/scripts/project-id-validation.test.sh`
- [x] `openspec validate resolve-review-followups-85 --type change --strict`
- [x] `git diff --check`
- [x] `npm exec -- prettier --check package.json .github/workflows/ci.yml packages/wrapper/src/util/read-version.ts packages/wrapper/src/sync/sync-engine.ts packages/wrapper/src/sync/skill-transform.ts packages/wrapper/tests/providers.test.ts packages/wrapper/tests/sync.test.ts`

## Notes

`npx tsx test/fixtures/harness.ts --binary packages/wrapper/dist/cli.js`에서 발견된 skeleton fixture 3건 실패는 별도 issue #86으로 분리했습니다.
