### PR TITLE
fix(wrapper): close 핸들러를 spawn 직후 등록하여 경쟁 조건으로 인한 타이머 누수 수정

### DIFF
--- a/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/.openspec.yaml
+++ b/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/design.md
+++ b/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`packages/wrapper/src/util/spawn-stream.ts`의 `spawnStream` 함수는 자식 프로세스를 생성하고 stdout을 `AsyncIterable<string>`으로 yield한다. 현재 구조:
+
+1. `spawn()` 호출
+2. `for await (const chunk of child.stdout)` — stdout 소비
+3. `new Promise<void>((resolve, reject) => { child.on('close', ...) })` 등록 및 await
+
+`for await` 루프는 stdout 스트림이 닫힐 때 종료된다. stdout이 닫히는 시점과 프로세스 `close` 이벤트 발생 시점 사이에 gap이 있으며, 이 gap 동안 `close` 이벤트 핸들러가 아직 등록되지 않은 상태에서 이벤트가 발생할 수 있다. `EventEmitter`는 등록 전 발생한 이벤트를 재전달하지 않으므로 핸들러가 영구히 호출되지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `spawnStream`이 모든 프로세스 종료 타이밍에서 `close` 이벤트를 반드시 수신하도록 보장한다.
+- 함수 시그니처(`binary`, `args`, `config`, `options`), 반환 타입(`AsyncIterable<string>`), 에러 메시지 형식을 유지한다.
+
+**Non-Goals:**
+- 타이머 관리 로직 추가 — `clearExecutionTimers()` 등의 cleanup은 호출자(provider) 책임이다.
+- `stderr` 수집 방식 변경.
+- 재시도, 백오프, 프로세스 재시작 로직.
+
+## Decisions
+
+### Decision 1: `close` Promise를 `spawn()` 직후 생성
+
+**선택**: `spawn()` 직후, `for await` 루프 이전에 `closePromise`를 생성하고 핸들러를 등록한다.
+
+```typescript
+const closePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+  (resolve, reject) => {
+    child.on('close', (code, signal) => resolve({ code, signal }));
+    child.on('error', reject);
+  }
+);
+
+for await (const chunk of child.stdout) { ... }
+
+const { code, signal } = await closePromise;
+```
+
+**대안 고려**: `child.on('close', ...)` 핸들러를 루프 전에 등록하고 변수에 저장하는 방식도 가능하지만, Promise로 캡처하면 `error` 이벤트와 `close` 이벤트를 단일 `await` 지점에서 처리할 수 있어 오류 전파가 명확하다.
+
+**이유**: Node.js `EventEmitter`는 리스너 등록 전 발생한 이벤트를 재전달하지 않는다. 핸들러를 `spawn()` 직후 등록하면 경쟁 조건의 발생 가능성 자체를 제거한다.
+
+### Decision 2: `error` 이벤트도 `closePromise`로 통합
+
+기존 코드는 `close` Promise 내에서 `child.on('error', reject)`를 함께 등록했다. 이 구조를 `closePromise`로 이전하여 하나의 `await` 지점에서 `close`와 `error` 모두를 처리한다.
+
+## Risks / Trade-offs
+
+- **`stdout` 소비 중 `error` 이벤트 발생** → `for await` 루프가 예외를 던질 수 있고, `closePromise`가 reject 상태가 될 수 있다. `for await` 이후 `await closePromise`가 실행되지 않을 수 있지만, reject된 Promise는 GC에서 정리된다. 실질적 리스크 없음.
+- **변경 범위 최소** → 함수 본문 내 `Promise` 생성 위치 이동과 `await` 구조 변경만으로 구성되므로 회귀 위험이 낮다.
+- **테스트 커버리지** → 빠르게 종료되는 프로세스 시나리오를 단위 테스트로 추가해야 한다.
+
+## Migration Plan
+
+코드 변경 범위가 `spawnStream` 내부 구현에 한정되고 외부 인터페이스가 동일하므로 별도 마이그레이션 절차 없음. 단위 테스트로 회귀 검증 후 바로 배포 가능.

--- a/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/proposal.md
+++ b/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`spawn-stream.ts`의 `child.on('close', ...)` 핸들러가 `for await` 루프 완료 후에 등록되어, 프로세스가 루프 실행 중 종료되면 `close` 이벤트가 핸들러 등록 전에 발생한다. 결과적으로 `clearExecutionTimers()`가 호출되지 않아 `timeoutTimer`와 `forceKillTimer`가 프로세스 수명 이후에도 잔존한다.
+
+## What Changes
+
+- `close` 이벤트 핸들러를 `spawn()` 직후에 등록하고 결과를 `Promise`로 캡처한다.
+- `for await` 루프 완료 후 해당 `Promise`를 `await`하여 종료 코드와 시그널을 처리한다.
+- 경쟁 조건 없이 모든 프로세스 종료 경로에서 `close` 이벤트가 확실히 처리된다.
+
+## Capabilities
+
+### New Capabilities
+
+- `spawn-stream-close-safety`: `spawnStream`이 프로세스 종료 시 `close` 이벤트를 항상 수신하도록 보장하는 동작 — `spawn()` 직후 핸들러를 등록하고 스트림 소비 후 `await`한다.
+
+### Modified Capabilities
+
+<!-- 기존 스펙 수준 요구사항 변경 없음 -->
+
+## Impact
+
+- **영향 파일**: `packages/wrapper/src/util/spawn-stream.ts` (line 84~98)
+- **영향 범위**: 모든 provider가 사용하는 `spawnStream` 유틸리티. 외부 API 변경 없음.
+- **하위 호환성**: 함수 시그니처 및 반환 타입 변경 없음.
+- **리스크**: 낮음 — 이벤트 핸들러 등록 순서 변경만으로 동작 보장을 확보한다.

--- a/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/specs/spawn-stream-close-safety/spec.md
+++ b/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/specs/spawn-stream-close-safety/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: close 이벤트 핸들러를 spawn 직후 등록
+`spawnStream`은 `spawn()` 호출 직후, stdout 소비를 시작하기 전에 `child`의 `close` 이벤트 핸들러를 등록해야 한다. 등록된 핸들러는 프로세스 종료 코드와 시그널을 Promise로 캡처하고, stdout 소비 완료 후 해당 Promise를 `await`하여 결과를 처리해야 한다.
+
+#### Scenario: 프로세스가 stdout 소비 전에 종료될 때 close 이벤트 수신
+- **WHEN** 자식 프로세스가 stdout 데이터를 출력하고 `for await` 루프 실행 중에 종료되는 경우
+- **THEN** `close` 이벤트가 핸들러 등록 이전에 발생하더라도 `closePromise`가 해당 이벤트를 캡처하여 종료 코드와 시그널이 정확히 처리된다
+
+#### Scenario: 프로세스가 정상 종료될 때 close 이벤트 수신
+- **WHEN** 자식 프로세스가 stdout을 모두 출력하고 exit code 0으로 종료되는 경우
+- **THEN** `closePromise`가 `{ code: 0, signal: null }`로 resolve되고 `spawnStream`이 정상 완료된다
+
+#### Scenario: 프로세스가 비정상 exit code로 종료될 때 에러 전파
+- **WHEN** 자식 프로세스가 exit code 1 이상으로 종료되는 경우
+- **THEN** `closePromise`가 resolve되고 종료 코드 기반의 에러 메시지를 포함한 `Error`가 throw된다
+
+#### Scenario: 프로세스가 시그널로 종료될 때 에러 전파
+- **WHEN** 자식 프로세스가 `SIGKILL` 등의 시그널에 의해 종료되는 경우
+- **THEN** `closePromise`가 resolve되고 시그널 이름을 포함한 에러 메시지의 `Error`가 throw된다
+
+### Requirement: error 이벤트를 closePromise에서 통합 처리
+`spawnStream`은 `child.on('error', ...)` 핸들러를 `closePromise` 생성 시 함께 등록하여, spawn 실패 또는 프로세스 에러가 동일한 `await` 지점에서 reject로 전파되도록 해야 한다.
+
+#### Scenario: spawn 에러 발생 시 reject 전파
+- **WHEN** `child.on('error', ...)` 이벤트가 발생하는 경우
+- **THEN** `closePromise`가 reject되어 `spawnStream` 호출자에게 에러가 전파된다

--- a/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/tasks.md
+++ b/openspec/changes/fix-110-spawn-stream-close-race-timer-leak/tasks.md
@@ -1,0 +1,18 @@
+## 1. 구현
+
+- [x] 1.1 `spawn()` 직후 `closePromise`를 생성하고 `close`/`error` 핸들러를 등록한다
+- [x] 1.2 `for await` 루프 이후 `await closePromise`로 종료 코드와 시그널을 처리한다
+- [x] 1.3 기존 `new Promise<void>(...child.on('close', ...))` 블록을 제거한다
+
+## 2. 테스트
+
+- [x] 2.1 빠르게 종료되는 프로세스 시나리오에서 `close` 이벤트가 캡처됨을 검증하는 단위 테스트 추가
+- [x] 2.2 exit code 0 정상 종료 시나리오 테스트
+- [x] 2.3 exit code 1 이상 비정상 종료 시나리오 테스트
+- [x] 2.4 시그널(`SIGKILL`) 종료 시나리오 테스트
+
+## 3. 검증
+
+- [x] 3.1 `npm run typecheck` 통과 확인
+- [x] 3.2 `npm test` 통과 확인
+- [x] 3.3 `aco run -- echo hello` 실행 후 타이머 누수 없음 확인

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "prepack": "node -e \"const fs = require('fs'); const path = require('path'); const src = path.resolve(process.cwd(), '../../templates'); const dest = path.resolve(process.cwd(), 'templates'); fs.rmSync(dest, { recursive: true, force: true }); fs.mkdirSync(dest, { recursive: true }); fs.cpSync(src, dest, { recursive: true });\"",
-    "test": "node --require tsx/cjs --test tests/command-output-buffering.test.ts tests/spawn-stream-buffering.test.ts tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts tests/ask-cli.test.ts tests/doctor-cli.test.ts tests/pack-runtime-contract.test.ts tests/provider-session-reliability.test.ts",
+    "test": "node --require tsx/cjs --test tests/command-output-buffering.test.ts tests/spawn-stream-buffering.test.ts tests/spawn-stream-close-safety.test.ts tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts tests/ask-cli.test.ts tests/doctor-cli.test.ts tests/pack-runtime-contract.test.ts tests/provider-session-reliability.test.ts",
     "test:pack-runtime-contract": "tsx tests/pack-runtime-contract-smoke.ts",
     "test:smoke": "tsx tests/smoke.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/wrapper/src/util/spawn-stream.ts
+++ b/packages/wrapper/src/util/spawn-stream.ts
@@ -151,6 +151,37 @@ export async function* spawnStream(
     throw new Error(`${config.processName}: failed to open stdout pipe`);
   }
 
+  const closePromise = new Promise<void>((resolve, reject) => {
+    child.on('close', (code, signal) => {
+      clearExecutionTimers();
+      if (timedOut) {
+        reject(
+          new ProviderExecutionError(
+            'timeout',
+            `${config.processName} timed out after ${Math.ceil((options?.timeoutMs ?? 0) / 1000)}s`
+          )
+        );
+        return;
+      }
+
+      if (code !== 0 || signal !== null) {
+        const reason =
+          signal === null
+            ? `${config.processName} exited with code ${code}`
+            : `${config.processName} terminated by signal ${signal}`;
+        const detail = stderr.trim();
+        reject(new Error(detail ? `${reason}\n${detail}` : reason));
+      } else {
+        resolve();
+      }
+    });
+    child.on('error', (err) => {
+      clearExecutionTimers();
+      reject(err);
+    });
+  });
+  closePromise.catch(() => {});
+
   // Track the last line to detect sentinel without buffering entire output
   let lastLineBuffer = '';
 
@@ -190,33 +221,5 @@ export async function* spawnStream(
     }
   }
 
-  await new Promise<void>((resolve, reject) => {
-    child.on('close', (code, signal) => {
-      clearExecutionTimers();
-      if (timedOut) {
-        reject(
-          new ProviderExecutionError(
-            'timeout',
-            `${config.processName} timed out after ${Math.ceil((options?.timeoutMs ?? 0) / 1000)}s`
-          )
-        );
-        return;
-      }
-
-      if (code !== 0 || signal !== null) {
-        const reason =
-          signal === null
-            ? `${config.processName} exited with code ${code}`
-            : `${config.processName} terminated by signal ${signal}`;
-        const detail = stderr.trim();
-        reject(new Error(detail ? `${reason}\n${detail}` : reason));
-      } else {
-        resolve();
-      }
-    });
-    child.on('error', (err) => {
-      clearExecutionTimers();
-      reject(err);
-    });
-  });
+  await closePromise;
 }

--- a/packages/wrapper/tests/spawn-stream-close-safety.test.ts
+++ b/packages/wrapper/tests/spawn-stream-close-safety.test.ts
@@ -1,0 +1,127 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnStream } from '../src/util/spawn-stream.js';
+
+async function makeScriptBinary(binDir: string, name: string, script: string): Promise<string> {
+  const binaryPath = join(binDir, name);
+  await writeFile(binaryPath, `#!/usr/bin/env node\n${script}`, { mode: 0o755 });
+  return binaryPath;
+}
+
+describe('spawnStream close event race condition fix', () => {
+  it('captures close event when process exits before for-await loop drains stdout', async () => {
+    const tmpBin = await mkdtemp(join(tmpdir(), 'aco-spawn-close-race-'));
+    // Process writes one line and exits immediately — may exit before consumer reads
+    const binary = await makeScriptBinary(
+      tmpBin,
+      'fast-exit',
+      `process.stdout.write('hello\\n'); process.exit(0);`
+    );
+
+    try {
+      const chunks: string[] = [];
+      for await (const chunk of spawnStream(
+        binary,
+        [],
+        { processName: 'fast-exit', stdin: 'ignore' }
+      )) {
+        chunks.push(chunk);
+      }
+      assert.ok(chunks.join('').includes('hello'));
+    } finally {
+      await rm(tmpBin, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves normally when process exits with code 0', async () => {
+    const tmpBin = await mkdtemp(join(tmpdir(), 'aco-spawn-close-exit0-'));
+    const binary = await makeScriptBinary(
+      tmpBin,
+      'exit-0',
+      `process.stdout.write('ok\\n'); process.exit(0);`
+    );
+
+    try {
+      const chunks: string[] = [];
+      for await (const chunk of spawnStream(
+        binary,
+        [],
+        { processName: 'exit-0', stdin: 'ignore' }
+      )) {
+        chunks.push(chunk);
+      }
+      assert.ok(chunks.join('').includes('ok'));
+    } finally {
+      await rm(tmpBin, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects with error message when process exits with non-zero code', async () => {
+    const tmpBin = await mkdtemp(join(tmpdir(), 'aco-spawn-close-exit1-'));
+    const binary = await makeScriptBinary(
+      tmpBin,
+      'exit-1',
+      `process.stderr.write('something went wrong\\n'); process.exit(1);`
+    );
+
+    try {
+      await assert.rejects(
+        (async () => {
+          for await (const chunk of spawnStream(
+            binary,
+            [],
+            { processName: 'exit-1', stdin: 'ignore' }
+          )) {
+            void chunk;
+          }
+        })(),
+        (err: unknown) => {
+          assert.ok(err instanceof Error);
+          assert.ok(
+            err.message.includes('exited with code 1'),
+            `Expected "exited with code 1" in: ${err.message}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      await rm(tmpBin, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects with signal message when process is killed by SIGKILL', async () => {
+    const tmpBin = await mkdtemp(join(tmpdir(), 'aco-spawn-close-signal-'));
+    const binary = await makeScriptBinary(
+      tmpBin,
+      'signal-exit',
+      `process.kill(process.pid, 'SIGKILL');`
+    );
+
+    try {
+      await assert.rejects(
+        (async () => {
+          for await (const chunk of spawnStream(
+            binary,
+            [],
+            { processName: 'signal-exit', stdin: 'ignore' }
+          )) {
+            void chunk;
+          }
+        })(),
+        (err: unknown) => {
+          assert.ok(err instanceof Error);
+          assert.ok(
+            err.message.includes('terminated by signal'),
+            `Expected "terminated by signal" in: ${err.message}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      await rm(tmpBin, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #110

## What

`packages/wrapper/src/util/spawn-stream.ts`의 `child.on('close', ...)` 핸들러를 `for await` 루프 **이전**에 등록하도록 구조를 변경합니다.

## Why

기존 코드에서 `closePromise`가 `for await` 루프 완료 후에 생성되어, 루프 실행 중 프로세스가 종료되면 `close` 이벤트가 핸들러 등록 전에 발생할 수 있었습니다. `EventEmitter`는 등록 전 발생한 이벤트를 재전달하지 않으므로 `close` 핸들러가 영구히 호출되지 않고, 그 결과 `timeoutTimer`와 `forceKillTimer`가 프로세스 수명 이후에도 잔존하는 누수가 발생했습니다. (PR #108 리뷰에서 제기된 문제)

## Changes

- `packages/wrapper/src/util/spawn-stream.ts`: `closePromise`를 `spawn()` 직후(stdout 소비 전)에 생성하고 `close`/`error` 핸들러를 즉시 등록. 루프 완료 후 `await closePromise`로 교체.
- `packages/wrapper/tests/spawn-stream-close-safety.test.ts`: 빠른 종료 프로세스, 정상 exit 0, 비정상 exit code, SIGKILL 시나리오 테스트 4개 추가.
- `packages/wrapper/package.json`: 신규 테스트 파일을 `test` 스크립트에 추가.

## Checklist

- [x] 핵심 수정: `closePromise`를 `spawn()` 직후 생성하도록 이동
- [x] 단위 테스트 4개 추가 (경쟁 조건, 정상/비정상 종료, 시그널)
- [x] `npm run typecheck` 통과
- [x] `npm test` 221/221 통과 (신규 4개 포함)
- [x] smoke test 10/10 통과