### PR TITLE
fix(wrapper): add provider timeout and cancellation reliability

### DIFF
--- a/docs/guides/runbook.md
+++ b/docs/guides/runbook.md
@@ -111,6 +111,34 @@ aco run codex review --input "demo"
 
 위 `aco run` 두 명령은 실제 provider CLI와 로컬 credential이 준비된 경우에만 실행한다. CI/기본 검증에서는 `test:pack-runtime-contract`의 fake provider smoke와 `aco ask --preset ... --dry-run`을 사용한다.
 
+## Provider Timeout And Session Reliability 검증
+
+deterministic repo validation:
+
+```bash
+npm exec --workspace=packages/wrapper -- node --require tsx/cjs --test tests/provider-session-reliability.test.ts
+npm run typecheck --workspace=packages/wrapper
+npm test --workspace=packages/wrapper
+git diff --check
+```
+
+`aco run`과 `aco ask --yes`는 provider timeout을 다음 순서로 결정한다.
+
+1. `--timeout <seconds>`
+2. `ACO_TIMEOUT_SECONDS`
+3. 기본값 `300`
+
+Timeout 발생 시 session은 `failed`가 되고, cancellation은 `cancelled`가 된다. 두 경로 모두 가능한 경우 `~/.aco/sessions/<session-id>/error.log`를 남긴다.
+
+optional live provider smoke:
+
+```bash
+node packages/wrapper/dist/cli.js run gemini review --input "hello" --permission-profile restricted --timeout 120
+node packages/wrapper/dist/cli.js run codex review --input "hello" --permission-profile restricted --timeout 120
+```
+
+이 live smoke는 실제 provider CLI, local auth, network, provider latency에 의존한다. 명시 승인 없이 CI나 기본 완료 검증으로 실행하지 않는다.
+
 ## 일반적인 문제
 
 ## Consent-Gated Delegation MVP

--- a/docs/reference/session-artifacts.md
+++ b/docs/reference/session-artifacts.md
@@ -31,6 +31,7 @@ Current fields:
 - `providers`
 - `permissionProfile`
 - `outputMode`
+- `timeoutSeconds`
 - `advisory`
 - `sessions`
 
@@ -115,6 +116,22 @@ Human-readable session summary with:
 ### `error.log`
 
 Created when provider execution fails or a cancellation path records an error. It is not created for successful sessions.
+
+## Timeout And Cancellation
+
+`aco run` and provider-invoking `aco ask --yes` apply provider execution timeout in this order:
+
+1. `--timeout <seconds>`
+2. `ACO_TIMEOUT_SECONDS`
+3. default `300` seconds
+
+Invalid timeout values are rejected before a provider session is created.
+
+When timeout occurs, the wrapper best-effort terminates the provider process, marks the session `failed`, preserves partial `output.log`, and writes the timeout reason to `error.log`.
+
+When `aco cancel --session <id>` cancels a running session, the wrapper marks the session `cancelled`, writes `error.log`, and best-effort terminates the provider process. If the original `aco run` or `aco ask --yes` process later observes that status, it does not overwrite `cancelled` with `done` or `failed`.
+
+`task.json` includes `pid` when the provider implementation exposes a spawned child process PID. `aco status --session <id>` reports the PID when present.
 
 ## Output Modes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,6 +73,18 @@ Default permission profile is `restricted`.
 
 Do not enable broader permission profiles unless the task requires it and the provider behavior is understood.
 
+## Timeout And Cancellation Boundary
+
+`aco run` and `aco ask --yes` apply provider execution timeout with this precedence:
+
+1. `--timeout <seconds>`
+2. `ACO_TIMEOUT_SECONDS`
+3. default `300` seconds
+
+Timeout and `aco cancel --session <id>` are reliability controls. They best-effort terminate provider processes and record session artifacts, but they are not sandbox, secret-redaction, or remote-auth guarantees.
+
+Real Codex/Gemini smoke commands can require provider credentials, local CLI setup, network access, and real provider latency. Keep those commands opt-in and separate from default CI or deterministic repo tests.
+
 ## Secrets Policy
 
 Do not send secrets, credentials, private tokens, local auth files, or unrelated sensitive files through `--input` or `--input-file`.

--- a/docs/superpowers/plans/2026-05-13-provider-smoke-timeout-session-reliability.md
+++ b/docs/superpowers/plans/2026-05-13-provider-smoke-timeout-session-reliability.md
@@ -1,0 +1,758 @@
+# Provider Smoke Timeout Session Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement issue #105 by giving Node wrapper `aco run`, `aco ask`, and `aco cancel` a deterministic timeout/cancellation/session artifact contract without putting live Codex/Gemini calls in default CI.
+
+**Architecture:** Keep `packages/wrapper/src/runtime/provider-session-runner.ts` as the shared execution coordinator for `aco run` and `aco ask`. Add small, testable runtime helpers for timeout resolution, typed provider execution errors, and provider process termination; then wire command handlers to preserve final session state and artifacts.
+
+**Tech Stack:** TypeScript, Node.js test runner, `tsx`, npm workspaces, OpenSpec, Markdown docs. In this Codex environment, prefix shell commands with `rtk`; repo/CI commands are the same without the `rtk` prefix.
+
+---
+
+## Source Inputs
+
+- GitHub issue: `#105 bug: add provider smoke timeout and session reliability`
+- OpenSpec change: `openspec/changes/add-provider-smoke-timeout-session-reliability/`
+- Existing artifact contract: `docs/reference/session-artifacts.md`
+- Existing process contract contrast: `docs/contract/process-execution-contract.md`
+- Current runtime runner: `packages/wrapper/src/runtime/provider-session-runner.ts`
+- Current child process helper: `packages/wrapper/src/util/spawn-stream.ts`
+
+## Skill And Agent Plan
+
+| Phase                     | Required capability                                                            | Use in this task                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| Spec gate                 | `openspec-propose`, architecture/system design review                          | Keep proposal, design, spec, and tasks aligned before implementation.                                                 |
+| Plan gate                 | `superpowers:writing-plans`, `testing-strategy`, `deploy-checklist`            | This document defines file ownership, TDD tasks, validation gates, and release readiness.                             |
+| Implementation            | `superpowers:test-driven-development`                                          | No production code before a failing test is observed.                                                                 |
+| Parallel execution option | `superpowers:subagent-driven-development`                                      | If the user explicitly authorizes subagents, split tests/runtime/docs into separate workers with disjoint write sets. |
+| Review gate               | `superpowers:requesting-code-review`, `typescript-reviewer`, `code-simplifier` | Review runtime correctness, security, and maintainability before final verification.                                  |
+| Completion gate           | `superpowers:verification-before-completion`                                   | Fresh validation results must be written to `validation-ledger.md` before claiming done.                              |
+
+## File Map
+
+- Create `packages/wrapper/tests/provider-session-reliability.test.ts`: deterministic tests for timeout resolution, PID recording, timeout failure artifacts, cancellation, cancelled-state preservation, provider failure artifacts, and ask ledger status.
+- Create `packages/wrapper/src/runtime/provider-execution-control.ts`: timeout parsing, default timeout constants, kill grace constants, and execution-control normalization.
+- Create `packages/wrapper/src/runtime/provider-execution-error.ts`: typed errors for timeout and cancellation with stable `code` values.
+- Modify `packages/wrapper/src/providers/interface.ts`: add execution-control fields to `InvokeOptions`.
+- Modify `packages/wrapper/src/util/spawn-stream.ts`: spawn provider children in a process group where supported, record PID, terminate on timeout/cancel, and keep stderr-tail diagnostics.
+- Modify `packages/wrapper/src/runtime/provider-session-runner.ts`: apply shared timeout, call provider invoke with execution control, preserve cancellation semantics, and return typed errors.
+- Modify `packages/wrapper/src/cli.ts`: parse `--timeout` for `aco run`, pass execution control, preserve `cancelled`, and improve `aco cancel`.
+- Modify `packages/wrapper/src/commands/ask.ts`: parse `--timeout`, pass execution control, preserve `cancelled`, and record ledger/session artifacts.
+- Modify `packages/wrapper/package.json`: include the new test file in the wrapper `test` script if the script enumerates files explicitly.
+- Modify `docs/reference/session-artifacts.md`: document timeout, cancellation, PID, and `error.log` behavior.
+- Modify `docs/security.md`: document provider execution timeout/cancel boundaries and opt-in live smoke.
+- Modify `docs/guides/runbook.md`: add deterministic validation commands and opt-in live Codex/Gemini smoke commands.
+- Create `openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md`: evidence split for repo tests, dry-run proof, live smoke, and skipped live-smoke rationale.
+
+## Test Strategy
+
+- Unit tests cover timeout value parsing and execution-control helpers without spawning providers.
+- Runtime integration tests use fake provider binaries and temp `HOME` so no real Codex/Gemini credentials or network are needed.
+- Cancellation tests start a long-running fake provider, wait until `task.json` includes a PID, run `aco cancel --session <id>`, and assert final artifacts.
+- One or two integration tests may use a one-second timeout; keep slower behavior out of the full suite by using helper-level tests for grace/termination details.
+- Existing `mock` provider tests stay advisory/runtime tests, not AI quality tests.
+- Live Codex/Gemini smoke is documented as opt-in and recorded separately in `validation-ledger.md`.
+
+## Deploy / Readiness Checklist
+
+- [ ] OpenSpec validation passes for `add-provider-smoke-timeout-session-reliability`.
+- [ ] Targeted provider reliability tests pass.
+- [ ] `npm run typecheck --workspace=packages/wrapper` passes.
+- [ ] `npm test --workspace=packages/wrapper` passes.
+- [ ] `git diff --check` passes.
+- [ ] Documentation states live provider smoke is opt-in and credential-dependent.
+- [ ] `validation-ledger.md` separates repo-local tests, dry-run proof, and optional live runtime smoke.
+- [ ] PR body links `Closes #105` and does not claim live smoke unless it was actually run.
+
+## Task 1: Spec Gate And Validation Ledger
+
+**Files:**
+
+- Create: `openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md`
+- Modify: `openspec/changes/add-provider-smoke-timeout-session-reliability/tasks.md`
+
+- [ ] **Step 1: Create the validation ledger before code**
+
+Create `validation-ledger.md` with this structure:
+
+```markdown
+# Provider Smoke Timeout Session Reliability Validation Ledger
+
+## Scope
+
+- Issue: #105
+- Change: add-provider-smoke-timeout-session-reliability
+- Worktree: /Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-provider-smoke-timeout-session
+- Branch: fix/provider-smoke-timeout-session
+
+## Repo-Local Deterministic Evidence
+
+| Command     | Result  | Notes                              |
+| ----------- | ------- | ---------------------------------- |
+| Not run yet | Pending | Tests must be added failing-first. |
+
+## Dry-Run Evidence
+
+| Command     | Result  | Notes                                                                  |
+| ----------- | ------- | ---------------------------------------------------------------------- |
+| Not run yet | Pending | Add dry-run proof if runtime commands are exercised without providers. |
+
+## Optional Live Runtime Smoke
+
+| Command | Result  | Notes                                                                 |
+| ------- | ------- | --------------------------------------------------------------------- |
+| Not run | Skipped | Live Codex/Gemini smoke requires explicit approval and provider auth. |
+
+## Review Notes
+
+- Architecture/system-design review: pending.
+- Testing/TDD review: pending.
+- Security/runtime review: pending.
+- Code-simplifier pass: pending.
+```
+
+- [ ] **Step 2: Validate the current OpenSpec package**
+
+Run:
+
+```bash
+rtk openspec validate add-provider-smoke-timeout-session-reliability --type change --strict
+```
+
+Expected:
+
+```text
+Change 'add-provider-smoke-timeout-session-reliability' is valid
+```
+
+- [ ] **Step 3: Record spec gate result**
+
+Append the validation result to `validation-ledger.md`. If validation fails, fix OpenSpec artifacts before writing tests.
+
+## Task 2: Failing Tests For Timeout Resolution
+
+**Files:**
+
+- Create: `packages/wrapper/tests/provider-session-reliability.test.ts`
+- Create: `packages/wrapper/src/runtime/provider-execution-control.ts`
+- Modify: `packages/wrapper/package.json`
+
+- [ ] **Step 1: Add RED tests for timeout parsing**
+
+Create the test file with this initial section:
+
+```typescript
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveProviderTimeoutSeconds } from '../src/runtime/provider-execution-control';
+
+describe('provider execution timeout resolution', () => {
+  it('uses the 300 second default when no flag or env timeout is provided', () => {
+    assert.equal(resolveProviderTimeoutSeconds(undefined, {}), 300);
+  });
+
+  it('uses ACO_TIMEOUT_SECONDS when no CLI timeout is provided', () => {
+    assert.equal(resolveProviderTimeoutSeconds(undefined, { ACO_TIMEOUT_SECONDS: '42' }), 42);
+  });
+
+  it('lets --timeout take precedence over ACO_TIMEOUT_SECONDS', () => {
+    assert.equal(resolveProviderTimeoutSeconds('7', { ACO_TIMEOUT_SECONDS: '42' }), 7);
+  });
+
+  it('rejects non-positive and non-numeric timeout values', () => {
+    assert.throws(() => resolveProviderTimeoutSeconds('0', {}), /--timeout/);
+    assert.throws(() => resolveProviderTimeoutSeconds('-1', {}), /--timeout/);
+    assert.throws(() => resolveProviderTimeoutSeconds('abc', {}), /--timeout/);
+  });
+});
+```
+
+- [ ] **Step 2: Wire the test into the wrapper test script**
+
+If `packages/wrapper/package.json` still enumerates tests explicitly, add `tests/provider-session-reliability.test.ts` to the `test` script.
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+```
+
+Expected: fail because `provider-execution-control` does not exist.
+
+- [ ] **Step 4: Implement the minimal timeout helper**
+
+Create `packages/wrapper/src/runtime/provider-execution-control.ts`:
+
+```typescript
+export const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 300;
+export const DEFAULT_PROVIDER_KILL_GRACE_MS = 5_000;
+
+export interface TimeoutEnv {
+  ACO_TIMEOUT_SECONDS?: string;
+}
+
+export interface ProviderExecutionControl {
+  timeoutMs: number;
+  killGraceMs: number;
+}
+
+export function resolveProviderTimeoutSeconds(
+  flagValue: string | undefined,
+  env: TimeoutEnv = process.env
+): number {
+  const source = flagValue ?? env.ACO_TIMEOUT_SECONDS;
+  if (source === undefined || source === '') return DEFAULT_PROVIDER_TIMEOUT_SECONDS;
+
+  const parsed = Number(source);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    const label = flagValue !== undefined ? '--timeout' : 'ACO_TIMEOUT_SECONDS';
+    throw new Error(`Invalid ${label}: expected a positive number of seconds`);
+  }
+
+  return parsed;
+}
+
+export function resolveProviderExecutionControl(
+  flagValue: string | undefined,
+  env: TimeoutEnv = process.env
+): ProviderExecutionControl {
+  return {
+    timeoutMs: Math.ceil(resolveProviderTimeoutSeconds(flagValue, env) * 1000),
+    killGraceMs: DEFAULT_PROVIDER_KILL_GRACE_MS,
+  };
+}
+```
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+```
+
+Expected: timeout parsing tests pass.
+
+## Task 3: Failing Runtime Tests For Timeout, PID, And Failure Artifacts
+
+**Files:**
+
+- Modify: `packages/wrapper/tests/provider-session-reliability.test.ts`
+- Create: `packages/wrapper/src/runtime/provider-execution-error.ts`
+- Modify: `packages/wrapper/src/providers/interface.ts`
+- Modify: `packages/wrapper/src/util/spawn-stream.ts`
+- Modify: `packages/wrapper/src/runtime/provider-session-runner.ts`
+
+- [ ] **Step 1: Add fake binary helpers to the test**
+
+Add these helpers below the imports:
+
+```typescript
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, writeFile, readdir, stat } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, delimiter } from 'node:path';
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  home: string;
+}
+
+async function makeHome(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'aco-provider-reliability-home-'));
+}
+
+async function makeFakeProviderBin(name: string, body: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'aco-provider-reliability-bin-'));
+  const file = join(dir, name);
+  await writeFile(file, `#!/usr/bin/env node\n${body}\n`, { mode: 0o755 });
+  return dir;
+}
+
+async function runCli(
+  args: string[],
+  options: { home?: string; cwd?: string; timeoutMs?: number; pathPrefix?: string } = {}
+): Promise<CliResult> {
+  const home = options.home ?? (await makeHome());
+  const cliRoot = resolve(__dirname, '..');
+  const cliPath = join(cliRoot, 'src', 'cli.ts');
+  const tsxRegister = require.resolve('tsx/cjs');
+
+  return new Promise((resolveResult) => {
+    execFile(
+      process.execPath,
+      ['--require', tsxRegister, cliPath, ...args],
+      {
+        cwd: options.cwd ?? cliRoot,
+        timeout: options.timeoutMs ?? 5_000,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          NO_COLOR: '1',
+          PATH: options.pathPrefix
+            ? `${options.pathPrefix}${delimiter}${process.env.PATH ?? ''}`
+            : process.env.PATH,
+        },
+      },
+      (error, stdout, stderr) => {
+        const code =
+          error && typeof (error as { code?: unknown }).code === 'number'
+            ? (error as { code: number }).code ?? 1
+            : error
+            ? 1
+            : 0;
+        resolveResult({ code, stdout, stderr, home });
+      }
+    );
+  });
+}
+
+async function latestSessionId(home: string): Promise<string> {
+  const entries = await readdir(join(home, '.aco', 'sessions'));
+  assert.equal(entries.length, 1);
+  return entries[0];
+}
+```
+
+- [ ] **Step 2: Add RED test for timeout artifacts**
+
+Add:
+
+```typescript
+describe('provider execution timeout artifacts', () => {
+  it('marks a slow spawned provider failed and writes error.log', async () => {
+    const binDir = await makeFakeProviderBin(
+      'gemini',
+      [
+        "process.stdout.write('partial output before timeout\\n');",
+        'setInterval(() => {}, 1000);',
+      ].join('\n')
+    );
+
+    const result = await runCli(['run', 'gemini', 'review', '--input', 'demo', '--timeout', '1'], {
+      pathPrefix: binDir,
+      timeoutMs: 4_000,
+    });
+
+    assert.equal(result.code, 1);
+    const sessionId = await latestSessionId(result.home);
+    const sessionDir = join(result.home, '.aco', 'sessions', sessionId);
+    const task = JSON.parse(await readFile(join(sessionDir, 'task.json'), 'utf8'));
+    const output = await readFile(join(sessionDir, 'output.log'), 'utf8');
+    const error = await readFile(join(sessionDir, 'error.log'), 'utf8');
+
+    assert.equal(task.status, 'failed');
+    assert.equal(task.provider, 'gemini');
+    assert.equal(task.command, 'review');
+    assert.equal(typeof task.pid, 'number');
+    assert.match(output, /partial output before timeout/);
+    assert.match(error, /timed out/i);
+  });
+});
+```
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+```
+
+Expected: fail because timeout execution control is not wired into provider invocation.
+
+- [ ] **Step 4: Add typed execution errors**
+
+Create `packages/wrapper/src/runtime/provider-execution-error.ts`:
+
+```typescript
+export type ProviderExecutionErrorCode = 'timeout' | 'cancelled';
+
+export class ProviderExecutionError extends Error {
+  constructor(
+    readonly code: ProviderExecutionErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ProviderExecutionError';
+  }
+}
+
+export function isProviderExecutionError(
+  error: unknown,
+  code?: ProviderExecutionErrorCode
+): error is ProviderExecutionError {
+  return error instanceof ProviderExecutionError && (code === undefined || error.code === code);
+}
+```
+
+- [ ] **Step 5: Extend provider invocation options**
+
+In `packages/wrapper/src/providers/interface.ts`, add these optional fields to `InvokeOptions`:
+
+```typescript
+  /** Maximum provider execution time in milliseconds. */
+  timeoutMs?: number;
+  /** Grace period after SIGTERM before SIGKILL. */
+  killGraceMs?: number;
+```
+
+- [ ] **Step 6: Implement process termination in `spawn-stream.ts`**
+
+Update the child spawn and cleanup shape:
+
+```typescript
+const child = spawn(binary, args, {
+  stdio: [config.stdin, 'pipe', 'pipe'],
+  detached: process.platform !== 'win32',
+});
+
+let timedOut = false;
+let timeout: NodeJS.Timeout | undefined;
+let forceKill: NodeJS.Timeout | undefined;
+
+const terminate = (signal: NodeJS.Signals): void => {
+  if (child.pid === undefined) return;
+  try {
+    if (process.platform !== 'win32') {
+      process.kill(-child.pid, signal);
+      return;
+    }
+  } catch {
+    // Fall back to direct PID kill below.
+  }
+  try {
+    process.kill(child.pid, signal);
+  } catch {
+    // The process may already be gone.
+  }
+};
+
+if (options?.timeoutMs !== undefined) {
+  timeout = setTimeout(() => {
+    timedOut = true;
+    terminate('SIGTERM');
+    forceKill = setTimeout(() => terminate('SIGKILL'), options.killGraceMs ?? 5_000);
+  }, options.timeoutMs);
+}
+```
+
+Then clear timers on close and reject timeout with:
+
+```typescript
+if (timedOut) {
+  reject(
+    new ProviderExecutionError(
+      'timeout',
+      `${config.processName} timed out after ${Math.ceil((options?.timeoutMs ?? 0) / 1000)}s`
+    )
+  );
+  return;
+}
+```
+
+- [ ] **Step 7: Pass timeout from `invokeProviderForSession()`**
+
+When calling `options.provider.invoke(...)`, include:
+
+```typescript
+timeoutMs: options.timeoutMs,
+killGraceMs: options.killGraceMs,
+```
+
+Also add these fields to `ProviderSessionRunOptions`.
+
+- [ ] **Step 8: Verify GREEN for timeout artifacts**
+
+Run:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+```
+
+Expected: timeout parsing and timeout artifact tests pass.
+
+## Task 4: Failing Tests And Implementation For Cancellation
+
+**Files:**
+
+- Modify: `packages/wrapper/tests/provider-session-reliability.test.ts`
+- Modify: `packages/wrapper/src/cli.ts`
+- Modify: `packages/wrapper/src/commands/ask.ts`
+- Modify: `packages/wrapper/src/session/store.ts`
+
+- [ ] **Step 1: Add RED cancellation test**
+
+Add a spawn-based test that starts `aco run`, waits for a session PID, cancels it, and asserts final artifacts:
+
+```typescript
+import { spawn } from 'node:child_process';
+
+async function waitForSessionWithPid(home: string): Promise<{ id: string; pid: number }> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const root = join(home, '.aco', 'sessions');
+    if (existsSync(root)) {
+      const ids = await readdir(root);
+      for (const id of ids) {
+        const taskPath = join(root, id, 'task.json');
+        const task = JSON.parse(await readFile(taskPath, 'utf8'));
+        if (typeof task.pid === 'number') return { id, pid: task.pid };
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('Timed out waiting for session PID');
+}
+
+it('cancels a running spawned provider and preserves cancelled status', async () => {
+  const home = await makeHome();
+  const binDir = await makeFakeProviderBin(
+    'gemini',
+    [
+      "process.stdout.write('provider started\\n');",
+      "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 50));",
+      'setInterval(() => {}, 1000);',
+    ].join('\n')
+  );
+  const cliRoot = resolve(__dirname, '..');
+  const cliPath = join(cliRoot, 'src', 'cli.ts');
+  const tsxRegister = require.resolve('tsx/cjs');
+  const env = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    NO_COLOR: '1',
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+  };
+
+  const running = spawn(
+    process.execPath,
+    [
+      '--require',
+      tsxRegister,
+      cliPath,
+      'run',
+      'gemini',
+      'review',
+      '--input',
+      'demo',
+      '--timeout',
+      '30',
+    ],
+    {
+      cwd: cliRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  const { id } = await waitForSessionWithPid(home);
+  const cancel = await runCli(['cancel', '--session', id], { home, pathPrefix: binDir });
+  assert.equal(cancel.code, 0);
+
+  await new Promise((resolve) => running.once('exit', resolve));
+
+  const task = JSON.parse(await readFile(join(home, '.aco', 'sessions', id, 'task.json'), 'utf8'));
+  const error = await readFile(join(home, '.aco', 'sessions', id, 'error.log'), 'utf8');
+  assert.equal(task.status, 'cancelled');
+  assert.match(error, /cancelled/i);
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+```
+
+Expected: fail because `cmdRun()` can overwrite cancelled status and `cmdCancel()` does not write `error.log`.
+
+- [ ] **Step 3: Update `cmdCancel()`**
+
+In `packages/wrapper/src/cli.ts`, after reading a running record, write cancellation error and terminate process:
+
+```typescript
+if (record.pid) {
+  terminateProviderProcess(record.pid, 'SIGTERM');
+}
+
+await appendFile(
+  sessionStore.errorLogPath(sessionId),
+  `Session ${sessionId} cancelled by operator request\n`,
+  { mode: 0o600 }
+);
+await sessionStore.markCancelled(sessionId);
+console.log(`Session ${sessionId} cancelled.`);
+```
+
+Use the same termination helper as `spawnStream()` exports or move it into a shared runtime module.
+
+- [ ] **Step 4: Preserve cancelled state in `cmdRun()`**
+
+After provider invocation returns or errors, read latest session status before marking final state:
+
+```typescript
+const latest = await sessionStore.read(session.id).catch(() => undefined);
+if (latest?.status === 'cancelled') {
+  await appendFile(
+    sessionStore.errorLogPath(session.id),
+    'Provider execution observed cancellation\n',
+    {
+      mode: 0o600,
+    }
+  );
+  process.exit(EXIT_ERROR);
+}
+```
+
+Place this check before `markDone()` and before changing failed state on provider errors.
+
+- [ ] **Step 5: Preserve cancelled state in `cmdAsk()`**
+
+Keep the existing cancelled checks and extend them so timeout/cancel errors are represented in the per-session ledger with `status: 'cancelled'` when `task.json` is already cancelled.
+
+- [ ] **Step 6: Verify GREEN for cancellation**
+
+Run:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+```
+
+Expected: timeout and cancellation tests pass.
+
+## Task 5: Docs And Opt-In Live Smoke
+
+**Files:**
+
+- Modify: `docs/reference/session-artifacts.md`
+- Modify: `docs/security.md`
+- Modify: `docs/guides/runbook.md`
+- Modify: `openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md`
+
+- [ ] **Step 1: Update session artifact docs**
+
+Add a short section to `docs/reference/session-artifacts.md`:
+
+```markdown
+## Timeout And Cancellation
+
+`aco run` and `aco ask --yes` apply provider execution timeout in this order:
+
+1. `--timeout <seconds>`
+2. `ACO_TIMEOUT_SECONDS`
+3. default `300` seconds
+
+When timeout occurs, the session is marked `failed`, partial `output.log` remains inspectable, and `error.log` records the timeout. When `aco cancel --session <id>` cancels a running session, the session is marked `cancelled` and `error.log` records the operator cancellation. `pid` is recorded in `task.json` when the provider process exposes a child PID.
+```
+
+- [ ] **Step 2: Update security docs**
+
+Add a note to `docs/security.md` that timeout/cancel are reliability controls, not a sandbox guarantee, and live Codex/Gemini smoke requires explicit approval and credentials.
+
+- [ ] **Step 3: Update runbook**
+
+Add deterministic validation commands:
+
+```bash
+rtk npm test --workspace=packages/wrapper -- tests/provider-session-reliability.test.ts
+rtk npm run typecheck --workspace=packages/wrapper
+rtk npm test --workspace=packages/wrapper
+```
+
+Add opt-in live smoke commands under a clearly labelled heading:
+
+```bash
+node packages/wrapper/dist/cli.js run gemini review --input "hello" --permission-profile restricted --timeout 120
+node packages/wrapper/dist/cli.js run codex review --input "hello" --permission-profile restricted --timeout 120
+```
+
+- [ ] **Step 4: Record validation status**
+
+Update `validation-ledger.md` with each command, result, and live-smoke status. If live smoke is skipped, write: `Skipped because live provider execution requires explicit approval and local provider auth.`
+
+## Task 6: Final Verification And Review Gate
+
+**Files:**
+
+- Modify: `openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md`
+
+- [ ] **Step 1: Run OpenSpec validation**
+
+Run:
+
+```bash
+rtk openspec validate add-provider-smoke-timeout-session-reliability --type change --strict
+```
+
+Expected:
+
+```text
+Change 'add-provider-smoke-timeout-session-reliability' is valid
+```
+
+- [ ] **Step 2: Run package checks**
+
+Run:
+
+```bash
+rtk npm run typecheck --workspace=packages/wrapper
+rtk npm test --workspace=packages/wrapper
+rtk git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Run review and simplification gates**
+
+Review changed TypeScript with TypeScript/runtime/security focus. Apply only findings that affect correctness, runtime behavior, maintainability, testability, or backward compatibility. Then do a simplification pass to remove accidental duplication without changing behavior.
+
+- [ ] **Step 4: Final ledger update**
+
+Record the final commands and outcomes in `validation-ledger.md`. Separate:
+
+- repo-local deterministic tests
+- dry-run proof
+- optional live runtime smoke
+- skipped live runtime smoke rationale
+
+- [ ] **Step 5: Prepare PR handoff**
+
+The PR body should include:
+
+```markdown
+Closes #105
+
+## What
+
+- Adds deterministic provider timeout/cancel/session reliability for Node wrapper provider execution.
+- Records PID/error artifacts and preserves cancellation state.
+- Documents opt-in live provider smoke separately from repo-local validation.
+
+## Validation
+
+- [ ] npm run typecheck --workspace=packages/wrapper
+- [ ] npm test --workspace=packages/wrapper
+- [ ] openspec validate add-provider-smoke-timeout-session-reliability --type change --strict
+- [ ] git diff --check
+```
+
+Do not claim live Codex/Gemini smoke unless it was actually executed and recorded.
+
+## Self-Review
+
+- Spec coverage: Every requirement in `provider-session-reliability/spec.md` maps to Tasks 2-6.
+- Placeholder scan: No task uses open-ended `TBD`, `TODO`, or "implement later" language.
+- Type consistency: `timeoutMs`, `killGraceMs`, `ProviderExecutionError`, and `resolveProviderTimeoutSeconds()` are named consistently across tests and implementation tasks.
+- Scope check: The plan stays inside Node wrapper provider execution, docs, and OpenSpec evidence; it does not change provider auth, aggregation, or Go runtime behavior.

--- a/openspec/changes/add-provider-smoke-timeout-session-reliability/.openspec.yaml
+++ b/openspec/changes/add-provider-smoke-timeout-session-reliability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-13

--- a/openspec/changes/add-provider-smoke-timeout-session-reliability/design.md
+++ b/openspec/changes/add-provider-smoke-timeout-session-reliability/design.md
@@ -1,0 +1,132 @@
+## Context
+
+Issue #105 targets the public Node wrapper path, not the older Go runtime contract. The current Node wrapper already writes `~/.aco/sessions/<session-id>/task.json`, `output.log`, `brief.md`, and `error.log` in several paths, and it records provider PID through `InvokeOptions.onPid` when `spawnStream()` starts a child process.
+
+The gap is that timeout and cancellation are not one coherent runtime contract across `aco run`, `aco ask`, `aco cancel`, session state, and validation docs. `cmdRun()` can mark a cancelled session as failed, `cmdCancel()` only sends `SIGTERM` to the recorded PID, `spawnStream()` does not own timeout/graceful-kill behavior, and live Codex/Gemini smoke is not separated from deterministic fake-provider tests.
+
+Important constraints from repo history and memory:
+
+- Work must stay in the #105 worktree and branch.
+- OpenSpec artifacts, implementation, tests, docs, and validation ledger must stay aligned as one contract.
+- Live provider smoke must remain opt-in and must not be treated as implicit approval.
+- TDD is required for behavior changes: failing tests first, then minimal implementation, then green verification.
+- Plans should name the skills/plugins/agents or review roles to use at each phase so later agentic workers can execute without guessing.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define one timeout contract for `aco run` and `aco ask`.
+- Preserve current success-path provider streaming and artifact layout.
+- Make provider failure, timeout, and cancellation produce deterministic session status and `error.log`.
+- Record child process PID and terminate the provider process group where the platform supports it.
+- Keep `aco cancel --session <id>` idempotent and safe for already-final sessions.
+- Add deterministic unit/integration tests using fake/mock providers.
+- Document opt-in real Codex/Gemini smoke separately from CI-safe repo tests.
+
+**Non-Goals:**
+
+- No live provider execution during CI or normal repo tests.
+- No provider auth redesign.
+- No multi-provider aggregation or structured `findings.json` schema.
+- No OS-level sandbox promise for `restricted`; it remains a provider instruction/profile boundary.
+- No Go runtime behavior changes except documentation cross-reference if needed.
+
+## Decisions
+
+### Decision 1: Put timeout control in the provider execution layer
+
+`invokeProviderForSession()` will accept resolved execution control, including timeout milliseconds and kill grace milliseconds. It will pass timeout/cancel metadata through `InvokeOptions` to provider implementations and `spawnStream()`.
+
+Rationale:
+
+- `aco run` and `aco ask` already share `invokeProviderForSession()`.
+- Timeout status and `error.log` handling must be consistent across both call sites.
+- Keeping timeout below provider-specific classes avoids duplicating timers in Codex/Gemini providers.
+
+Alternative considered: implement timeout only in each CLI command. That would miss provider-level PID/process-group cleanup and would likely drift between `run` and `ask`.
+
+### Decision 2: Use `--timeout <seconds>` plus `ACO_TIMEOUT_SECONDS`, with a 300 second default
+
+Timeout precedence will be:
+
+1. CLI `--timeout <seconds>`
+2. `ACO_TIMEOUT_SECONDS`
+3. Default `300`
+
+Rationale:
+
+- It matches the existing Go runtime contract closely enough for user expectations.
+- Seconds are easier to document for operators and smoke runbooks.
+- Tests can use fake provider binaries with a one-second timeout, while lower-level unit tests can exercise millisecond helpers.
+
+Alternative considered: add `--timeout-ms`. That is more test-friendly but creates a second public unit and diverges from the documented Go runtime shape.
+
+### Decision 3: Add typed provider execution errors
+
+Add a small runtime error module, for example `packages/wrapper/src/runtime/provider-execution-error.ts`, with `ProviderTimeoutError` and `ProviderCancelledError` or a shared error type carrying a stable `code`.
+
+Rationale:
+
+- `cmdRun()` and `cmdAsk()` can decide whether to mark `failed` or preserve `cancelled` without brittle string matching.
+- Tests can assert semantic error codes and user-visible messages.
+
+Alternative considered: keep plain `Error` messages. That is smaller, but it makes status handling fragile and hard to test without string coupling.
+
+### Decision 4: Terminate process groups for real child processes
+
+`spawnStream()` will spawn provider CLIs with a POSIX process group where supported, record the child PID, and use a helper such as `terminateProviderProcess(pid, signal)` for timeout/cancel cleanup. On POSIX the helper will prefer `process.kill(-pid, signal)` and fall back to `process.kill(pid, signal)` when group kill fails. On Windows it will kill the child PID.
+
+Rationale:
+
+- Codex/Gemini CLIs can spawn worker subprocesses.
+- PID-only `SIGTERM` is not enough for reliable cancellation.
+- This mirrors the existing Go runtime process-group contract without porting Go code.
+
+Alternative considered: leave Node wrapper cancellation as PID-only. That is backward-compatible but does not satisfy the #105 reliability goal.
+
+### Decision 5: Preserve cancelled state as final
+
+If a running CLI observes that `task.json` was changed to `cancelled`, it must not overwrite it with `done` or `failed`. `cmdAsk()` already checks this in some paths; `cmdRun()` needs equivalent logic.
+
+Rationale:
+
+- `aco cancel` is a second process racing with the original `aco run`/`aco ask`.
+- The session store is the observable contract; the final status must reflect the operator action.
+
+Alternative considered: treat cancellation as failure. That loses operator intent and makes `aco status` less useful.
+
+### Decision 6: Keep live provider smoke opt-in and record evidence separately
+
+Add a runbook/scripted command for real Codex/Gemini smoke, but keep default `npm test`, targeted package tests, and CI smoke on mock/fake providers. Add a validation ledger under this change to split deterministic repo tests from optional live smoke.
+
+Rationale:
+
+- The user's workflow distinguishes local tests, dry-run proof, live runtime proof, and pushed/merged state.
+- Live providers can be slow, authenticated, rate-limited, or mutating; they need explicit consent.
+
+Alternative considered: run a small real Gemini smoke as part of completion. That crosses the consent boundary and makes CI unreliable.
+
+## Risks / Trade-offs
+
+- Timeout race can leave a child process alive if the provider CLI ignores `SIGTERM` → use process-group kill on POSIX, schedule `SIGKILL` after grace, and test with a fake child process that does not exit immediately.
+- Process-group spawn can behave differently on Windows → keep a platform fallback and avoid claiming full process-tree cleanup on unsupported platforms.
+- `aco cancel` cannot update a run-level `ledger.json` after the original `aco ask` process exits early or is killed externally → preserve session truth in `task.json`/`error.log` and document run ledger behavior.
+- One-second timeout integration tests can be slow in full suites → keep most timeout behavior in unit tests with fake clocks/helpers, and limit CLI integration tests to one or two focused cases.
+- Adding a public `--timeout` flag changes CLI help and docs → keep it additive, backward-compatible, and default-preserving.
+
+## Migration Plan
+
+1. Add failing tests for timeout parsing, provider timeout failure, PID recording, cancellation state preservation, and process termination.
+2. Implement minimal runtime execution-control helpers and wire them through `aco run`, `aco ask`, provider `InvokeOptions`, and `spawnStream()`.
+3. Update docs and runbook with deterministic test commands and opt-in live smoke commands.
+4. Add `validation-ledger.md` for this change, recording which checks are repo-local and which live smoke checks were skipped or executed.
+5. Validate with `openspec validate add-provider-smoke-timeout-session-reliability --type change --strict`, targeted package tests, `npm run typecheck`, `npm test`, and `git diff --check`.
+
+Rollback is straightforward because the change is additive: revert the branch commits. No data migration is required; existing session artifacts remain readable.
+
+## Open Questions
+
+- Should `--timeout 0` be rejected or interpreted as no timeout? This design rejects non-positive values and keeps "no timeout" unsupported for public commands.
+- Should `aco cancel` write `error.log` immediately, or should the running process write it after observing cancellation? This design makes `aco cancel` write a concise cancellation entry so the artifact exists even if the runner exits abruptly.
+- Should `aco ask` run-level `ledger.json` include a top-level timeout setting? This design records timeout per run and per session if implementation can do so without broad schema churn; otherwise it documents timeout in session metadata first.

--- a/openspec/changes/add-provider-smoke-timeout-session-reliability/proposal.md
+++ b/openspec/changes/add-provider-smoke-timeout-session-reliability/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Real Codex and Gemini provider runs can hang, take minutes, or fail because of local auth/runtime state while the current Node wrapper contract leaves timeout, cancellation, session status, and error artifacts underspecified. This blocks reliable pilot use because `aco run` and `aco ask` can hold the supervising Codex/Claude session without a deterministic failure record.
+
+## What Changes
+
+- Add a provider execution reliability contract for Node wrapper `aco run` and `aco ask`.
+- Define timeout precedence and observable behavior for slow provider invocations.
+- Ensure timeout and provider failure paths end sessions deterministically and write `error.log`.
+- Record child process PID metadata in `task.json` when a provider process is spawned.
+- Harden `aco cancel --session <id>` so cancellation updates session state and best-effort terminates the provider child process.
+- Add fake/mock provider tests for success, provider failure, timeout, cancellation, and PID recording.
+- Document opt-in real Codex/Gemini smoke commands and keep live provider calls out of default CI.
+- Keep validation evidence split between repo-local deterministic tests and live runtime smoke.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-session-reliability`: Node wrapper provider execution timeout, cancellation, PID, session status, and validation evidence behavior for `aco run` and `aco ask`.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected code: `packages/wrapper/src/runtime/provider-session-runner.ts`, `packages/wrapper/src/commands/ask.ts`, `packages/wrapper/src/cli.ts`, `packages/wrapper/src/session/store.ts`, provider implementations, and focused tests under `packages/wrapper/tests/`.
+- Affected docs: `docs/reference/session-artifacts.md`, `docs/security.md`, `docs/guides/runbook.md`, and the change validation ledger.
+- Runtime impact: provider child processes gain explicit timeout/cancel handling while success-path streaming and artifact layout remain backward-compatible.
+- Security impact: live provider smoke remains opt-in, and deterministic tests use mock/fake providers so CI does not require provider credentials or leak secrets.

--- a/openspec/changes/add-provider-smoke-timeout-session-reliability/specs/provider-session-reliability/spec.md
+++ b/openspec/changes/add-provider-smoke-timeout-session-reliability/specs/provider-session-reliability/spec.md
@@ -1,0 +1,122 @@
+## ADDED Requirements
+
+### Requirement: Provider execution timeout
+
+The Node wrapper SHALL apply a documented provider execution timeout to `aco run` and provider-invoking `aco ask` sessions.
+
+#### Scenario: Default timeout is applied
+
+- **WHEN** a user runs `aco run <provider> <command>` or `aco ask --yes` without a timeout flag or timeout environment variable
+- **THEN** the provider execution timeout SHALL be `300` seconds.
+
+#### Scenario: Environment timeout is applied
+
+- **WHEN** `ACO_TIMEOUT_SECONDS` is set to a positive numeric value and the user does not pass `--timeout`
+- **THEN** the provider execution timeout SHALL use `ACO_TIMEOUT_SECONDS`.
+
+#### Scenario: CLI timeout takes precedence
+
+- **WHEN** the user passes `--timeout <seconds>` and `ACO_TIMEOUT_SECONDS` is also set
+- **THEN** the provider execution timeout SHALL use the CLI `--timeout` value.
+
+#### Scenario: Invalid timeout is rejected before provider execution
+
+- **WHEN** the user passes a non-numeric, zero, or negative `--timeout` value
+- **THEN** the command SHALL exit non-zero before creating a provider session
+- **AND** the error message SHALL identify `--timeout` as invalid.
+
+#### Scenario: Timeout fails the session deterministically
+
+- **WHEN** a provider invocation exceeds the resolved timeout
+- **THEN** the command SHALL terminate provider execution
+- **AND** the session `task.json` status SHALL be `failed`
+- **AND** `error.log` SHALL include a timeout message with the provider name and timeout duration
+- **AND** the command SHALL exit non-zero.
+
+### Requirement: Provider process metadata and cleanup
+
+The Node wrapper SHALL record spawned provider process metadata and use it for best-effort cancellation and timeout cleanup.
+
+#### Scenario: PID is recorded after provider spawn
+
+- **WHEN** a provider implementation spawns a child process and exposes a PID
+- **THEN** the session `task.json` SHALL include that PID before provider output completion.
+
+#### Scenario: Timeout terminates provider process group when supported
+
+- **WHEN** a timeout occurs for a spawned provider child on a POSIX platform
+- **THEN** the wrapper SHALL send a termination signal to the provider process group
+- **AND** SHALL send a force-kill signal after the configured grace period if the child has not exited.
+
+#### Scenario: Timeout cleanup falls back to PID kill
+
+- **WHEN** process-group termination is unsupported or fails
+- **THEN** the wrapper SHALL attempt to terminate the recorded provider PID directly
+- **AND** SHALL still record the timeout failure in session artifacts.
+
+### Requirement: Session cancellation is final and observable
+
+The Node wrapper SHALL treat `aco cancel --session <id>` as an idempotent operator action that produces an observable final session state.
+
+#### Scenario: Running session is cancelled
+
+- **WHEN** a user runs `aco cancel --session <id>` for a running session with a recorded PID
+- **THEN** the wrapper SHALL best-effort terminate provider execution
+- **AND** the session `task.json` status SHALL become `cancelled`
+- **AND** `error.log` SHALL include a cancellation message
+- **AND** `aco cancel` SHALL exit successfully.
+
+#### Scenario: Runner preserves cancelled status
+
+- **WHEN** the original `aco run` or `aco ask --yes` process observes that its session was marked `cancelled`
+- **THEN** it SHALL NOT overwrite the session status with `done` or `failed`
+- **AND** it SHALL exit non-zero after recording any available cancellation details.
+
+#### Scenario: Final sessions are not cancelled again
+
+- **WHEN** a user runs `aco cancel --session <id>` for a session already marked `done`, `failed`, or `cancelled`
+- **THEN** the wrapper SHALL leave the session status unchanged
+- **AND** SHALL print an idempotent message rather than raising a provider execution error.
+
+### Requirement: Provider failures preserve artifacts
+
+The Node wrapper SHALL preserve inspectable artifacts for provider failure, timeout, and cancellation paths.
+
+#### Scenario: Provider failure preserves partial output
+
+- **WHEN** a provider emits output and then exits with an error
+- **THEN** `output.log` SHALL retain the emitted provider output
+- **AND** `error.log` SHALL contain the provider failure message
+- **AND** session status SHALL be `failed`.
+
+#### Scenario: Ask run ledger separates failed sessions
+
+- **WHEN** `aco ask --yes` has a provider session that fails, times out, or is cancelled
+- **THEN** the run-level `ledger.json` SHALL include that provider session with status `failed` or `cancelled`
+- **AND** the run command SHALL exit non-zero.
+
+#### Scenario: Status reports timeout and cancellation metadata
+
+- **WHEN** a user runs `aco status --session <id>` after timeout or cancellation
+- **THEN** the command SHALL report the final status, provider, command, started time, ended time, permission profile, and PID when present.
+
+### Requirement: Deterministic tests and opt-in live smoke
+
+The change SHALL distinguish deterministic repo validation from live provider smoke.
+
+#### Scenario: Default tests avoid live providers
+
+- **WHEN** `npm test` or the targeted package test command runs in CI
+- **THEN** it SHALL use mock or fake providers only
+- **AND** it SHALL NOT invoke real Codex or Gemini provider CLIs for remote model execution.
+
+#### Scenario: Live smoke is explicitly opted in
+
+- **WHEN** an operator wants to run real Codex or Gemini smoke
+- **THEN** the docs or runbook SHALL provide an explicit opt-in command
+- **AND** the command SHALL state that it can require provider auth and real runtime latency.
+
+#### Scenario: Validation ledger separates evidence classes
+
+- **WHEN** the change is prepared for PR
+- **THEN** its validation ledger SHALL separate repo-local tests, dry-run proof, and optional live runtime smoke results.

--- a/openspec/changes/add-provider-smoke-timeout-session-reliability/tasks.md
+++ b/openspec/changes/add-provider-smoke-timeout-session-reliability/tasks.md
@@ -1,0 +1,43 @@
+## 1. Spec and Review Gates
+
+- [x] 1.1 Review `proposal.md`, `design.md`, and `specs/provider-session-reliability/spec.md` against issue #105 acceptance criteria and update any missing timeout, cancellation, PID, artifact, live-smoke, or validation-ledger requirement before implementation.
+- [x] 1.2 Record architecture/system-design, testing/TDD, and security/runtime review results in the change directory before writing production code.
+- [x] 1.3 Confirm the public timeout contract: `--timeout <seconds>`, `ACO_TIMEOUT_SECONDS`, and default `300` seconds.
+- [x] 1.4 Confirm live Codex/Gemini smoke remains opt-in and is not part of default CI or `npm test`.
+
+## 2. Failing Tests First
+
+- [x] 2.1 Add failing tests for timeout parsing and precedence in `aco run` and `aco ask`.
+- [x] 2.2 Add a failing runtime test proving a slow fake provider times out, exits non-zero, marks the session `failed`, preserves partial `output.log`, and writes `error.log`.
+- [x] 2.3 Add a failing runtime test proving provider PID is recorded in `task.json` after a spawned fake provider starts.
+- [x] 2.4 Add a failing cancellation test proving `aco cancel --session <id>` marks a running session `cancelled`, writes `error.log`, and terminates the fake provider process.
+- [x] 2.5 Add a failing race test proving the original `aco run` or `aco ask --yes` process does not overwrite a `cancelled` session with `done` or `failed`.
+- [x] 2.6 Add failing tests for provider failure artifact preservation and `aco ask` run-level ledger status when a provider fails, times out, or is cancelled.
+- [x] 2.7 Run the new targeted tests before implementation and record the expected RED failures in `validation-ledger.md`.
+
+## 3. Runtime Contract Implementation
+
+- [x] 3.1 Add shared timeout parsing/resolution helpers for CLI flag, environment variable, default, and validation error handling.
+- [x] 3.2 Add provider execution error types for timeout and cancellation so command handlers do not rely on string matching.
+- [x] 3.3 Extend `InvokeOptions`, `invokeProviderForSession()`, and `spawnStream()` with timeout/graceful-kill execution control.
+- [x] 3.4 Update `spawnStream()` to record PID, use process-group termination on POSIX where supported, and fall back to direct PID termination.
+- [x] 3.5 Update `cmdRun()` to pass timeout control, preserve cancelled status, write `error.log`, and exit with the documented status.
+- [x] 3.6 Update `cmdAsk()` to pass timeout control, preserve cancelled status, write per-session artifacts, and reflect failed/cancelled sessions in `ledger.json`.
+- [x] 3.7 Update `cmdCancel()` to write a cancellation `error.log`, best-effort terminate the provider process, and remain idempotent for final sessions.
+
+## 4. Documentation and Validation Evidence
+
+- [x] 4.1 Update `docs/reference/session-artifacts.md` with timeout, cancellation, PID, `error.log`, and run ledger behavior.
+- [x] 4.2 Update `docs/security.md` with the timeout/cancel boundary and the fact that live provider smoke is explicit and credential-dependent.
+- [x] 4.3 Update `docs/guides/runbook.md` with deterministic repo validation commands and opt-in real Codex/Gemini smoke commands.
+- [x] 4.4 Add `openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md` separating repo-local tests, dry-run proof, optional live runtime smoke, and skipped live-smoke rationale.
+
+## 5. Review, Simplification, and Completion Verification
+
+- [x] 5.1 Run targeted timeout/cancel/session tests and make them pass with minimal implementation.
+- [x] 5.2 Run `npm run typecheck --workspace=packages/wrapper`.
+- [x] 5.3 Run `npm test --workspace=packages/wrapper`.
+- [x] 5.4 Run `npm run test:smoke --workspace=packages/wrapper` if the changed runtime paths affect existing smoke coverage.
+- [x] 5.5 Run `openspec validate add-provider-smoke-timeout-session-reliability --type change --strict`.
+- [x] 5.6 Run `git diff --check`.
+- [x] 5.7 Perform TypeScript/runtime/security review and a code-simplifier pass, then update `validation-ledger.md` with final evidence before claiming implementation complete.

--- a/openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md
+++ b/openspec/changes/add-provider-smoke-timeout-session-reliability/validation-ledger.md
@@ -1,0 +1,45 @@
+# Provider Smoke Timeout Session Reliability Validation Ledger
+
+## Scope
+
+- Issue: #105
+- Change: `add-provider-smoke-timeout-session-reliability`
+- Worktree: `/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-provider-smoke-timeout-session`
+- Branch: `fix/provider-smoke-timeout-session`
+
+## Repo-Local Deterministic Evidence
+
+| Command                                                                                                             | Result                 | Notes                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `openspec validate add-provider-smoke-timeout-session-reliability --type change --strict`                           | Passed                 | `Change 'add-provider-smoke-timeout-session-reliability' is valid`.                                                                                                      |
+| `npx --yes prettier@3.0.0 --check <touched files>`                                                                  | Passed                 | Formatting initially flagged the new test and ledger; `prettier --write` was run, then check passed.                                                                     |
+| `npm exec --workspace=packages/wrapper -- node --require tsx/cjs --test tests/provider-session-reliability.test.ts` | RED failed as expected | Before implementation: invalid `--timeout` was ignored, slow provider runs succeeded, ask ledger stayed successful, and cancellation did not finish the original runner. |
+| `npm exec --workspace=packages/wrapper -- node --require tsx/cjs --test tests/provider-session-reliability.test.ts` | Passed                 | After implementation: 9 tests passed, 0 failed.                                                                                                                          |
+| `npm run typecheck --workspace=packages/wrapper`                                                                    | Passed                 | `tsc --noEmit` exited 0.                                                                                                                                                 |
+| `npm test --workspace=packages/wrapper`                                                                             | Passed                 | 226 tests passed, 0 failed.                                                                                                                                              |
+| `npm run test:smoke --workspace=packages/wrapper`                                                                   | Passed                 | 10 smoke checks passed, 0 failed.                                                                                                                                        |
+| `git diff --check`                                                                                                  | Passed                 | No whitespace errors after formatting.                                                                                                                                   |
+
+## Dry-Run Evidence
+
+| Command                                                                                                                                           | Result | Notes                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ---------------------------------------------------------------- |
+| `npm exec --workspace=packages/wrapper -- node --require tsx/cjs src/cli.ts ask --providers mock --task "timeout dry run" --dry-run --timeout 12` | Passed | Printed `Timeout seconds: 12` and `Provider execution: skipped`. |
+
+## Optional Live Runtime Smoke
+
+| Command                                                                                                             | Result  | Notes                                                                       |
+| ------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------------------------------------------- |
+| `node packages/wrapper/dist/cli.js run gemini review --input "hello" --permission-profile restricted --timeout 120` | Skipped | Live provider execution requires explicit approval and local provider auth. |
+| `node packages/wrapper/dist/cli.js run codex review --input "hello" --permission-profile restricted --timeout 120`  | Skipped | Live provider execution requires explicit approval and local provider auth. |
+
+## Review Notes
+
+- Architecture/system-design review: reviewed before production code. The timeout/cancel control belongs in the shared Node wrapper provider execution path (`invokeProviderForSession()` -> provider `invoke()` -> `spawnStream()`), not separately in every provider command handler. The design keeps live provider smoke opt-in and preserves existing success-path artifact layout.
+- Testing/TDD review: reviewed before production code. Implementation must begin with failing deterministic tests that use fake provider binaries and temp `HOME`; real Codex/Gemini provider execution remains outside default CI.
+- Security/runtime review: reviewed before production code. Timeout and cancellation are reliability controls, not sandbox guarantees. Cancellation must be best-effort and artifact-visible, and live smoke must not run without explicit approval and local provider auth.
+- Code-simplifier pass: completed after green targeted/full tests. Recent changes stayed split into timeout parsing, typed execution errors, process termination, shared runner wiring, command handlers, tests, and docs; no extra abstraction was added.
+
+## Evidence Boundary
+
+This ledger intentionally separates deterministic repo evidence from live runtime smoke. A green repo test run does not prove live provider latency/auth behavior. A live provider smoke result must not be claimed unless the command was explicitly approved, executed, and recorded here.

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "prepack": "node -e \"const fs = require('fs'); const path = require('path'); const src = path.resolve(process.cwd(), '../../templates'); const dest = path.resolve(process.cwd(), 'templates'); fs.rmSync(dest, { recursive: true, force: true }); fs.mkdirSync(dest, { recursive: true }); fs.cpSync(src, dest, { recursive: true });\"",
-    "test": "node --require tsx/cjs --test tests/command-output-buffering.test.ts tests/spawn-stream-buffering.test.ts tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts tests/ask-cli.test.ts tests/doctor-cli.test.ts tests/pack-runtime-contract.test.ts",
+    "test": "node --require tsx/cjs --test tests/command-output-buffering.test.ts tests/spawn-stream-buffering.test.ts tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts tests/ask-cli.test.ts tests/doctor-cli.test.ts tests/pack-runtime-contract.test.ts tests/provider-session-reliability.test.ts",
     "test:pack-runtime-contract": "tsx tests/pack-runtime-contract-smoke.ts",
     "test:smoke": "tsx tests/smoke.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -24,6 +24,11 @@ import { renderRuntimeDashboard } from './runtime/dashboard.js';
 import { formatAuthStatus } from './runtime/auth-display.js';
 import { invokeProviderForSession } from './runtime/provider-session-runner.js';
 import { resolveRunPromptTemplate } from './runtime/run-prompt-template.js';
+import {
+  parseProviderTimeoutFlag,
+  resolveProviderExecutionControl,
+} from './runtime/provider-execution-control.js';
+import { terminateProviderProcess } from './runtime/provider-process.js';
 import { runSync } from './sync/sync-engine.js';
 
 const execFileAsync = promisify(execFile);
@@ -150,7 +155,7 @@ async function cmdProvider(args: string[]): Promise<void> {
 async function cmdRun(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.error(
-      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted]'
+      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>]'
     );
     process.exit(0);
   }
@@ -160,7 +165,7 @@ async function cmdRun(args: string[]): Promise<void> {
 
   if (!providerKey || !command) {
     console.error(
-      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted]'
+      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>]'
     );
     process.exit(EXIT_ERROR);
   }
@@ -176,6 +181,13 @@ async function cmdRun(args: string[]): Promise<void> {
     console.error(
       `Invalid --permission-profile '${permissionProfile}'. Valid values: default|restricted|unrestricted`
     );
+    process.exit(EXIT_ERROR);
+  }
+  let executionControl: ReturnType<typeof resolveProviderExecutionControl>;
+  try {
+    executionControl = resolveProviderExecutionControl(parseProviderTimeoutFlag(args));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
     process.exit(EXIT_ERROR);
   }
   const inputFlag = parseFlag(args, '--input') ?? '';
@@ -217,8 +229,16 @@ async function cmdRun(args: string[]): Promise<void> {
     sessionId: session.id,
     output: tee,
     outputBuffer: resolveRunOutputBuffering(),
+    timeoutMs: executionControl.timeoutMs,
+    killGraceMs: executionControl.killGraceMs,
   });
   const runError = runResult.error;
+  const latest = await sessionStore.read(session.id).catch(() => undefined);
+
+  if (latest?.status === 'cancelled') {
+    console.error(`Session ${session.id} cancelled.`);
+    process.exit(EXIT_ERROR);
+  }
 
   if (runError) {
     const msg = runError instanceof Error ? runError.message : String(runError);
@@ -271,6 +291,7 @@ async function cmdStatus(args: string[]): Promise<void> {
     console.log(`Status:     ${record.status}`);
     console.log(`Started:    ${record.startedAt}`);
     if (record.endedAt) console.log(`Ended:      ${record.endedAt}`);
+    if (record.pid !== undefined) console.log(`PID:        ${record.pid}`);
     if (record.permissionProfile) console.log(`Permission: ${record.permissionProfile}`);
     if (record.runtimeContext) {
       const active = record.runtimeContext.active;
@@ -329,15 +350,13 @@ async function cmdCancel(args: string[]): Promise<void> {
     return;
   }
 
-  if (record.pid) {
-    try {
-      process.kill(record.pid, 'SIGTERM');
-    } catch {
-      // The process may have already exited — safe to ignore
-    }
-  }
-
+  await appendFile(sessionStore.errorLogPath(sessionId), `Session ${sessionId} cancelled.\n`, {
+    mode: 0o600,
+  });
   await sessionStore.markCancelled(sessionId);
+  if (record.pid) {
+    terminateProviderProcess(record.pid, 'SIGTERM');
+  }
   console.log(`Session ${sessionId} cancelled.`);
 }
 
@@ -451,7 +470,7 @@ function printUsage(): void {
   aco sync [--check] [--dry-run] [--force]
   aco ask --task <text> [--providers codex,gemini,mock] [--input <text>] [--input-file <path>] [--preset <name>] [--permission-profile restricted|default|unrestricted] [--output-mode brief|save-only|full] [--dry-run|--yes]
   aco doctor
-  aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted]
+  aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>]
   aco result [--session <id>]
   aco status [--session <id>]
   aco cancel [--session <id>]

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -8,6 +8,12 @@ import { providerRegistry } from '../providers/registry.js';
 import { sessionStore } from '../session/store.js';
 import type { OutputBufferPolicy, PermissionProfile } from '../providers/interface.js';
 import { invokeProviderForSession } from '../runtime/provider-session-runner.js';
+import {
+  parseProviderTimeoutFlag,
+  resolveProviderExecutionControl,
+  resolveProviderTimeoutSeconds,
+  type ProviderExecutionControl,
+} from '../runtime/provider-execution-control.js';
 import { defaultSummarizeOutput } from '../util/summarize-output.js';
 
 const EXIT_ERROR = 1;
@@ -39,6 +45,8 @@ interface AskOptions {
   outputMode: OutputMode;
   yes: boolean;
   dryRun: boolean;
+  timeoutSeconds: number;
+  executionControl: ProviderExecutionControl;
 }
 
 interface AskSessionLedger {
@@ -57,7 +65,12 @@ export async function cmdAsk(args: string[]): Promise<void> {
     return;
   }
 
-  const options = parseAskOptions(args);
+  let options: AskOptions;
+  try {
+    options = parseAskOptions(args);
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err));
+  }
   validateAskOptions(options);
 
   const providers = resolveProviders(options.providers);
@@ -114,6 +127,8 @@ export async function cmdAsk(args: string[]): Promise<void> {
       output: outputStream,
       outputBuffer,
       maxOutputBuffer: SUMMARY_SOURCE_CHAR_LIMIT,
+      timeoutMs: options.executionControl.timeoutMs,
+      killGraceMs: options.executionControl.killGraceMs,
       onChunk:
         options.outputMode === 'full'
           ? (chunk) => {
@@ -182,6 +197,7 @@ export async function cmdAsk(args: string[]): Promise<void> {
         providers: providers.map((provider) => provider.key),
         permissionProfile: options.permissionProfile,
         outputMode: options.outputMode,
+        timeoutSeconds: options.timeoutSeconds,
         advisory: ADVISORY_NOTICE,
         sessions,
       },
@@ -206,6 +222,7 @@ export async function cmdAsk(args: string[]): Promise<void> {
 }
 
 function parseAskOptions(args: string[]): AskOptions {
+  const timeoutFlag = parseProviderTimeoutFlag(args);
   return {
     providers: parseProviders(parseFlag(args, '--providers')),
     task: parseFlag(args, '--task'),
@@ -216,6 +233,8 @@ function parseAskOptions(args: string[]): AskOptions {
     outputMode: parseFlag<OutputMode>(args, '--output-mode') ?? 'brief',
     yes: args.includes('--yes'),
     dryRun: args.includes('--dry-run'),
+    timeoutSeconds: resolveProviderTimeoutSeconds(timeoutFlag),
+    executionControl: resolveProviderExecutionControl(timeoutFlag),
   };
 }
 
@@ -320,6 +339,7 @@ function printDryRun(options: AskOptions, input: string, preset: string | undefi
   console.log(`Providers: ${options.providers.join(',')}`);
   console.log(`Permission profile: ${options.permissionProfile}`);
   console.log(`Output mode: ${options.outputMode}`);
+  console.log(`Timeout seconds: ${options.timeoutSeconds}`);
   if (options.preset) console.log(`Preset: ${options.preset}`);
   console.log(`Task: ${options.task ?? '(preset only)'}`);
   console.log(`Input bytes: ${Buffer.byteLength(input, 'utf8')}`);
@@ -365,6 +385,7 @@ function renderRunBrief(runId: string, options: AskOptions, sessions: AskSession
     `Providers: ${options.providers.join(',')}`,
     `Permission profile: ${options.permissionProfile}`,
     `Output mode: ${options.outputMode}`,
+    `Timeout seconds: ${options.timeoutSeconds}`,
     '',
     `Advisory: ${ADVISORY_NOTICE}`,
     '',
@@ -413,6 +434,7 @@ Options:
   --permission-profile <profile>  restricted|default|unrestricted (default: restricted)
   --output-mode <mode>            brief|save-only|full (default: brief)
                                     brief summary bound: ${SUMMARY_CHAR_LIMIT} chars
+  --timeout <seconds>             Provider execution timeout (default: 300, env: ACO_TIMEOUT_SECONDS)
   --dry-run                       Print execution plan without invoking providers
   --yes                           Explicitly consent to provider execution`);
 }

--- a/packages/wrapper/src/providers/interface.ts
+++ b/packages/wrapper/src/providers/interface.ts
@@ -37,6 +37,10 @@ export interface InvokeOptions {
   outputBuffer?: OutputBufferPolicy;
   /** Called once the provider process has been spawned, with its PID. */
   onPid?: (pid: number) => void;
+  /** Maximum provider execution time in milliseconds. */
+  timeoutMs?: number;
+  /** Grace period after SIGTERM before SIGKILL. */
+  killGraceMs?: number;
 }
 
 export interface IProvider {

--- a/packages/wrapper/src/runtime/provider-execution-control.ts
+++ b/packages/wrapper/src/runtime/provider-execution-control.ts
@@ -1,0 +1,48 @@
+export const DEFAULT_PROVIDER_TIMEOUT_SECONDS = 300;
+export const DEFAULT_PROVIDER_KILL_GRACE_MS = 5_000;
+
+export interface TimeoutEnv {
+  ACO_TIMEOUT_SECONDS?: string;
+}
+
+export interface ProviderExecutionControl {
+  timeoutMs: number;
+  killGraceMs: number;
+}
+
+export function resolveProviderTimeoutSeconds(
+  flagValue: string | undefined,
+  env: TimeoutEnv = process.env
+): number {
+  const source = flagValue ?? env.ACO_TIMEOUT_SECONDS;
+  if (source === undefined || source === '') return DEFAULT_PROVIDER_TIMEOUT_SECONDS;
+
+  const parsed = Number(source);
+  const label = flagValue !== undefined ? '--timeout' : 'ACO_TIMEOUT_SECONDS';
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label}: expected a positive number of seconds`);
+  }
+
+  return parsed;
+}
+
+export function resolveProviderExecutionControl(
+  flagValue: string | undefined,
+  env: TimeoutEnv = process.env
+): ProviderExecutionControl {
+  return {
+    timeoutMs: Math.ceil(resolveProviderTimeoutSeconds(flagValue, env) * 1000),
+    killGraceMs: DEFAULT_PROVIDER_KILL_GRACE_MS,
+  };
+}
+
+export function parseProviderTimeoutFlag(args: string[]): string | undefined {
+  const index = args.indexOf('--timeout');
+  if (index === -1) return undefined;
+
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith('-')) {
+    throw new Error('Invalid --timeout: expected a positive number of seconds');
+  }
+  return value;
+}

--- a/packages/wrapper/src/runtime/provider-execution-error.ts
+++ b/packages/wrapper/src/runtime/provider-execution-error.ts
@@ -1,0 +1,18 @@
+export type ProviderExecutionErrorCode = 'timeout' | 'cancelled';
+
+export class ProviderExecutionError extends Error {
+  constructor(
+    readonly code: ProviderExecutionErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = 'ProviderExecutionError';
+  }
+}
+
+export function isProviderExecutionError(
+  error: unknown,
+  code?: ProviderExecutionErrorCode
+): error is ProviderExecutionError {
+  return error instanceof ProviderExecutionError && (code === undefined || error.code === code);
+}

--- a/packages/wrapper/src/runtime/provider-process.ts
+++ b/packages/wrapper/src/runtime/provider-process.ts
@@ -1,0 +1,19 @@
+export function terminateProviderProcess(pid: number, signal: NodeJS.Signals = 'SIGTERM'): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+
+  if (process.platform !== 'win32') {
+    try {
+      process.kill(-pid, signal);
+      return true;
+    } catch {
+      // Fall back to direct PID termination below.
+    }
+  }
+
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -21,6 +21,10 @@ export interface ProviderSessionRunOptions {
   outputBuffer?: OutputBufferPolicy;
   /** Maximum number of characters to buffer in memory. Used only for bounded output collection. */
   maxOutputBuffer?: number;
+  /** Maximum provider execution time in milliseconds. */
+  timeoutMs?: number;
+  /** Grace period after SIGTERM before SIGKILL. */
+  killGraceMs?: number;
 }
 
 export interface ProviderSessionRunResult {
@@ -57,6 +61,8 @@ export async function invokeProviderForSession(
         permissionProfile: options.permissionProfile,
         sessionId: options.sessionId,
         outputBuffer,
+        timeoutMs: options.timeoutMs,
+        killGraceMs: options.killGraceMs,
         onPid: (pid) => {
           sessionStore.update(options.sessionId, { pid }).catch((err: unknown) => {
             console.warn(

--- a/packages/wrapper/src/util/spawn-stream.ts
+++ b/packages/wrapper/src/util/spawn-stream.ts
@@ -7,6 +7,9 @@ import {
   type OutputBufferPolicy,
 } from '../providers/interface.js';
 import { parseSentinel, type SentinelMeta } from './sentinel.js';
+import { DEFAULT_PROVIDER_KILL_GRACE_MS } from '../runtime/provider-execution-control.js';
+import { ProviderExecutionError } from '../runtime/provider-execution-error.js';
+import { terminateProviderProcess } from '../runtime/provider-process.js';
 
 export interface SpawnStreamConfig {
   /** Process name used in error messages, e.g. "gemini". */
@@ -84,10 +87,40 @@ export async function* spawnStream(
 
   const child = spawn(binary, args, {
     stdio: [config.stdin, 'pipe', 'pipe'],
+    detached: process.platform !== 'win32',
   });
 
   if (child.pid !== undefined) {
     options?.onPid?.(child.pid);
+  }
+
+  let timedOut = false;
+  let timeoutTimer: NodeJS.Timeout | undefined;
+  let forceKillTimer: NodeJS.Timeout | undefined;
+
+  const clearExecutionTimers = (): void => {
+    if (timeoutTimer !== undefined) {
+      clearTimeout(timeoutTimer);
+      timeoutTimer = undefined;
+    }
+    if (forceKillTimer !== undefined) {
+      clearTimeout(forceKillTimer);
+      forceKillTimer = undefined;
+    }
+  };
+
+  if (options?.timeoutMs !== undefined) {
+    timeoutTimer = setTimeout(() => {
+      timedOut = true;
+      if (child.pid !== undefined) {
+        terminateProviderProcess(child.pid, 'SIGTERM');
+        forceKillTimer = setTimeout(() => {
+          if (child.pid !== undefined) {
+            terminateProviderProcess(child.pid, 'SIGKILL');
+          }
+        }, options.killGraceMs ?? DEFAULT_PROVIDER_KILL_GRACE_MS);
+      }
+    }, options.timeoutMs);
   }
 
   if (config.stdin === 'pipe' && child.stdin) {
@@ -159,6 +192,17 @@ export async function* spawnStream(
 
   await new Promise<void>((resolve, reject) => {
     child.on('close', (code, signal) => {
+      clearExecutionTimers();
+      if (timedOut) {
+        reject(
+          new ProviderExecutionError(
+            'timeout',
+            `${config.processName} timed out after ${Math.ceil((options?.timeoutMs ?? 0) / 1000)}s`
+          )
+        );
+        return;
+      }
+
       if (code !== 0 || signal !== null) {
         const reason =
           signal === null
@@ -170,6 +214,9 @@ export async function* spawnStream(
         resolve();
       }
     });
-    child.on('error', reject);
+    child.on('error', (err) => {
+      clearExecutionTimers();
+      reject(err);
+    });
   });
 }

--- a/packages/wrapper/tests/provider-session-reliability.test.ts
+++ b/packages/wrapper/tests/provider-session-reliability.test.ts
@@ -1,0 +1,353 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { execFile, spawn } from 'node:child_process';
+import { delimiter, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { mkdir, mkdtemp, readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { resolveProviderTimeoutSeconds } from '../src/runtime/provider-execution-control';
+
+interface CliResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  home: string;
+}
+
+async function makeHome(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'aco-provider-reliability-home-'));
+}
+
+async function makeWorkspaceWithPrompt(): Promise<string> {
+  const workspace = await mkdtemp(join(tmpdir(), 'aco-provider-reliability-workspace-'));
+  const promptDir = join(workspace, '.claude', 'aco', 'prompts', 'gemini');
+  await mkdir(promptDir, { recursive: true });
+  await writeFile(join(promptDir, 'review.md'), 'Review this input.\n');
+  return workspace;
+}
+
+async function makeFakeProviderBin(name: string, body: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'aco-provider-reliability-bin-'));
+  const file = join(dir, name);
+  await writeFile(file, `#!/usr/bin/env node\n${body}\n`, { mode: 0o755 });
+  return dir;
+}
+
+function makeFakeGeminiBody(runtimeBody: string): string {
+  return [
+    "if (process.argv.includes('--version')) {",
+    "  process.stdout.write('gemini-test 0.0.0\\n');",
+    '  process.exit(0);',
+    '}',
+    runtimeBody,
+  ].join('\n');
+}
+
+async function runCli(
+  args: string[],
+  options: {
+    home?: string;
+    cwd?: string;
+    timeoutMs?: number;
+    pathPrefix?: string;
+    env?: Record<string, string>;
+  } = {}
+): Promise<CliResult> {
+  const home = options.home ?? (await makeHome());
+  const cliRoot = resolve(__dirname, '..');
+  const cliPath = join(cliRoot, 'src', 'cli.ts');
+  const tsxRegister = require.resolve('tsx/cjs');
+
+  return new Promise((resolveResult) => {
+    execFile(
+      process.execPath,
+      ['--require', tsxRegister, cliPath, ...args],
+      {
+        cwd: options.cwd ?? cliRoot,
+        timeout: options.timeoutMs ?? 5_000,
+        env: {
+          ...process.env,
+          HOME: home,
+          USERPROFILE: home,
+          NO_COLOR: '1',
+          GEMINI_API_KEY: 'test-key',
+          PATH: options.pathPrefix
+            ? `${options.pathPrefix}${delimiter}${process.env.PATH ?? ''}`
+            : process.env.PATH,
+          ...options.env,
+        },
+      },
+      (error, stdout, stderr) => {
+        const code =
+          error && typeof (error as { code?: unknown }).code === 'number'
+            ? (error as { code: number }).code ?? 1
+            : error
+            ? 1
+            : 0;
+        resolveResult({ code, stdout, stderr, home });
+      }
+    );
+  });
+}
+
+async function latestSessionId(home: string): Promise<string> {
+  const entries = await readdir(join(home, '.aco', 'sessions'));
+  assert.equal(entries.length, 1);
+  return entries[0];
+}
+
+async function latestRunId(home: string): Promise<string> {
+  const entries = await readdir(join(home, '.aco', 'runs'));
+  assert.equal(entries.length, 1);
+  return entries[0];
+}
+
+async function waitForSessionWithPid(home: string): Promise<{ id: string; pid: number }> {
+  const deadline = Date.now() + 3_000;
+  while (Date.now() < deadline) {
+    const root = join(home, '.aco', 'sessions');
+    if (existsSync(root)) {
+      const ids = await readdir(root);
+      for (const id of ids) {
+        const task = JSON.parse(await readFile(join(root, id, 'task.json'), 'utf8')) as {
+          pid?: unknown;
+        };
+        if (typeof task.pid === 'number') return { id, pid: task.pid };
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('Timed out waiting for session PID');
+}
+
+describe('provider execution timeout resolution', () => {
+  it('uses the 300 second default when no flag or env timeout is provided', () => {
+    assert.equal(resolveProviderTimeoutSeconds(undefined, {}), 300);
+  });
+
+  it('uses ACO_TIMEOUT_SECONDS when no CLI timeout is provided', () => {
+    assert.equal(resolveProviderTimeoutSeconds(undefined, { ACO_TIMEOUT_SECONDS: '42' }), 42);
+  });
+
+  it('lets --timeout take precedence over ACO_TIMEOUT_SECONDS', () => {
+    assert.equal(resolveProviderTimeoutSeconds('7', { ACO_TIMEOUT_SECONDS: '42' }), 7);
+  });
+
+  it('rejects non-positive and non-numeric timeout values', () => {
+    assert.throws(() => resolveProviderTimeoutSeconds('0', {}), /--timeout/);
+    assert.throws(() => resolveProviderTimeoutSeconds('-1', {}), /--timeout/);
+    assert.throws(() => resolveProviderTimeoutSeconds('abc', {}), /--timeout/);
+  });
+});
+
+describe('provider session reliability CLI contract', () => {
+  it('rejects invalid timeout values before creating provider sessions', async () => {
+    const workspace = await makeWorkspaceWithPrompt();
+    const binDir = await makeFakeProviderBin(
+      'gemini',
+      makeFakeGeminiBody("process.stdout.write('should not run\\n');")
+    );
+
+    const runResult = await runCli(['run', 'gemini', 'review', '--timeout', '0'], {
+      cwd: workspace,
+      pathPrefix: binDir,
+    });
+
+    assert.equal(runResult.code, 1);
+    assert.match(runResult.stderr, /Invalid --timeout/);
+    assert.equal(existsSync(join(runResult.home, '.aco', 'sessions')), false);
+
+    const askResult = await runCli(
+      ['ask', '--providers', 'mock', '--task', 'demo', '--yes', '--timeout', 'abc'],
+      { cwd: workspace }
+    );
+
+    assert.equal(askResult.code, 1);
+    assert.match(askResult.stderr, /Invalid --timeout/);
+    assert.equal(existsSync(join(askResult.home, '.aco', 'sessions')), false);
+  });
+
+  it('marks a slow spawned provider failed and writes timeout artifacts', async () => {
+    const workspace = await makeWorkspaceWithPrompt();
+    const binDir = await makeFakeProviderBin(
+      'gemini',
+      makeFakeGeminiBody(
+        [
+          "process.stdout.write('partial output before timeout\\n');",
+          "setTimeout(() => { process.stdout.write('late output\\n'); process.exit(0); }, 3000);",
+        ].join('\n')
+      )
+    );
+
+    const result = await runCli(['run', 'gemini', 'review', '--input', 'demo', '--timeout', '1'], {
+      cwd: workspace,
+      pathPrefix: binDir,
+      timeoutMs: 5_000,
+    });
+
+    assert.equal(result.code, 1);
+    const sessionId = await latestSessionId(result.home);
+    const sessionDir = join(result.home, '.aco', 'sessions', sessionId);
+    const task = JSON.parse(await readFile(join(sessionDir, 'task.json'), 'utf8')) as {
+      provider: string;
+      command: string;
+      status: string;
+      pid?: unknown;
+    };
+    const output = await readFile(join(sessionDir, 'output.log'), 'utf8');
+    const error = await readFile(join(sessionDir, 'error.log'), 'utf8');
+
+    assert.equal(task.provider, 'gemini');
+    assert.equal(task.command, 'review');
+    assert.equal(task.status, 'failed');
+    assert.equal(typeof task.pid, 'number');
+    assert.match(output, /partial output before timeout/);
+    assert.doesNotMatch(output, /late output/);
+    assert.match(error, /timed out/i);
+  });
+
+  it('records ask timeout in the run ledger without invoking live providers', async () => {
+    const workspace = await makeWorkspaceWithPrompt();
+    const binDir = await makeFakeProviderBin(
+      'gemini',
+      makeFakeGeminiBody(
+        [
+          "process.stdout.write('ask partial output before timeout\\n');",
+          "setTimeout(() => { process.stdout.write('ask late output\\n'); process.exit(0); }, 3000);",
+        ].join('\n')
+      )
+    );
+
+    const result = await runCli(
+      [
+        'ask',
+        '--providers',
+        'gemini',
+        '--task',
+        'demo',
+        '--yes',
+        '--output-mode',
+        'save-only',
+        '--timeout',
+        '1',
+      ],
+      { cwd: workspace, pathPrefix: binDir, timeoutMs: 5_000 }
+    );
+
+    assert.equal(result.code, 1);
+    const sessionId = await latestSessionId(result.home);
+    const runId = await latestRunId(result.home);
+    const sessionDir = join(result.home, '.aco', 'sessions', sessionId);
+    const ledger = JSON.parse(
+      await readFile(join(result.home, '.aco', 'runs', runId, 'ledger.json'), 'utf8')
+    ) as { sessions: Array<{ id: string; status: string; error?: string }> };
+    const task = JSON.parse(await readFile(join(sessionDir, 'task.json'), 'utf8')) as {
+      status: string;
+      pid?: unknown;
+    };
+    const error = await readFile(join(sessionDir, 'error.log'), 'utf8');
+
+    assert.equal(task.status, 'failed');
+    assert.equal(typeof task.pid, 'number');
+    assert.equal(ledger.sessions[0].id, sessionId);
+    assert.equal(ledger.sessions[0].status, 'failed');
+    assert.match(ledger.sessions[0].error ?? '', /timed out/i);
+    assert.match(error, /timed out/i);
+  });
+
+  it('cancels a running spawned provider and preserves cancelled status', async () => {
+    const home = await makeHome();
+    const workspace = await makeWorkspaceWithPrompt();
+    const binDir = await makeFakeProviderBin(
+      'gemini',
+      makeFakeGeminiBody(
+        [
+          "process.stdout.write('provider started\\n');",
+          "process.on('SIGTERM', () => setTimeout(() => process.exit(0), 50));",
+          'setInterval(() => {}, 1000);',
+        ].join('\n')
+      )
+    );
+    const cliRoot = resolve(__dirname, '..');
+    const cliPath = join(cliRoot, 'src', 'cli.ts');
+    const tsxRegister = require.resolve('tsx/cjs');
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      NO_COLOR: '1',
+      GEMINI_API_KEY: 'test-key',
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+    };
+
+    const running = spawn(
+      process.execPath,
+      [
+        '--require',
+        tsxRegister,
+        cliPath,
+        'run',
+        'gemini',
+        'review',
+        '--input',
+        'demo',
+        '--timeout',
+        '30',
+      ],
+      {
+        cwd: workspace,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }
+    );
+
+    const { id } = await waitForSessionWithPid(home);
+    const cancel = await runCli(['cancel', '--session', id], {
+      home,
+      cwd: workspace,
+      pathPrefix: binDir,
+    });
+    assert.equal(cancel.code, 0);
+
+    const exitCode = await new Promise<number | null>((resolveExit, rejectExit) => {
+      const timeout = setTimeout(() => rejectExit(new Error('aco run did not exit')), 3_000);
+      running.once('exit', (code) => {
+        clearTimeout(timeout);
+        resolveExit(code);
+      });
+    });
+
+    const task = JSON.parse(
+      await readFile(join(home, '.aco', 'sessions', id, 'task.json'), 'utf8')
+    ) as { status: string; pid?: unknown };
+    const error = await readFile(join(home, '.aco', 'sessions', id, 'error.log'), 'utf8');
+
+    assert.equal(exitCode, 1);
+    assert.equal(task.status, 'cancelled');
+    assert.equal(typeof task.pid, 'number');
+    assert.match(error, /cancelled/i);
+  });
+
+  it('preserves provider failure artifacts for ask ledgers', async () => {
+    const result = await runCli(
+      ['ask', '--providers', 'mock', '--task', 'demo', '--yes', '--output-mode', 'save-only'],
+      {
+        env: { ACO_MOCK_FAIL: '1' },
+      }
+    );
+
+    assert.equal(result.code, 1);
+    const sessionId = await latestSessionId(result.home);
+    const runId = await latestRunId(result.home);
+    const sessionDir = join(result.home, '.aco', 'sessions', sessionId);
+    const ledger = JSON.parse(
+      await readFile(join(result.home, '.aco', 'runs', runId, 'ledger.json'), 'utf8')
+    ) as { sessions: Array<{ id: string; status: string; error?: string }> };
+
+    await stat(join(sessionDir, 'output.log'));
+    const error = await readFile(join(sessionDir, 'error.log'), 'utf8');
+    assert.equal(ledger.sessions[0].id, sessionId);
+    assert.equal(ledger.sessions[0].status, 'failed');
+    assert.match(error, /mock provider forced failure/);
+  });
+});


### PR DESCRIPTION
Closes #105

## What

provider 실행 timeout과 cancellation contract를 `aco run` / `aco ask` 공통 경로에 추가했습니다. 느리거나 멈춘 provider도 session artifact와 exit code를 신뢰할 수 있게 만드는 변경입니다.

## Why

real Codex/Gemini provider 실행은 인증, 네트워크, provider latency 때문에 mock 검증과 다르게 오래 멈출 수 있습니다. 기존 wrapper는 timeout, cancel, child process cleanup, `error.log` 기록 기준이 명확하지 않아 pilot 중 실패 상태를 해석하기 어려웠습니다.

## Changes

- `--timeout <seconds>`와 `ACO_TIMEOUT_SECONDS`를 추가하고 기본값을 `300`초로 문서화했습니다.
- timeout 시 provider process group/PID를 best-effort 종료하고 session을 `failed`로 기록합니다.
- `aco cancel --session <id>`가 `error.log`를 남기고 `cancelled` 상태를 보존하도록 했습니다.
- provider PID를 session에 기록하고 `aco status`에서 표시합니다.
- fake provider 기반 TDD test로 invalid timeout, timeout failure, ask ledger, cancel, provider failure artifact를 고정했습니다.
- OpenSpec change, 실행계획, validation ledger, runbook/security/session artifact docs를 함께 갱신했습니다.

## Validation

- [x] `npm exec --workspace=packages/wrapper -- node --require tsx/cjs --test tests/provider-session-reliability.test.ts`
- [x] `npm run typecheck --workspace=packages/wrapper`
- [x] `openspec validate add-provider-smoke-timeout-session-reliability --type change --strict`
- [x] `git diff --check`
- [x] `npx --yes prettier@3.0.0 --check <touched files>`
- [x] `npm test --workspace=packages/wrapper`
- [x] `npm run test:smoke --workspace=packages/wrapper`

## Checklist

- [x] `Closes #105` 연결
- [x] Project status는 PR 생성 후 `In Review`로 이동
- [x] durable labels만 PR에 복사: `type:bug`, `area:wrapper`, `area:ci`, `area:docs`
- [x] live Codex/Gemini smoke는 명시 승인 없이 실행하지 않고 `validation-ledger.md`에 skipped로 기록
