### PR TITLE
fix(wrapper): backport consent-gated ask summary + tee deadlock follow-ups

### DIFF
--- a/.agents/skills/github-kanban-ops/SKILL.md
+++ b/.agents/skills/github-kanban-ops/SKILL.md
@@ -191,12 +191,15 @@ Use this workflow when the user asks Codex to triage unresolved PR review thread
 3. Fetch unresolved review threads using GitHub MCP tools or `gh api graphql`.
 4. Categorize each unresolved thread as an immediate fix, deferred issue, or needs user decision.
 5. For immediate fixes, make the local code change, reply with a concise fix summary, and resolve the thread only when the user asked Codex to handle review follow-up.
-6. For deferred issues, use only `task`, `bug`, or `chore`; never create an `epic` from a review thread without separate user instruction.
-7. Generate each deferred issue body with `.agents/skills/github-kanban-ops/scripts/make_issue_body.py`, including the review comment, affected path or line, deferred scope, acceptance criteria, and PR reference in `Notes`.
-8. Create each deferred issue with `type:<type>`, `origin:review`, and optional `area:*` labels only.
-9. Add deferred issues to the active Project, set `Status=Backlog`, and set assessed `Priority` when confidence is sufficient.
-10. If priority confidence is too low, leave `Priority` unset and report `Priority unset for deferred issue — triage needed`.
-11. Report resolved threads, deferred issue URLs, Project status and Priority results, review replies, and warnings.
+6. Preserve review traceability for immediate fixes: commit review follow-up changes as new commits on top of the reviewed PR head, then push with a normal fast-forward `git push`.
+7. Do not amend, rebase, squash, force-push, or use `--force-with-lease` during `/gh-pr-followup` unless the user explicitly asks for branch-history repair.
+8. If explicit branch-history repair requires a non-fast-forward push, report the before and after head SHAs and why the repair was needed.
+9. For deferred issues, use only `task`, `bug`, or `chore`; never create an `epic` from a review thread without separate user instruction.
+10. Generate each deferred issue body with `.agents/skills/github-kanban-ops/scripts/make_issue_body.py`, including the review comment, affected path or line, deferred scope, acceptance criteria, and PR reference in `Notes`.
+11. Create each deferred issue with `type:<type>`, `origin:review`, and optional `area:*` labels only.
+12. Add deferred issues to the active Project, set `Status=Backlog`, and set assessed `Priority` when confidence is sufficient.
+13. If priority confidence is too low, leave `Priority` unset and report `Priority unset for deferred issue — triage needed`.
+14. Report resolved threads, deferred issue URLs, Project status and Priority results, review replies, and warnings.
 
 ### Plan or Triage
 

--- a/.claude/skills/github-kanban-ops/SKILL.md
+++ b/.claude/skills/github-kanban-ops/SKILL.md
@@ -191,12 +191,15 @@ Use this workflow when the user asks Codex to triage unresolved PR review thread
 3. Fetch unresolved review threads using GitHub MCP tools or `gh api graphql`.
 4. Categorize each unresolved thread as an immediate fix, deferred issue, or needs user decision.
 5. For immediate fixes, make the local code change, reply with a concise fix summary, and resolve the thread only when the user asked Codex to handle review follow-up.
-6. For deferred issues, use only `task`, `bug`, or `chore`; never create an `epic` from a review thread without separate user instruction.
-7. Generate each deferred issue body with `.agents/skills/github-kanban-ops/scripts/make_issue_body.py`, including the review comment, affected path or line, deferred scope, acceptance criteria, and PR reference in `Notes`.
-8. Create each deferred issue with `type:<type>`, `origin:review`, and optional `area:*` labels only.
-9. Add deferred issues to the active Project, set `Status=Backlog`, and set assessed `Priority` when confidence is sufficient.
-10. If priority confidence is too low, leave `Priority` unset and report `Priority unset for deferred issue — triage needed`.
-11. Report resolved threads, deferred issue URLs, Project status and Priority results, review replies, and warnings.
+6. Preserve review traceability for immediate fixes: commit review follow-up changes as new commits on top of the reviewed PR head, then push with a normal fast-forward `git push`.
+7. Do not amend, rebase, squash, force-push, or use `--force-with-lease` during `/gh-pr-followup` unless the user explicitly asks for branch-history repair.
+8. If explicit branch-history repair requires a non-fast-forward push, report the before and after head SHAs and why the repair was needed.
+9. For deferred issues, use only `task`, `bug`, or `chore`; never create an `epic` from a review thread without separate user instruction.
+10. Generate each deferred issue body with `.agents/skills/github-kanban-ops/scripts/make_issue_body.py`, including the review comment, affected path or line, deferred scope, acceptance criteria, and PR reference in `Notes`.
+11. Create each deferred issue with `type:<type>`, `origin:review`, and optional `area:*` labels only.
+12. Add deferred issues to the active Project, set `Status=Backlog`, and set assessed `Priority` when confidence is sufficient.
+13. If priority confidence is too low, leave `Priority` unset and report `Priority unset for deferred issue — triage needed`.
+14. Report resolved threads, deferred issue URLs, Project status and Priority results, review replies, and warnings.
 
 ### Plan or Triage
 

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -1,19 +1,21 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { closeSync, createWriteStream, existsSync, openSync, readSync, statSync } from 'node:fs';
+import { createWriteStream, existsSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
-import type { Writable } from 'node:stream';
 import { providerRegistry } from '../providers/registry.js';
 import { sessionStore } from '../session/store.js';
 import type { OutputBufferPolicy, PermissionProfile } from '../providers/interface.js';
+import { invokeProviderForSession } from '../runtime/provider-session-runner.js';
+import { defaultSummarizeOutput } from '../util/summarize-output.js';
 
 const EXIT_ERROR = 1;
 const DEFAULT_PROVIDERS = ['mock'];
 const VALID_PERMISSION_PROFILES: PermissionProfile[] = ['default', 'restricted', 'unrestricted'];
 const VALID_OUTPUT_MODES = ['brief', 'save-only', 'full'] as const;
 const VALID_PRESET_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const SUMMARY_CHAR_LIMIT = 600;
 const ADVISORY_NOTICE =
   'External provider output is advisory. Claude Code remains the supervisor and final synthesizer.';
 
@@ -44,6 +46,7 @@ interface AskSessionLedger {
   status: 'done' | 'failed' | 'cancelled';
   outputLog: string;
   briefPath: string;
+  summary: string;
   error?: string;
 }
 
@@ -81,7 +84,6 @@ export async function cmdAsk(args: string[]): Promise<void> {
   await mkdir(runDir, { recursive: true, mode: 0o700 });
 
   const sessions: AskSessionLedger[] = [];
-  const outputPreviews: Record<string, string> = {};
   for (const provider of providers) {
     const session = await sessionStore.create(
       provider.key,
@@ -101,21 +103,25 @@ export async function cmdAsk(args: string[]): Promise<void> {
     }
     let error: string | undefined;
     let status: AskSessionLedger['status'] = 'done';
-    try {
-      for await (const chunk of provider.invoke('ask', prompt, input, {
-        permissionProfile: options.permissionProfile,
-        sessionId: session.id,
-        outputBuffer,
-        onPid: (pid) => {
-          sessionStore.update(session.id, { pid }).catch(() => undefined);
-        },
-      })) {
-        await writeChunk(outputStream, chunk);
-        if (options.outputMode === 'full') {
-          process.stdout.write(chunk);
-        }
-      }
+    const runResult = await invokeProviderForSession({
+      provider,
+      command: 'ask',
+      prompt,
+      content: input,
+      permissionProfile: options.permissionProfile,
+      sessionId: session.id,
+      output: outputStream,
+      outputBuffer,
+      maxOutputBuffer: SUMMARY_CHAR_LIMIT,
+      onChunk:
+        options.outputMode === 'full'
+          ? (chunk) => {
+              process.stdout.write(chunk);
+            }
+          : undefined,
+    });
 
+    if (!runResult.error) {
       const latest = await sessionStore.read(session.id);
       if (latest.status === 'cancelled') {
         status = 'cancelled';
@@ -124,7 +130,8 @@ export async function cmdAsk(args: string[]): Promise<void> {
       } else {
         await sessionStore.markDone(session.id);
       }
-    } catch (err) {
+    } else {
+      const err = runResult.error;
       error = err instanceof Error ? err.message : String(err);
       await writeFile(sessionStore.errorLogPath(session.id), `${error}\n`, { mode: 0o600 });
       const latest = await sessionStore.read(session.id).catch(() => undefined);
@@ -134,23 +141,9 @@ export async function cmdAsk(args: string[]): Promise<void> {
         status = 'failed';
         await sessionStore.markFailed(session.id);
       }
-    } finally {
-      await endWritable(outputStream);
     }
 
-    let outputPreview: string | undefined;
-    if (outputBuffer.mode === 'bounded' && outputBuffer.snapshot) {
-      outputPreview = trimOutputForPreview(outputBuffer.snapshot.value, 1000);
-    }
-
-    if (!outputPreview && existsSync(outputLog)) {
-      outputPreview = readBoundedOutput(outputLog, 1000);
-    }
-
-    if (outputPreview) {
-      outputPreviews[session.id] = outputPreview;
-    }
-
+    const summary = summarizeProviderOutput(runResult.fullOutput, provider);
     const brief = renderSessionBrief({
       runId,
       task: options.task ?? '',
@@ -158,8 +151,8 @@ export async function cmdAsk(args: string[]): Promise<void> {
       sessionId: session.id,
       outputLog,
       status,
+      summary,
       error,
-      outputPreview,
     });
     const briefPath = join(sessionDir, 'brief.md');
     await writeFile(briefPath, brief, { mode: 0o600 });
@@ -170,11 +163,12 @@ export async function cmdAsk(args: string[]): Promise<void> {
       status,
       outputLog,
       briefPath,
+      summary,
       ...(error ? { error } : {}),
     });
   }
 
-  const runBrief = renderRunBrief(runId, options, sessions, outputPreviews);
+  const runBrief = renderRunBrief(runId, options, sessions);
   await writeFile(join(runDir, 'brief.md'), runBrief, { mode: 0o600 });
   await writeFile(
     join(runDir, 'ledger.json'),
@@ -339,8 +333,8 @@ function renderSessionBrief(input: {
   sessionId: string;
   outputLog: string;
   status: AskSessionLedger['status'];
+  summary: string;
   error?: string;
-  outputPreview?: string;
 }): string {
   return [
     '# aco ask session brief',
@@ -350,22 +344,18 @@ function renderSessionBrief(input: {
     `Session: ${input.sessionId}`,
     `Status: ${input.status}`,
     `Full output saved: ${input.outputLog}`,
+    `Summary:`,
+    input.summary,
     '',
     `Advisory: ${ADVISORY_NOTICE}`,
     input.error ? `Error: ${input.error}` : undefined,
-    input.outputPreview ? `\nOutput Preview:\n---\n${input.outputPreview}\n---` : undefined,
     '',
   ]
     .filter((line): line is string => line !== undefined)
     .join('\n');
 }
 
-function renderRunBrief(
-  runId: string,
-  options: AskOptions,
-  sessions: AskSessionLedger[],
-  outputPreviews?: Record<string, string>
-): string {
+function renderRunBrief(runId: string, options: AskOptions, sessions: AskSessionLedger[]): string {
   return [
     '# aco ask brief',
     '',
@@ -382,15 +372,26 @@ function renderRunBrief(
       `Session: ${session.id}`,
       `Status: ${session.status}`,
       `Full output saved: ${session.outputLog}`,
+      `Summary:`,
+      session.summary,
       session.error ? `Error: ${session.error}` : undefined,
-      outputPreviews && outputPreviews[session.id]
-        ? `\nOutput Preview:\n---\n${outputPreviews[session.id]}\n---`
-        : undefined,
       '',
     ]),
   ]
     .filter((line): line is string => line !== undefined)
     .join('\n');
+}
+
+function summarizeProviderOutput(
+  output: string,
+  provider: import('../providers/interface.js').IProvider
+): string {
+  if (provider.summarizeOutput) {
+    return provider.summarizeOutput(output, SUMMARY_CHAR_LIMIT);
+  }
+  // Fallback for providers that have not yet implemented summarizeOutput.
+  // All built-in providers should implement this; the fallback is a safety net.
+  return defaultSummarizeOutput(output, SUMMARY_CHAR_LIMIT);
 }
 
 function parseFlag<T extends string = string>(args: string[], flag: string): T | undefined {
@@ -410,53 +411,9 @@ Options:
   --preset <name>                 .claude/aco/tasks/<name>.md
   --permission-profile <profile>  restricted|default|unrestricted (default: restricted)
   --output-mode <mode>            brief|save-only|full (default: brief)
+                                    brief summary bound: ${SUMMARY_CHAR_LIMIT} chars
   --dry-run                       Print execution plan without invoking providers
   --yes                           Explicitly consent to provider execution`);
-}
-
-async function writeChunk(stream: Writable, chunk: string): Promise<void> {
-  if (stream.write(chunk)) return;
-  await new Promise<void>((resolve) => stream.once('drain', resolve));
-}
-
-async function endWritable(stream: Writable): Promise<void> {
-  if (stream.writableEnded || stream.destroyed) return;
-  await new Promise<void>((resolve, reject) => {
-    stream.end((err?: Error | null) => (err ? reject(err) : resolve()));
-  });
-}
-
-function trimOutputForPreview(output: string, maxCharacters: number): string {
-  const wasPreTrimmed = output.length > maxCharacters * 2;
-  const previewSource = wasPreTrimmed ? output.slice(0, maxCharacters * 2) : output;
-  const characters = Array.from(previewSource);
-  if (characters.length > maxCharacters || wasPreTrimmed) {
-    return `${characters.slice(0, maxCharacters).join('')}\n... (truncated)`;
-  }
-  return output;
-}
-
-function readBoundedOutput(path: string, limit: number = 1000): string {
-  try {
-    const stats = statSync(path);
-    const UTF8_MAX_BYTES = 4;
-    const maxPreviewBytes = Math.min(stats.size, limit * UTF8_MAX_BYTES + UTF8_MAX_BYTES);
-    const fd = openSync(path, 'r');
-    try {
-      const buffer = Buffer.alloc(maxPreviewBytes);
-      const bytesRead = readSync(fd, buffer, 0, maxPreviewBytes, 0);
-      const content = buffer.toString('utf8', 0, bytesRead);
-      const characters = Array.from(content);
-      if (characters.length > limit) {
-        return characters.slice(0, limit).join('') + '\n... (truncated)';
-      }
-      return bytesRead < stats.size ? `${content}\n... (truncated)` : content;
-    } finally {
-      closeSync(fd);
-    }
-  } catch {
-    return '';
-  }
 }
 
 function fail(message: string): never {

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -16,6 +16,7 @@ const VALID_PERMISSION_PROFILES: PermissionProfile[] = ['default', 'restricted',
 const VALID_OUTPUT_MODES = ['brief', 'save-only', 'full'] as const;
 const VALID_PRESET_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
 const SUMMARY_CHAR_LIMIT = 600;
+const SUMMARY_SOURCE_CHAR_LIMIT = 16 * 1024;
 const ADVISORY_NOTICE =
   'External provider output is advisory. Claude Code remains the supervisor and final synthesizer.';
 
@@ -112,7 +113,7 @@ export async function cmdAsk(args: string[]): Promise<void> {
       sessionId: session.id,
       output: outputStream,
       outputBuffer,
-      maxOutputBuffer: SUMMARY_CHAR_LIMIT,
+      maxOutputBuffer: SUMMARY_SOURCE_CHAR_LIMIT,
       onChunk:
         options.outputMode === 'full'
           ? (chunk) => {

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -29,6 +29,8 @@ export interface ProviderSessionRunResult {
   error?: unknown;
 }
 
+const OMITTED_OUTPUT_MARKER = '\n...[output omitted]...\n';
+
 export async function invokeProviderForSession(
   options: ProviderSessionRunOptions
 ): Promise<ProviderSessionRunResult> {
@@ -42,7 +44,7 @@ export async function invokeProviderForSession(
         MAX_OUTPUT_BUFFER_BYTES
       )
     : 0;
-  let fullOutput = '';
+  const outputCapture = maxBuffer > 0 ? createBoundedOutputCapture(maxBuffer) : undefined;
   let hasOutput = false;
   let error: unknown;
 
@@ -66,12 +68,7 @@ export async function invokeProviderForSession(
       }
     )) {
       await writeChunk(options.output, chunk);
-      if (maxBuffer > 0 && fullOutput.length < maxBuffer) {
-        fullOutput += chunk;
-        if (fullOutput.length > maxBuffer) {
-          fullOutput = fullOutput.slice(0, maxBuffer);
-        }
-      }
+      outputCapture?.append(chunk);
       hasOutput = true;
       await options.onChunk?.(chunk);
     }
@@ -81,15 +78,10 @@ export async function invokeProviderForSession(
     await endWritable(options.output);
   }
 
-  return { fullOutput, hasOutput, ...(error ? { error } : {}) };
+  return { fullOutput: outputCapture?.value() ?? '', hasOutput, ...(error ? { error } : {}) };
 }
 
 async function writeChunk(stream: Writable, chunk: string): Promise<void> {
-  if ((stream as { skipDrainWait?: boolean }).skipDrainWait) {
-    stream.write(chunk);
-    return;
-  }
-
   if (stream.write(chunk)) return;
   await new Promise<void>((resolve) => stream.once('drain', resolve));
 }
@@ -99,4 +91,37 @@ async function endWritable(stream: Writable): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     stream.end((err?: Error | null) => (err ? reject(err) : resolve()));
   });
+}
+
+function createBoundedOutputCapture(maxBuffer: number): {
+  append(chunk: string): void;
+  value(): string;
+} {
+  let head = '';
+  let tail = '';
+  let totalLength = 0;
+
+  return {
+    append(chunk: string): void {
+      totalLength += chunk.length;
+      if (head.length < maxBuffer) {
+        head += chunk.slice(0, maxBuffer - head.length);
+      }
+
+      tail += chunk;
+      if (tail.length > maxBuffer) {
+        tail = tail.slice(tail.length - maxBuffer);
+      }
+    },
+    value(): string {
+      if (totalLength <= maxBuffer) return head;
+
+      const marker = OMITTED_OUTPUT_MARKER.slice(0, maxBuffer);
+      const available = Math.max(0, maxBuffer - marker.length);
+      const headLength = Math.ceil(available / 2);
+      const tailLength = available - headLength;
+
+      return `${head.slice(0, headLength)}${marker}${tail.slice(tail.length - tailLength)}`;
+    },
+  };
 }

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -34,13 +34,14 @@ export async function invokeProviderForSession(
 ): Promise<ProviderSessionRunResult> {
   const outputBuffer = options.outputBuffer ?? { mode: 'stream-only' };
   const outputBufferMode = outputBuffer.mode ?? 'stream-only';
-  const maxBuffer =
-    outputBufferMode === 'bounded'
-      ? Math.min(
-          options.maxOutputBuffer ?? outputBuffer.maxBytes ?? DEFAULT_OUTPUT_BUFFER_BYTES,
-          MAX_OUTPUT_BUFFER_BYTES
-        )
-      : 0;
+  const shouldCaptureOutput =
+    options.maxOutputBuffer !== undefined || outputBufferMode === 'bounded';
+  const maxBuffer = shouldCaptureOutput
+    ? Math.min(
+        options.maxOutputBuffer ?? outputBuffer.maxBytes ?? DEFAULT_OUTPUT_BUFFER_BYTES,
+        MAX_OUTPUT_BUFFER_BYTES
+      )
+    : 0;
   let fullOutput = '';
   let hasOutput = false;
   let error: unknown;

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -84,6 +84,11 @@ export async function invokeProviderForSession(
 }
 
 async function writeChunk(stream: Writable, chunk: string): Promise<void> {
+  if ((stream as { skipDrainWait?: boolean }).skipDrainWait) {
+    stream.write(chunk);
+    return;
+  }
+
   if (stream.write(chunk)) return;
   await new Promise<void>((resolve) => stream.once('drain', resolve));
 }

--- a/packages/wrapper/src/session/store.ts
+++ b/packages/wrapper/src/session/store.ts
@@ -136,6 +136,7 @@ export class SessionStore {
         fileStream.end(cb);
       },
     });
+    (tee as { skipDrainWait?: boolean }).skipDrainWait = true;
 
     return tee;
   }

--- a/packages/wrapper/src/session/store.ts
+++ b/packages/wrapper/src/session/store.ts
@@ -3,7 +3,7 @@ import { existsSync, createWriteStream, readdirSync, readFileSync } from 'node:f
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
-import { Transform, type Writable } from 'node:stream';
+import { Writable } from 'node:stream';
 import type { RuntimeContext } from '../runtime/types.js';
 
 export type SessionStatus = 'running' | 'done' | 'failed' | 'cancelled';
@@ -125,21 +125,24 @@ export class SessionStore {
     const logPath = this.outputLogPath(id);
     const fileStream = createWriteStream(logPath, { flags: 'a', mode: 0o600 });
 
-    const tee = new Transform({
-      transform(chunk: Buffer, _enc: string, cb: () => void) {
-        process.stdout.write(chunk);
-        fileStream.write(chunk);
-        this.push(chunk);
-        cb();
+    return new Writable({
+      write(chunk: Buffer, _enc: string, cb: (error?: Error | null) => void) {
+        Promise.all([writeSink(process.stdout, chunk), writeSink(fileStream, chunk)]).then(
+          () => cb(),
+          (err: unknown) => cb(err instanceof Error ? err : new Error(String(err)))
+        );
       },
-      flush(cb: () => void) {
+      final(cb: (error?: Error | null) => void) {
         fileStream.end(cb);
       },
     });
-    (tee as { skipDrainWait?: boolean }).skipDrainWait = true;
-
-    return tee;
   }
 }
 
 export const sessionStore = new SessionStore();
+
+function writeSink(stream: Writable, chunk: Buffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    stream.write(chunk, (err?: Error | null) => (err ? reject(err) : resolve()));
+  });
+}

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -419,6 +419,12 @@ describe('aco ask CLI', () => {
     assert.doesNotMatch(saveOnly.stdout, /Brief/);
     assert.doesNotMatch(saveOnly.stdout, /Summary:/);
     assert.doesNotMatch(saveOnly.stdout, /Findings:/);
+    const saveOnlyRunId = await latestRunId(saveOnly.home);
+    const saveOnlyLedger = JSON.parse(
+      await readFile(join(saveOnly.home, '.aco', 'runs', saveOnlyRunId, 'ledger.json'), 'utf8')
+    );
+    assert.match(saveOnlyLedger.sessions[0].summary, /Provider: mock/);
+    assert.doesNotMatch(saveOnlyLedger.sessions[0].summary, /\(no provider output\)/);
 
     const full = await runCli([
       'ask',
@@ -436,6 +442,12 @@ describe('aco ask CLI', () => {
     assert.equal(full.code, 0);
     assert.match(full.stdout, /Provider: mock/);
     assert.match(full.stdout, /Findings:/);
+    const fullRunId = await latestRunId(full.home);
+    const fullLedger = JSON.parse(
+      await readFile(join(full.home, '.aco', 'runs', fullRunId, 'ledger.json'), 'utf8')
+    );
+    assert.match(fullLedger.sessions[0].summary, /Provider: mock/);
+    assert.doesNotMatch(fullLedger.sessions[0].summary, /\(no provider output\)/);
   });
 
   it('loads presets and input files into saved artifacts', async () => {
@@ -606,7 +618,7 @@ describe('aco ask CLI', () => {
     assert.match(badPreset.stderr, /Invalid --preset/);
   });
 
-  it('keeps fullOutput empty in stream-only mode even when maxOutputBuffer is set', async () => {
+  it('captures bounded fullOutput for summaries when maxOutputBuffer is set', async () => {
     const provider = new MockProvider();
     const output = new Writable({
       write(_chunk, _encoding, callback) {
@@ -626,7 +638,7 @@ describe('aco ask CLI', () => {
     });
 
     assert.ok(runResult.hasOutput);
-    assert.equal(runResult.fullOutput, '');
+    assert.equal(runResult.fullOutput.length, 600);
   });
 
   it('caps fullOutput in runResult when bounded output buffering is set', async () => {

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -1,10 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFile, spawn } from 'node:child_process';
-import { mkdtemp, readdir, readFile, rm, stat, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, stat, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { Writable } from 'node:stream';
+import { invokeProviderForSession } from '../src/runtime/provider-session-runner';
+import { MockProvider } from '../src/providers/mock';
 
 interface CliResult {
   code: number | null;
@@ -165,7 +168,7 @@ describe('aco ask CLI', () => {
     assert.match(result.stdout, /Run:/);
     assert.match(result.stdout, /Session:/);
     assert.match(result.stdout, /Full output saved/);
-    assert.match(result.stdout, /Findings:/);
+    assert.doesNotMatch(result.stdout, /Findings:/);
 
     const sessionId = await latestSessionId(result.home);
     const sessionDir = join(result.home, '.aco', 'sessions', sessionId);
@@ -194,24 +197,170 @@ describe('aco ask CLI', () => {
     await stat(join(runDir, 'brief.md'));
   });
 
-  it('does not mark multibyte brief output as truncated when it is within the character limit', async () => {
-    const multibyteInput = '가'.repeat(300);
+  it('preserves raw inline input including leading spaces and trailing newline', async () => {
+    const rawInput = '  leading spaces stay\ntrailing newline stays\n';
+
     const result = await runCli([
       'ask',
       '--providers',
       'mock',
       '--task',
-      'review multibyte output',
+      'preserve raw inline input',
       '--input',
-      multibyteInput,
+      rawInput,
+      '--yes',
+      '--output-mode',
+      'save-only',
+    ]);
+
+    assert.equal(result.code, 0);
+    const sessionId = await latestSessionId(result.home);
+    const savedInput = await readFile(
+      join(result.home, '.aco', 'sessions', sessionId, 'input.md'),
+      'utf8'
+    );
+
+    assert.equal(savedInput, rawInput);
+  });
+
+  it('preserves raw input-file content exactly', async () => {
+    const home = await makeHome();
+    const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-workspace-'));
+    const rawFileInput = '  file leading spaces stay\nfile trailing newline stays\n';
+    await writeFile(join(workspace, 'raw-input.md'), rawFileInput);
+
+    const result = await runCli(
+      [
+        'ask',
+        '--providers',
+        'mock',
+        '--task',
+        'preserve raw file input',
+        '--input-file',
+        'raw-input.md',
+        '--yes',
+        '--output-mode',
+        'save-only',
+      ],
+      { home, cwd: workspace }
+    );
+
+    assert.equal(result.code, 0);
+    const sessionId = await latestSessionId(home);
+    const savedInput = await readFile(
+      join(home, '.aco', 'sessions', sessionId, 'input.md'),
+      'utf8'
+    );
+
+    assert.equal(savedInput, rawFileInput);
+  });
+
+  it('combines inline and file input with a deterministic raw-preserving separator', async () => {
+    const home = await makeHome();
+    const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-workspace-'));
+    const inlineInput = ' inline block ends with newline\n';
+    const fileInput = '\nfile block starts with newline\n';
+    await writeFile(join(workspace, 'combined-input.md'), fileInput);
+
+    const result = await runCli(
+      [
+        'ask',
+        '--providers',
+        'mock',
+        '--task',
+        'preserve combined raw input',
+        '--input',
+        inlineInput,
+        '--input-file',
+        'combined-input.md',
+        '--yes',
+        '--output-mode',
+        'save-only',
+      ],
+      { home, cwd: workspace }
+    );
+
+    assert.equal(result.code, 0);
+    const sessionId = await latestSessionId(home);
+    const savedInput = await readFile(
+      join(home, '.aco', 'sessions', sessionId, 'input.md'),
+      'utf8'
+    );
+
+    assert.equal(savedInput, `${inlineInput}\n\n${fileInput}`);
+  });
+
+  it('prints a bounded provider summary in brief mode without dumping the full body', async () => {
+    const hiddenTail = 'UNIQUE_AFTER_BOUND_SHOULD_NOT_APPEAR_IN_BRIEF';
+    const largeInput = `${'x'.repeat(1400)}${hiddenTail}`;
+
+    const result = await runCli([
+      'ask',
+      '--providers',
+      'mock',
+      '--task',
+      'summarize this long provider output',
+      '--input',
+      largeInput,
       '--yes',
       '--output-mode',
       'brief',
     ]);
 
     assert.equal(result.code, 0);
-    assert.equal(result.stdout.includes(multibyteInput), true);
-    assert.doesNotMatch(result.stdout, /\.\.\. \(truncated\)/);
+    assert.match(result.stdout, /Summary:/);
+    assert.match(result.stdout, /Provider: mock/);
+    assert.doesNotMatch(result.stdout, new RegExp(hiddenTail));
+    assert.doesNotMatch(result.stdout, /Findings:/);
+
+    const sessionId = await latestSessionId(result.home);
+    const sessionBrief = await readFile(
+      join(result.home, '.aco', 'sessions', sessionId, 'brief.md'),
+      'utf8'
+    );
+    const runId = await latestRunId(result.home);
+    const runBrief = await readFile(join(result.home, '.aco', 'runs', runId, 'brief.md'), 'utf8');
+    const ledger = JSON.parse(
+      await readFile(join(result.home, '.aco', 'runs', runId, 'ledger.json'), 'utf8')
+    );
+
+    assert.match(sessionBrief, /Summary:/);
+    assert.match(runBrief, /Summary:/);
+    assert.equal(typeof ledger.sessions[0].summary, 'string');
+    assert.doesNotMatch(ledger.sessions[0].summary, new RegExp(hiddenTail));
+  });
+
+  it('does not truncate brief summaries at Findings headings inside raw input', async () => {
+    const inputWithHeading = 'alpha\nFindings:\nomega\n';
+
+    const result = await runCli([
+      'ask',
+      '--providers',
+      'mock',
+      '--task',
+      'summarize input containing a findings heading',
+      '--input',
+      inputWithHeading,
+      '--yes',
+      '--output-mode',
+      'brief',
+    ]);
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /alpha/);
+    assert.match(result.stdout, /omega/);
+    assert.doesNotMatch(result.stdout, /Treat this mock output as deterministic test data/);
+
+    const runId = await latestRunId(result.home);
+    const ledger = JSON.parse(
+      await readFile(join(result.home, '.aco', 'runs', runId, 'ledger.json'), 'utf8')
+    );
+    assert.match(ledger.sessions[0].summary, /alpha/);
+    assert.match(ledger.sessions[0].summary, /omega/);
+    assert.doesNotMatch(
+      ledger.sessions[0].summary,
+      /Treat this mock output as deterministic test data/
+    );
   });
 
   it('supports save-only and full output modes explicitly', async () => {
@@ -231,6 +380,7 @@ describe('aco ask CLI', () => {
     assert.equal(saveOnly.code, 0);
     assert.match(saveOnly.stdout, /saved/);
     assert.doesNotMatch(saveOnly.stdout, /Brief/);
+    assert.doesNotMatch(saveOnly.stdout, /Summary:/);
     assert.doesNotMatch(saveOnly.stdout, /Findings:/);
 
     const full = await runCli([
@@ -289,43 +439,6 @@ describe('aco ask CLI', () => {
     assert.match(input, /file demo/);
   });
 
-  it('preserves exact raw input including whitespace and newlines', async () => {
-    const home = await makeHome();
-    const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-raw-input-'));
-    try {
-      const inputContent = '  file content with leading/trailing spaces and newlines  \n\n';
-      await writeFile(join(workspace, 'raw-input.md'), inputContent);
-
-      const result = await runCli(
-        [
-          'ask',
-          '--providers',
-          'mock',
-          '--task',
-          'check raw input',
-          '--input',
-          '  inline content  ',
-          '--input-file',
-          'raw-input.md',
-          '--yes',
-        ],
-        { home, cwd: workspace }
-      );
-
-      assert.equal(result.code, 0);
-      const sessionId = await latestSessionId(home);
-      const sessionDir = join(home, '.aco', 'sessions', sessionId);
-
-      const input = await readFile(join(sessionDir, 'input.md'), 'utf8');
-      // Expected: "  inline content  " + "\n\n" + "  file content with leading/trailing spaces and newlines  \n\n"
-      const expected = '  inline content  \n\n  file content with leading/trailing spaces and newlines  \n\n';
-      assert.equal(input, expected);
-    } finally {
-      await rm(home, { recursive: true, force: true });
-      await rm(workspace, { recursive: true, force: true });
-    }
-  });
-
   it('saves partial output on provider failure so aco result can inspect it', async () => {
     const failed = await runCli(
       [
@@ -351,6 +464,7 @@ describe('aco ask CLI', () => {
 
     assert.equal(task.status, 'failed');
     assert.match(output, /Provider: mock/);
+    await stat(join(sessionDir, 'error.log'));
 
     const result = await runCli(['result', '--session', sessionId], { home: failed.home });
     assert.equal(result.code, 0);
@@ -453,5 +567,28 @@ describe('aco ask CLI', () => {
     ]);
     assert.equal(badPreset.code, 1);
     assert.match(badPreset.stderr, /Invalid --preset/);
+  });
+
+  it('caps fullOutput in runResult when maxOutputBuffer is set', async () => {
+    const provider = new MockProvider();
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const runResult = await invokeProviderForSession({
+      provider,
+      command: 'ask',
+      prompt: 'test',
+      content: 'x'.repeat(2000),
+      permissionProfile: 'restricted',
+      sessionId: 'test-session-cap',
+      output,
+      maxOutputBuffer: 600,
+    });
+
+    assert.ok(runResult.hasOutput);
+    assert.equal(runResult.fullOutput.length, 600);
   });
 });

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -8,6 +8,7 @@ import { join, resolve } from 'node:path';
 import { Writable } from 'node:stream';
 import { invokeProviderForSession } from '../src/runtime/provider-session-runner';
 import { MockProvider } from '../src/providers/mock';
+import type { IProvider } from '../src/providers/interface';
 
 interface CliResult {
   code: number | null;
@@ -368,14 +369,15 @@ describe('aco ask CLI', () => {
   });
 
   it('keeps raw input after Findings headings when the provider footer is beyond the summary source prefix', async () => {
-    const inputWithHeading = `alpha\nFindings:\nomega\n${'tail '.repeat(180)}`;
+    const inputWithHeading = `alpha\nFindings:\nomega\n${'tail '.repeat(4000)}`;
+    assert.ok(inputWithHeading.length > 16 * 1024);
 
     const result = await runCli([
       'ask',
       '--providers',
       'mock',
       '--task',
-      'summarize long input containing a findings heading',
+      'x',
       '--input',
       inputWithHeading,
       '--yes',
@@ -663,5 +665,51 @@ describe('aco ask CLI', () => {
 
     assert.ok(runResult.hasOutput);
     assert.equal(runResult.fullOutput.length, 600);
+  });
+
+  it('waits for writable drain even when the sink exposes compatibility flags', async () => {
+    let drainCount = 0;
+    let sawDrainBeforeSecondChunk = false;
+    const output = new Writable({
+      highWaterMark: 1,
+      write(_chunk, _encoding, callback) {
+        setTimeout(callback, 25);
+      },
+    }) as Writable & { skipDrainWait?: boolean };
+    output.skipDrainWait = true;
+    output.on('drain', () => {
+      drainCount += 1;
+    });
+
+    const provider: IProvider = {
+      key: 'slow-test',
+      installHint: 'test provider',
+      isAvailable: () => true,
+      checkAuth: async () => ({
+        ok: true,
+        method: 'cli-fallback',
+        version: 'test',
+        binaryPath: 'test',
+      }),
+      buildArgs: () => ['slow-test'],
+      async *invoke() {
+        yield 'first chunk';
+        sawDrainBeforeSecondChunk = drainCount > 0;
+        yield 'second chunk';
+      },
+    };
+
+    const runResult = await invokeProviderForSession({
+      provider,
+      command: 'ask',
+      prompt: 'test',
+      content: 'test',
+      permissionProfile: 'restricted',
+      sessionId: 'test-session-drain',
+      output,
+    });
+
+    assert.ok(runResult.hasOutput);
+    assert.equal(sawDrainBeforeSecondChunk, true);
   });
 });

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -310,6 +310,7 @@ describe('aco ask CLI', () => {
     assert.equal(result.code, 0);
     assert.match(result.stdout, /Summary:/);
     assert.match(result.stdout, /Provider: mock/);
+    assert.match(result.stdout, /\.\.\.\[truncated to 600 chars\]/);
     assert.doesNotMatch(result.stdout, new RegExp(hiddenTail));
     assert.doesNotMatch(result.stdout, /Findings:/);
 
@@ -326,7 +327,10 @@ describe('aco ask CLI', () => {
 
     assert.match(sessionBrief, /Summary:/);
     assert.match(runBrief, /Summary:/);
+    assert.match(sessionBrief, /\.\.\.\[truncated to 600 chars\]/);
+    assert.match(runBrief, /\.\.\.\[truncated to 600 chars\]/);
     assert.equal(typeof ledger.sessions[0].summary, 'string');
+    assert.match(ledger.sessions[0].summary, /\.\.\.\[truncated to 600 chars\]/);
     assert.doesNotMatch(ledger.sessions[0].summary, new RegExp(hiddenTail));
   });
 
@@ -339,6 +343,39 @@ describe('aco ask CLI', () => {
       'mock',
       '--task',
       'summarize input containing a findings heading',
+      '--input',
+      inputWithHeading,
+      '--yes',
+      '--output-mode',
+      'brief',
+    ]);
+
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /alpha/);
+    assert.match(result.stdout, /omega/);
+    assert.doesNotMatch(result.stdout, /Treat this mock output as deterministic test data/);
+
+    const runId = await latestRunId(result.home);
+    const ledger = JSON.parse(
+      await readFile(join(result.home, '.aco', 'runs', runId, 'ledger.json'), 'utf8')
+    );
+    assert.match(ledger.sessions[0].summary, /alpha/);
+    assert.match(ledger.sessions[0].summary, /omega/);
+    assert.doesNotMatch(
+      ledger.sessions[0].summary,
+      /Treat this mock output as deterministic test data/
+    );
+  });
+
+  it('keeps raw input after Findings headings when the provider footer is beyond the summary source prefix', async () => {
+    const inputWithHeading = `alpha\nFindings:\nomega\n${'tail '.repeat(180)}`;
+
+    const result = await runCli([
+      'ask',
+      '--providers',
+      'mock',
+      '--task',
+      'summarize long input containing a findings heading',
       '--input',
       inputWithHeading,
       '--yes',
@@ -569,7 +606,7 @@ describe('aco ask CLI', () => {
     assert.match(badPreset.stderr, /Invalid --preset/);
   });
 
-  it('caps fullOutput in runResult when maxOutputBuffer is set', async () => {
+  it('keeps fullOutput empty in stream-only mode even when maxOutputBuffer is set', async () => {
     const provider = new MockProvider();
     const output = new Writable({
       write(_chunk, _encoding, callback) {
@@ -585,6 +622,30 @@ describe('aco ask CLI', () => {
       permissionProfile: 'restricted',
       sessionId: 'test-session-cap',
       output,
+      maxOutputBuffer: 600,
+    });
+
+    assert.ok(runResult.hasOutput);
+    assert.equal(runResult.fullOutput, '');
+  });
+
+  it('caps fullOutput in runResult when bounded output buffering is set', async () => {
+    const provider = new MockProvider();
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const runResult = await invokeProviderForSession({
+      provider,
+      command: 'ask',
+      prompt: 'test',
+      content: 'x'.repeat(2000),
+      permissionProfile: 'restricted',
+      sessionId: 'test-session-cap',
+      output,
+      outputBuffer: { mode: 'bounded' },
       maxOutputBuffer: 600,
     });
 

--- a/packages/wrapper/tests/session.test.ts
+++ b/packages/wrapper/tests/session.test.ts
@@ -134,4 +134,80 @@ describe('SessionStore', () => {
     assert.ok(logPath.startsWith(dir));
     assert.ok(logPath.endsWith('output.log'));
   });
+
+  it('createOutputTee() writes output without buffering unread readable chunks', async () => {
+    const { store } = await makeStore();
+    const record = await store.create('gemini', 'review');
+    const originalStdoutWrite = process.stdout.write;
+    let stdout = '';
+
+    process.stdout.write = ((chunk: string | Uint8Array, ...args: unknown[]) => {
+      stdout += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+      const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+      callback?.();
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const tee = store.createOutputTee(record.id);
+      const chunk = Buffer.from('x'.repeat(1024));
+
+      await new Promise<void>((resolve, reject) => {
+        tee.write(chunk, (err?: Error | null) => (err ? reject(err) : resolve()));
+      });
+
+      assert.equal((tee as { readableLength?: number }).readableLength ?? 0, 0);
+
+      await new Promise<void>((resolve, reject) => {
+        tee.end((err?: Error | null) => (err ? reject(err) : resolve()));
+      });
+
+      assert.equal(stdout, chunk.toString('utf8'));
+      assert.equal(await readFile(store.outputLogPath(record.id), 'utf8'), chunk.toString('utf8'));
+    } finally {
+      process.stdout.write = originalStdoutWrite;
+    }
+  });
+
+  it('createOutputTee() waits for stdout backpressure before accepting the next chunk', async () => {
+    const { store } = await makeStore();
+    const record = await store.create('gemini', 'review');
+    const originalStdoutWrite = process.stdout.write;
+    let releaseStdout: (() => void) | undefined;
+
+    process.stdout.write = ((_chunk: string | Uint8Array, ...args: unknown[]) => {
+      const callback = args.find((arg): arg is () => void => typeof arg === 'function');
+      releaseStdout = callback;
+      return false;
+    }) as typeof process.stdout.write;
+
+    try {
+      const tee = store.createOutputTee(record.id);
+      let writeCompleted = false;
+      const writeDone = new Promise<void>((resolve, reject) => {
+        tee.write(Buffer.from('blocked'), (err?: Error | null) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          writeCompleted = true;
+          resolve();
+        });
+      });
+
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(writeCompleted, false);
+
+      releaseStdout?.();
+      await writeDone;
+
+      assert.equal(writeCompleted, true);
+
+      await new Promise<void>((resolve, reject) => {
+        tee.end((err?: Error | null) => (err ? reject(err) : resolve()));
+      });
+    } finally {
+      process.stdout.write = originalStdoutWrite;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- backport consent-gated follow-up ask behavior from branch 96/92 review worktrees onto current main context
- replace output preview printing with bounded summary in brief mode and include summary in ledger
- prevent deadlock by skipping drain wait on tee writable for run output path
- update aco ask CLI tests for raw input and summary regression coverage

## Checklist
- [x] Runtime-safe write path handling for output tee
- [x] ask output summary path and tests updated
- [x] Korean commit trailer policy and Co-Authored-By included