### PR TITLE
feat(wrapper): aco ask --output-mode brief에 세션별 결과 요약 포함

### DIFF
--- a/openspec/changes/aco-ask-output-mode-brief/.openspec.yaml
+++ b/openspec/changes/aco-ask-output-mode-brief/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/aco-ask-output-mode-brief/design.md
+++ b/openspec/changes/aco-ask-output-mode-brief/design.md
@@ -1,0 +1,29 @@
+## Context
+
+The `aco ask` MVP introduced different output modes. Specifically, `--output-mode brief` is designed to provide a high-level summary of the provider's execution, minimizing terminal scroll and token usage for orchestration tools. However, currently, the `brief` mode only outputs the session status, the path to the output log, and error messages (if any). It omits the actual text/content of the provider's response, forcing users to manually read the `outputLog` or run `aco result` to understand the result.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Include a bounded summary (first N characters) of the provider's output log in the `brief` output mode so users can get the gist of the response without running an extra command.
+- Apply this enhancement to both the overall run brief (`renderRunBrief`) and the session-specific brief (`renderSessionBrief`).
+- Maintain backward compatibility and not disrupt existing tests for `aco ask`.
+
+**Non-Goals:**
+- Summarizing the output using another AI model (this introduces cost and latency).
+- Modifying the behavior of the `full` output mode.
+
+## Decisions
+
+1. **Extracting Bounded Output Preview:**
+   - We will implement a simple substring extraction mechanism (e.g., `output.substring(0, 1000)`) from the `outputLog`. If the output exceeds the limit, we will append an omission indicator (e.g., `\n... (truncated)`).
+   - *Alternative Considered*: Running a local heuristic or NLP summarization. *Rationale for Rejection*: Too complex, prone to latency, and breaks the "lightweight" constraint of the wrapper. A simple substring is predictable and fast.
+
+2. **Integration points:**
+   - In `renderSessionBrief`, we will use the already available `outputLog` content, extracting the bounded text and appending it under an `Output Preview` section.
+   - In `renderRunBrief`, we will map over each session's `outputLog` and display the preview.
+   - The boundary limit will be hardcoded (e.g., 1000 characters) for simplicity in this MVP iteration.
+
+## Risks / Trade-offs
+
+- [Risk] Truncation might cut off important information like JSON structure or final conclusions located at the end of the log. -> Mitigation: Provide clear instructions in the brief that the output is truncated and point the user to the `outputLog` path for the complete output.

--- a/openspec/changes/aco-ask-output-mode-brief/proposal.md
+++ b/openspec/changes/aco-ask-output-mode-brief/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+현재 `aco ask --output-mode brief` 출력은 provider 상태와 파일 경로만 출력되어, 사용자가 실제 결과를 확인하려면 매번 `aco result`를 추가로 실행해야 하는 번거로움이 있습니다. 이는 토큰을 절약하면서도 핵심 요약을 전달하려는 'bounded brief' MVP의 원래 의도와 부합하지 않습니다. 세션별 outputLog의 핵심 내용을 brief 모드에 포함하여 워크플로우를 개선하고자 합니다.
+
+## What Changes
+
+- `renderRunBrief` 및 `renderSessionBrief` 함수가 세션 outputLog에서 bounded 요약(예: 최초 N바이트 또는 구조화된 상태 요약)을 추출하여 brief 출력에 포함하도록 수정합니다.
+- 토큰을 절약하는 원래 목적을 유지하면서도 사용자에게 필수적인 정보를 전달하는 균형을 맞춥니다.
+- 기존 테스트가 통과하도록 하위 호환성을 유지합니다.
+
+## Capabilities
+
+### New Capabilities
+- `aco-ask-brief-summary`: `aco ask --output-mode brief` 실행 시 세션별 bounded 요약을 포함하여 출력하는 기능.
+
+### Modified Capabilities
+
+## Impact
+
+- `packages/wrapper/src/commands/ask.ts` 파일의 UI 렌더링 로직(`renderRunBrief`, `renderSessionBrief`).
+- CLI 사용자의 경험: `aco ask --output-mode brief` 사용 시 `aco result`를 실행하지 않아도 provider 응답의 주요 내용을 즉시 확인할 수 있습니다.

--- a/openspec/changes/aco-ask-output-mode-brief/specs/aco-ask-brief-summary/spec.md
+++ b/openspec/changes/aco-ask-output-mode-brief/specs/aco-ask-brief-summary/spec.md
@@ -1,0 +1,13 @@
+## ADDED Requirements
+
+### Requirement: Brief Output Preview
+The system SHALL include a preview of the provider's output in the brief mode response (`renderRunBrief` and `renderSessionBrief`), bounded to the first 1000 characters.
+
+#### Scenario: Output is shorter than or equal to the boundary
+- **WHEN** the provider output length is 1000 characters or less
+- **THEN** the system includes the entire output in the brief preview section without any truncation indicator
+
+#### Scenario: Output is longer than the boundary
+- **WHEN** the provider output length exceeds 1000 characters
+- **THEN** the system includes exactly the first 1000 characters in the brief preview section
+- **THEN** the system appends a truncation indicator (e.g., `\n... (truncated)`) after the preview

--- a/openspec/changes/aco-ask-output-mode-brief/tasks.md
+++ b/openspec/changes/aco-ask-output-mode-brief/tasks.md
@@ -1,0 +1,19 @@
+## 1. Output Bounding Helper
+
+- [x] 1.1 Implement bounding logic to truncate output strings to a specified limit (e.g., 1000 characters).
+- [x] 1.2 Ensure a truncation indicator (`\n... (truncated)`) is appended if the output exceeds the boundary.
+
+## 2. Session Brief UI Update
+
+- [x] 2.1 Update `renderSessionBrief` in `packages/wrapper/src/commands/ask.ts` to include an `Output Preview` section.
+- [x] 2.2 Append the bounded preview of `outputLog` inside `renderSessionBrief`.
+
+## 3. Run Brief UI Update
+
+- [x] 3.1 Update `renderRunBrief` in `packages/wrapper/src/commands/ask.ts` to include bounded previews for each session.
+- [x] 3.2 Ensure the previews are correctly formatted within the overall run brief output.
+
+## 4. Tests & Validation
+
+- [x] 4.1 Validate changes with TypeScript and test suite (`npm run typecheck`, `npm test`).
+- [x] 4.2 Run a manual smoke test with `aco ask --output-mode brief` to visually confirm the summary extraction and truncation indicator.

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { createWriteStream, existsSync, readFileSync } from 'node:fs';
+import { closeSync, createWriteStream, existsSync, openSync, readSync, statSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -74,6 +74,7 @@ export async function cmdAsk(args: string[]): Promise<void> {
   await mkdir(runDir, { recursive: true, mode: 0o700 });
 
   const sessions: AskSessionLedger[] = [];
+  const outputPreviews: Record<string, string> = {};
   for (const provider of providers) {
     const session = await sessionStore.create(
       provider.key,
@@ -127,7 +128,8 @@ export async function cmdAsk(args: string[]): Promise<void> {
 
     let outputPreview: string | undefined;
     if (existsSync(outputLog)) {
-      outputPreview = truncateOutput(readFileSync(outputLog, 'utf8'));
+      outputPreview = readBoundedOutput(outputLog, 1000);
+      outputPreviews[session.id] = outputPreview;
     }
 
     const brief = renderSessionBrief({
@@ -151,13 +153,6 @@ export async function cmdAsk(args: string[]): Promise<void> {
       briefPath,
       ...(error ? { error } : {}),
     });
-  }
-
-  const outputPreviews: Record<string, string> = {};
-  for (const session of sessions) {
-    if (existsSync(session.outputLog)) {
-      outputPreviews[session.id] = truncateOutput(readFileSync(session.outputLog, 'utf8'));
-    }
   }
 
   const runBrief = renderRunBrief(runId, options, sessions, outputPreviews);
@@ -346,7 +341,12 @@ function renderSessionBrief(input: {
     .join('\n');
 }
 
-function renderRunBrief(runId: string, options: AskOptions, sessions: AskSessionLedger[], outputPreviews?: Record<string, string>): string {
+function renderRunBrief(
+  runId: string,
+  options: AskOptions,
+  sessions: AskSessionLedger[],
+  outputPreviews?: Record<string, string>
+): string {
   return [
     '# aco ask brief',
     '',
@@ -364,7 +364,9 @@ function renderRunBrief(runId: string, options: AskOptions, sessions: AskSession
       `Status: ${session.status}`,
       `Full output saved: ${session.outputLog}`,
       session.error ? `Error: ${session.error}` : undefined,
-      outputPreviews && outputPreviews[session.id] ? `\nOutput Preview:\n---\n${outputPreviews[session.id]}\n---` : undefined,
+      outputPreviews && outputPreviews[session.id]
+        ? `\nOutput Preview:\n---\n${outputPreviews[session.id]}\n---`
+        : undefined,
       '',
     ]),
   ]
@@ -405,9 +407,35 @@ async function endWritable(stream: Writable): Promise<void> {
   });
 }
 
-function truncateOutput(output: string, limit: number = 1000): string {
-  if (output.length <= limit) return output;
-  return output.substring(0, limit) + '\n... (truncated)';
+function readBoundedOutput(path: string, limit: number = 1000): string {
+  try {
+    const stats = statSync(path);
+    if (stats.size <= limit) {
+      const fd = openSync(path, 'r');
+      try {
+        const buffer = Buffer.alloc(stats.size);
+        readSync(fd, buffer, 0, stats.size, 0);
+        return buffer.toString('utf8');
+      } finally {
+        closeSync(fd);
+      }
+    }
+    const fd = openSync(path, 'r');
+    try {
+      const UTF8_MAX_BYTES = 4;
+      const buffer = Buffer.alloc(limit * UTF8_MAX_BYTES + UTF8_MAX_BYTES);
+      const bytesRead = readSync(fd, buffer, 0, limit * UTF8_MAX_BYTES + UTF8_MAX_BYTES, 0);
+      let content = buffer.toString('utf8', 0, bytesRead);
+      if (content.length > limit) {
+        content = content.substring(0, limit);
+      }
+      return content + '\n... (truncated)';
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return '';
+  }
 }
 
 function fail(message: string): never {

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -410,26 +410,18 @@ async function endWritable(stream: Writable): Promise<void> {
 function readBoundedOutput(path: string, limit: number = 1000): string {
   try {
     const stats = statSync(path);
-    if (stats.size <= limit) {
-      const fd = openSync(path, 'r');
-      try {
-        const buffer = Buffer.alloc(stats.size);
-        readSync(fd, buffer, 0, stats.size, 0);
-        return buffer.toString('utf8');
-      } finally {
-        closeSync(fd);
-      }
-    }
+    const UTF8_MAX_BYTES = 4;
+    const maxPreviewBytes = Math.min(stats.size, limit * UTF8_MAX_BYTES + UTF8_MAX_BYTES);
     const fd = openSync(path, 'r');
     try {
-      const UTF8_MAX_BYTES = 4;
-      const buffer = Buffer.alloc(limit * UTF8_MAX_BYTES + UTF8_MAX_BYTES);
-      const bytesRead = readSync(fd, buffer, 0, limit * UTF8_MAX_BYTES + UTF8_MAX_BYTES, 0);
-      let content = buffer.toString('utf8', 0, bytesRead);
-      if (content.length > limit) {
-        content = content.substring(0, limit);
+      const buffer = Buffer.alloc(maxPreviewBytes);
+      const bytesRead = readSync(fd, buffer, 0, maxPreviewBytes, 0);
+      const content = buffer.toString('utf8', 0, bytesRead);
+      const characters = Array.from(content);
+      if (characters.length > limit) {
+        return characters.slice(0, limit).join('') + '\n... (truncated)';
       }
-      return content + '\n... (truncated)';
+      return bytesRead < stats.size ? `${content}\n... (truncated)` : content;
     } finally {
       closeSync(fd);
     }

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { createWriteStream, existsSync } from 'node:fs';
+import { createWriteStream, existsSync, readFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -125,6 +125,11 @@ export async function cmdAsk(args: string[]): Promise<void> {
       await endWritable(outputStream);
     }
 
+    let outputPreview: string | undefined;
+    if (existsSync(outputLog)) {
+      outputPreview = truncateOutput(readFileSync(outputLog, 'utf8'));
+    }
+
     const brief = renderSessionBrief({
       runId,
       task: options.task ?? '',
@@ -133,6 +138,7 @@ export async function cmdAsk(args: string[]): Promise<void> {
       outputLog,
       status,
       error,
+      outputPreview,
     });
     const briefPath = join(sessionDir, 'brief.md');
     await writeFile(briefPath, brief, { mode: 0o600 });
@@ -147,7 +153,14 @@ export async function cmdAsk(args: string[]): Promise<void> {
     });
   }
 
-  const runBrief = renderRunBrief(runId, options, sessions);
+  const outputPreviews: Record<string, string> = {};
+  for (const session of sessions) {
+    if (existsSync(session.outputLog)) {
+      outputPreviews[session.id] = truncateOutput(readFileSync(session.outputLog, 'utf8'));
+    }
+  }
+
+  const runBrief = renderRunBrief(runId, options, sessions, outputPreviews);
   await writeFile(join(runDir, 'brief.md'), runBrief, { mode: 0o600 });
   await writeFile(
     join(runDir, 'ledger.json'),
@@ -313,6 +326,7 @@ function renderSessionBrief(input: {
   outputLog: string;
   status: AskSessionLedger['status'];
   error?: string;
+  outputPreview?: string;
 }): string {
   return [
     '# aco ask session brief',
@@ -325,13 +339,14 @@ function renderSessionBrief(input: {
     '',
     `Advisory: ${ADVISORY_NOTICE}`,
     input.error ? `Error: ${input.error}` : undefined,
+    input.outputPreview ? `\nOutput Preview:\n---\n${input.outputPreview}\n---` : undefined,
     '',
   ]
     .filter((line): line is string => line !== undefined)
     .join('\n');
 }
 
-function renderRunBrief(runId: string, options: AskOptions, sessions: AskSessionLedger[]): string {
+function renderRunBrief(runId: string, options: AskOptions, sessions: AskSessionLedger[], outputPreviews?: Record<string, string>): string {
   return [
     '# aco ask brief',
     '',
@@ -349,6 +364,7 @@ function renderRunBrief(runId: string, options: AskOptions, sessions: AskSession
       `Status: ${session.status}`,
       `Full output saved: ${session.outputLog}`,
       session.error ? `Error: ${session.error}` : undefined,
+      outputPreviews && outputPreviews[session.id] ? `\nOutput Preview:\n---\n${outputPreviews[session.id]}\n---` : undefined,
       '',
     ]),
   ]
@@ -387,6 +403,11 @@ async function endWritable(stream: Writable): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     stream.end((err?: Error | null) => (err ? reject(err) : resolve()));
   });
+}
+
+function truncateOutput(output: string, limit: number = 1000): string {
+  if (output.length <= limit) return output;
+  return output.substring(0, limit) + '\n... (truncated)';
 }
 
 function fail(message: string): never {

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -165,7 +165,7 @@ describe('aco ask CLI', () => {
     assert.match(result.stdout, /Run:/);
     assert.match(result.stdout, /Session:/);
     assert.match(result.stdout, /Full output saved/);
-    assert.doesNotMatch(result.stdout, /Findings:/);
+    assert.match(result.stdout, /Findings:/);
 
     const sessionId = await latestSessionId(result.home);
     const sessionDir = join(result.home, '.aco', 'sessions', sessionId);

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -194,6 +194,26 @@ describe('aco ask CLI', () => {
     await stat(join(runDir, 'brief.md'));
   });
 
+  it('does not mark multibyte brief output as truncated when it is within the character limit', async () => {
+    const multibyteInput = '가'.repeat(300);
+    const result = await runCli([
+      'ask',
+      '--providers',
+      'mock',
+      '--task',
+      'review multibyte output',
+      '--input',
+      multibyteInput,
+      '--yes',
+      '--output-mode',
+      'brief',
+    ]);
+
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout.includes(multibyteInput), true);
+    assert.doesNotMatch(result.stdout, /\.\.\. \(truncated\)/);
+  });
+
   it('supports save-only and full output modes explicitly', async () => {
     const saveOnly = await runCli([
       'ask',


### PR DESCRIPTION
Closes #94

## What

`aco ask --output-mode brief`의 출력에 세션별 결과 요약(최대 1000자)을 추가했습니다.
기존에는 상태와 저장 경로만 표시되었으나, 이제 실제 응답의 주요 내용을 `Output Preview` 섹션을 통해 확인할 수 있습니다.

## Why

사용자가 brief 모드의 간결한 출력을 확인한 후에도 실제 결과를 보기 위해 번거롭게 `aco result`를 추가 실행해야 하는 문제점을 해결하고자 했습니다.
토큰 절약이라는 본래 목적은 살리되 워크플로우 경험을 개선했습니다.

## Changes

- `packages/wrapper/src/commands/ask.ts`의 `renderSessionBrief`, `renderRunBrief` 함수 업데이트로 `Output Preview` 섹션 추가
- 출력 문자열을 지정된 제한(1000자)으로 자르고 생략 기호를 추가하는 `truncateOutput` 헬퍼 구현
- 변경된 동작을 검증하기 위한 `tests/ask-cli.test.ts` 테스트 케이스 수정
- `openspec/changes/aco-ask-output-mode-brief/`에 OpenSpec 구현 명세 추가

## Checklist

- [x] 관련 테스트 또는 smoke check 통과
- [x] 동작 변경 시 문서 업데이트 완료
- [x] Project 상태와 label 확인 완료
