### PR TITLE
fix(wrapper): preserve raw input whitespace and newlines in collectInput

### DIFF
--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -257,7 +257,7 @@ async function collectInput(options: AskOptions): Promise<string> {
     chunks.push(fileInput);
   }
 
-  return chunks.join('\n\n').trim();
+  return chunks.join('\n\n');
 }
 
 async function loadPreset(name: string): Promise<string> {

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -269,6 +269,38 @@ describe('aco ask CLI', () => {
     assert.match(input, /file demo/);
   });
 
+  it('preserves exact raw input including whitespace and newlines', async () => {
+    const home = await makeHome();
+    const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-raw-input-'));
+    const inputContent = '  file content with leading/trailing spaces and newlines  \n\n';
+    await writeFile(join(workspace, 'raw-input.md'), inputContent);
+
+    const result = await runCli(
+      [
+        'ask',
+        '--providers',
+        'mock',
+        '--task',
+        'check raw input',
+        '--input',
+        '  inline content  ',
+        '--input-file',
+        'raw-input.md',
+        '--yes',
+      ],
+      { home, cwd: workspace }
+    );
+
+    assert.equal(result.code, 0);
+    const sessionId = await latestSessionId(home);
+    const sessionDir = join(home, '.aco', 'sessions', sessionId);
+
+    const input = await readFile(join(sessionDir, 'input.md'), 'utf8');
+    // Expected: "  inline content  " + "\n\n" + "  file content with leading/trailing spaces and newlines  \n\n"
+    const expected = '  inline content  \n\n  file content with leading/trailing spaces and newlines  \n\n';
+    assert.equal(input, expected);
+  });
+
   it('saves partial output on provider failure so aco result can inspect it', async () => {
     const failed = await runCli(
       [

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile, spawn } from 'node:child_process';
-import { mkdtemp, readdir, readFile, stat, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -272,33 +272,38 @@ describe('aco ask CLI', () => {
   it('preserves exact raw input including whitespace and newlines', async () => {
     const home = await makeHome();
     const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-raw-input-'));
-    const inputContent = '  file content with leading/trailing spaces and newlines  \n\n';
-    await writeFile(join(workspace, 'raw-input.md'), inputContent);
+    try {
+      const inputContent = '  file content with leading/trailing spaces and newlines  \n\n';
+      await writeFile(join(workspace, 'raw-input.md'), inputContent);
 
-    const result = await runCli(
-      [
-        'ask',
-        '--providers',
-        'mock',
-        '--task',
-        'check raw input',
-        '--input',
-        '  inline content  ',
-        '--input-file',
-        'raw-input.md',
-        '--yes',
-      ],
-      { home, cwd: workspace }
-    );
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'check raw input',
+          '--input',
+          '  inline content  ',
+          '--input-file',
+          'raw-input.md',
+          '--yes',
+        ],
+        { home, cwd: workspace }
+      );
 
-    assert.equal(result.code, 0);
-    const sessionId = await latestSessionId(home);
-    const sessionDir = join(home, '.aco', 'sessions', sessionId);
+      assert.equal(result.code, 0);
+      const sessionId = await latestSessionId(home);
+      const sessionDir = join(home, '.aco', 'sessions', sessionId);
 
-    const input = await readFile(join(sessionDir, 'input.md'), 'utf8');
-    // Expected: "  inline content  " + "\n\n" + "  file content with leading/trailing spaces and newlines  \n\n"
-    const expected = '  inline content  \n\n  file content with leading/trailing spaces and newlines  \n\n';
-    assert.equal(input, expected);
+      const input = await readFile(join(sessionDir, 'input.md'), 'utf8');
+      // Expected: "  inline content  " + "\n\n" + "  file content with leading/trailing spaces and newlines  \n\n"
+      const expected = '  inline content  \n\n  file content with leading/trailing spaces and newlines  \n\n';
+      assert.equal(input, expected);
+    } finally {
+      await rm(home, { recursive: true, force: true });
+      await rm(workspace, { recursive: true, force: true });
+    }
   });
 
   it('saves partial output on provider failure so aco result can inspect it', async () => {


### PR DESCRIPTION
Closes #93

## What

packages/wrapper/src/commands/ask.ts의 collectInput 함수에서 입력값 수집 시 .trim() 호출을 제거하여 사용자가 제공한 원본 텍스트(공백, 개행 포함)를 그대로 보존하도록 수정했습니다. 또한 packages/wrapper/tests/ask-cli.test.ts에 이러한 보존 동작을 검증하는 통합 테스트 케이스를 추가했습니다.

## Why

패치 파일이나 마크다운 등 앞뒤 공백 및 개행이 의미를 가질 수 있는 입력 데이터가 --input이나 --input-file을 통해 전달될 때, 의도치 않게 트리밍되어 데이터의 정확성이 훼손되는 문제를 해결하기 위함입니다. 이는 aco run의 동작 방식과도 일관성을 맞추는 변경입니다.

## Changes

- packages/wrapper/src/commands/ask.ts: chunks.join('\n\n').trim()을 chunks.join('\n\n')으로 변경하여 트리밍 방지.
- packages/wrapper/tests/ask-cli.test.ts: 인라인 입력과 파일 입력의 공백 및 개행이 정확히 유지되는지 확인하는 preserves exact raw input including whitespace and newlines 테스트 추가.

## Checklist

- [x] 관련 테스트 또는 smoke check 통과
- [ ] 동작 변경 시 문서 업데이트 완료 (추가 문서 업데이트 필요 없음)
- [x] Project 상태와 label 확인 완료