### PR TITLE
fix(wrapper): forward SIGINT/SIGTERM to provider process during aco run

### DIFF
--- a/openspec/changes/fix-provider-process-orphan-signal/.openspec.yaml
+++ b/openspec/changes/fix-provider-process-orphan-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/fix-provider-process-orphan-signal/design.md
+++ b/openspec/changes/fix-provider-process-orphan-signal/design.md
@@ -1,0 +1,50 @@
+## Context
+
+`aco run`은 `invokeProviderForSession`을 통해 프로바이더 CLI(codex, gemini 등)를 child process로 실행한다. 현재 `cmdRun`은 세션이 실행 중인 동안 SIGINT/SIGTERM 핸들러를 등록하지 않는다. PR #108이 `spawn-stream.ts`에 `detached: process.platform !== 'win32'`를 추가하면 Unix에서 프로바이더가 별도 프로세스 그룹이 되어 터미널 신호(Ctrl+C)가 자동으로 전파되지 않는다. 결과적으로 `aco run` 종료 후에도 프로바이더 프로세스가 고아 상태로 남는다.
+
+현재 PID는 `sessionStore`에 기록되지만, `cmdRun`에서 이를 활성 신호 전달에 활용하지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `aco run`이 종료(SIGINT/SIGTERM)될 때 활성 프로바이더 프로세스(그룹)도 함께 종료한다.
+- `detached: true`(PR #108 이후)와 `detached: false`(현재) 모두에서 동작한다.
+- PR #108의 `terminateProviderProcess`와 동일한 구현을 사전에 도입하여 merge 충돌을 예방한다.
+
+**Non-Goals:**
+- `aco ask` 경로의 신호 전달 (별도 이슈로 분리)
+- `spawn-stream.ts`에서 `detached` 옵션 자체를 변경하거나 제거하는 것
+- timeout/killGrace 경로 변경 (PR #108 범위)
+
+## Decisions
+
+**D1: `terminateProviderProcess` 유틸리티 사전 도입**
+
+PR #108에서 동일한 함수를 도입 예정이므로, 이 fix에서 먼저 동일하게 구현한다. 두 PR이 merge될 때 중복이 되면 한쪽을 reuse하면 되고, 실질적 충돌 없이 통합된다.
+
+대안으로 검토한 것: `provider-process.ts` 없이 `cli.ts` 내에 인라인 구현 → 코드 중복 유발, 재사용 어려움.
+
+**D2: PID 추적을 위한 `onPid` 콜백을 `ProviderSessionRunOptions`에 추가**
+
+`invokeProviderForSession` 안에서 이미 `provider.invoke`에 `onPid`를 전달하고 있다. 여기에 `ProviderSessionRunOptions`에 선택적 `onPid`를 추가하여 `cmdRun`의 클로저 변수로 PID를 동기적으로 캡처한다.
+
+대안으로 검토한 것: 신호 수신 시 `sessionStore`에서 비동기 PID 읽기 → 신호 핸들러 내 async/await 불확실성, 신호 도착 시점에 아직 PID 미기록 가능성.
+
+**D3: SIGINT/SIGTERM 핸들러를 `cmdRun` 내에서 등록/해제**
+
+세션 시작 직전 핸들러를 등록하고, `invokeProviderForSession` 반환 후 `process.off`로 즉시 해제한다. Node.js는 SIGINT/SIGTERM 핸들러가 등록되면 기본 동작(process 종료)을 억제하므로 핸들러 내에서 `process.exit(1)`을 명시 호출한다.
+
+## Risks / Trade-offs
+
+- `process.kill(-pid, signal)` 실패 시(ESRCH 등) 폴백을 사용하지만, 프로세스가 이미 종료된 경우 조용히 무시한다. → `try/catch`로 흡수.
+- PID가 재사용될 수 있는 race condition 가능성이 있으나, 세션 수명이 짧아 실제 위험이 낮다. → 주석으로 명시.
+- SIGINT 핸들러에서 `process.exit(1)` 호출이 일부 cleanup hook을 건너뛸 수 있다. → 현재 cleanup이 없으므로 허용.
+
+## Migration Plan
+
+1. `provider-process.ts` 신규 생성.
+2. `provider-session-runner.ts`에 `onPid` 추가 (선택적 필드, 기존 코드 영향 없음).
+3. `cli.ts` `cmdRun`에 신호 핸들러 등록/해제 추가.
+4. `npm test` + `npm run typecheck`로 검증.
+
+롤백: 3개 변경을 revert — 세션 스토어 계약이나 API에 영향 없음.

--- a/openspec/changes/fix-provider-process-orphan-signal/proposal.md
+++ b/openspec/changes/fix-provider-process-orphan-signal/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+PR #108이 `spawn-stream.ts`에 `detached: process.platform !== 'win32'`를 도입하면서 Unix에서 프로바이더 CLI가 별도 프로세스 그룹으로 분리된다. `cli.ts`의 `cmdRun`에는 SIGINT/SIGTERM 포워딩 경로가 없어 `aco run` 종료(Ctrl+C 포함) 후에도 프로바이더 프로세스가 고아 상태로 계속 실행될 수 있다. PR #108이 프로세스 그룹 킬 유틸리티(`terminateProviderProcess`)를 timeout 경로에만 연결했고 인터랙티브 종료 경로는 연결하지 않은 것이 직접 원인이다.
+
+## What Changes
+
+- `packages/wrapper/src/runtime/provider-process.ts` 신규 생성 — `terminateProviderProcess(pid, signal)` 유틸리티. Unix에서는 `-pid` (process group) 킬을 먼저 시도하고 실패 시 `pid` 직접 킬로 폴백한다. PR #108과 동일한 구현으로 merge 충돌을 방지한다.
+- `packages/wrapper/src/runtime/provider-session-runner.ts` 수정 — `ProviderSessionRunOptions`에 `onPid?: (pid: number) => void` 추가. runner 내부에서 세션 스토어 업데이트와 함께 호출한다.
+- `packages/wrapper/src/cli.ts` 수정 — `cmdRun`에서 활성 provider PID를 클로저 변수로 추적하고, 세션이 실행 중인 동안 SIGINT/SIGTERM 핸들러를 등록해 `terminateProviderProcess`를 호출한다. 세션 종료 후 핸들러를 제거한다.
+
+## Capabilities
+
+### New Capabilities
+
+- `provider-process-lifecycle`: `aco run` 실행 중 SIGINT/SIGTERM 수신 시 활성 프로바이더 프로세스(그룹)를 신뢰할 수 있게 종료하는 경로
+
+### Modified Capabilities
+
+(없음)
+
+## Impact
+
+- 영향 파일: `packages/wrapper/src/cli.ts`, `packages/wrapper/src/runtime/provider-session-runner.ts`
+- 신규 파일: `packages/wrapper/src/runtime/provider-process.ts`
+- PR #108과 merge 순서에 관계없이 충돌 없이 통합 가능하도록 `terminateProviderProcess` 구현을 동일하게 유지한다.
+- 기존 public API 변경 없음. `ProviderSessionRunOptions`에 선택적 `onPid` 필드 추가만 있으므로 하위 호환성 유지.

--- a/openspec/changes/fix-provider-process-orphan-signal/specs/provider-process-lifecycle/spec.md
+++ b/openspec/changes/fix-provider-process-orphan-signal/specs/provider-process-lifecycle/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Signal forwarding during aco run
+`aco run`이 실행 중인 동안 SIGINT 또는 SIGTERM을 수신하면, 활성 프로바이더 프로세스(그룹)에 해당 신호를 포워딩한 후 `aco run` 프로세스 자체도 종료되어야 한다.
+
+#### Scenario: SIGINT received during active provider session
+- **WHEN** `aco run`이 프로바이더를 실행 중인 상태에서 SIGINT(Ctrl+C)를 수신한다
+- **THEN** 활성 프로바이더 PID(또는 프로세스 그룹)에 종료 신호가 전달되고, `aco run`은 exit code 1로 종료된다
+
+#### Scenario: SIGTERM received during active provider session
+- **WHEN** `aco run`이 프로바이더를 실행 중인 상태에서 SIGTERM을 수신한다
+- **THEN** 활성 프로바이더 PID(또는 프로세스 그룹)에 종료 신호가 전달되고, `aco run`은 exit code 1로 종료된다
+
+#### Scenario: Signal received before PID is available
+- **WHEN** 프로바이더가 아직 PID를 보고하지 않은 상태에서 신호를 수신한다
+- **THEN** `aco run`은 종료되며, PID가 없어도 프로세스 자체는 정상 종료된다
+
+#### Scenario: Signal received after provider has already exited
+- **WHEN** 프로바이더가 정상 종료된 후 신호 핸들러가 남아있는 상태에서 신호가 수신된다
+- **THEN** 신호 전달 시도가 무시되고 `aco run`은 정상 종료된다
+
+### Requirement: Process group kill compatibility
+Unix 시스템에서 프로바이더 프로세스를 종료할 때, 프로세스 그룹 킬(`-pid`)을 먼저 시도하고 실패 시 직접 PID 킬로 폴백해야 한다.
+
+#### Scenario: Provider spawned with detached process group (Unix)
+- **WHEN** 프로바이더가 `detached: true`로 스폰된 경우 종료 신호가 전달된다
+- **THEN** `process.kill(-pid, signal)`로 프로세스 그룹 전체가 종료된다
+
+#### Scenario: Provider spawned without detached (Unix)
+- **WHEN** 프로바이더가 `detached: false`(기본값)로 스폰된 경우 종료 신호가 전달된다
+- **THEN** `-pid` 킬이 실패하면 `process.kill(pid, signal)`로 직접 프로세스를 종료한다
+
+#### Scenario: Windows process termination
+- **WHEN** Windows 환경에서 프로바이더 종료 신호가 전달된다
+- **THEN** `process.kill(pid, signal)`이 직접 호출된다 (`-pid` 시도 없음)

--- a/openspec/changes/fix-provider-process-orphan-signal/tasks.md
+++ b/openspec/changes/fix-provider-process-orphan-signal/tasks.md
@@ -1,0 +1,21 @@
+## 1. provider-process 유틸리티 생성
+
+- [x] 1.1 `packages/wrapper/src/runtime/provider-process.ts` 신규 생성 — `terminateProviderProcess(pid, signal)` 구현 (Unix: `-pid` 그룹 킬 우선, 폴백 직접 킬; Windows: 직접 킬)
+
+## 2. ProviderSessionRunOptions에 onPid 추가
+
+- [x] 2.1 `packages/wrapper/src/runtime/provider-session-runner.ts`의 `ProviderSessionRunOptions` 인터페이스에 `onPid?: (pid: number) => void` 필드 추가
+- [x] 2.2 `invokeProviderForSession` 내부에서 기존 `sessionStore.update`와 함께 `options.onPid?.(pid)` 호출
+
+## 3. cmdRun에 SIGINT/SIGTERM 핸들러 등록
+
+- [x] 3.1 `packages/wrapper/src/cli.ts` `cmdRun`에서 `activePid: number | undefined` 클로저 변수 선언
+- [x] 3.2 `invokeProviderForSession` 호출 옵션에 `onPid: (pid) => { activePid = pid; }` 추가
+- [x] 3.3 세션 시작 전 SIGINT/SIGTERM 핸들러 등록 — `activePid`가 있으면 `terminateProviderProcess` 호출 후 `process.exit(1)`
+- [x] 3.4 `invokeProviderForSession` 반환 후 `process.off`로 핸들러 해제
+
+## 4. 검증
+
+- [x] 4.1 `npm run typecheck --workspace=packages/wrapper` 통과 확인
+- [x] 4.2 `npm test --workspace=packages/wrapper` 통과 확인
+- [x] 4.3 메인 레포의 change 디렉토리(`openspec/changes/fix-provider-process-orphan-signal/`)에 artifacts 동기화

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -23,12 +23,12 @@ import { collectRuntimeContext } from './runtime/context.js';
 import { renderRuntimeDashboard } from './runtime/dashboard.js';
 import { formatAuthStatus } from './runtime/auth-display.js';
 import { invokeProviderForSession } from './runtime/provider-session-runner.js';
+import { terminateProviderProcess } from './runtime/provider-process.js';
 import { resolveRunPromptTemplate } from './runtime/run-prompt-template.js';
 import {
   parseProviderTimeoutFlag,
   resolveProviderExecutionControl,
 } from './runtime/provider-execution-control.js';
-import { terminateProviderProcess } from './runtime/provider-process.js';
 import { runSync } from './sync/sync-engine.js';
 
 const execFileAsync = promisify(execFile);
@@ -220,6 +220,17 @@ async function cmdRun(args: string[]): Promise<void> {
   process.stderr.write(renderRuntimeDashboard(runtimeContext) + '\n');
 
   const tee = sessionStore.createOutputTee(session.id);
+  let activePid: number | undefined;
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    if (activePid !== undefined) {
+      terminateProviderProcess(activePid, signal);
+    }
+    sessionStore.markCancelled(session.id).finally(() => {
+      process.exit(EXIT_ERROR);
+    });
+  };
+  process.on('SIGINT', handleSignal);
+  process.on('SIGTERM', handleSignal);
   const runResult = await invokeProviderForSession({
     provider,
     command,
@@ -231,7 +242,12 @@ async function cmdRun(args: string[]): Promise<void> {
     outputBuffer: resolveRunOutputBuffering(),
     timeoutMs: executionControl.timeoutMs,
     killGraceMs: executionControl.killGraceMs,
+    onPid: (pid) => {
+      activePid = pid;
+    },
   });
+  process.off('SIGINT', handleSignal);
+  process.off('SIGTERM', handleSignal);
   const runError = runResult.error;
   const latest = await sessionStore.read(session.id).catch(() => undefined);
 

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -25,6 +25,8 @@ export interface ProviderSessionRunOptions {
   timeoutMs?: number;
   /** Grace period after SIGTERM before SIGKILL. */
   killGraceMs?: number;
+  /** Called once with the provider's OS PID when available. */
+  onPid?: (pid: number) => void;
 }
 
 export interface ProviderSessionRunResult {
@@ -64,6 +66,7 @@ export async function invokeProviderForSession(
         timeoutMs: options.timeoutMs,
         killGraceMs: options.killGraceMs,
         onPid: (pid) => {
+          options.onPid?.(pid);
           sessionStore.update(options.sessionId, { pid }).catch((err: unknown) => {
             console.warn(
               'Failed to record process PID:',


### PR DESCRIPTION
Closes #109

## What

`aco run` 실행 중 SIGINT(Ctrl+C) 또는 SIGTERM을 수신할 때 활성 프로바이더 프로세스(그룹)에 신호를 포워딩하고 정상 종료하는 경로를 추가한다.

## Why

PR #108이 `spawn-stream.ts`에 `detached: process.platform !== 'win32'`를 도입하면 Unix에서 프로바이더 CLI가 별도 프로세스 그룹으로 분리된다. 터미널 SIGINT가 자동으로 전파되지 않아 `aco run` 종료 후에도 `codex`/`gemini` 같은 프로바이더 프로세스가 고아 상태로 계속 실행된다. `cli.ts`의 `cmdRun`에 SIGINT/SIGTERM 포워딩 경로가 없는 것이 직접 원인이다.

## Changes

- **신규** `packages/wrapper/src/runtime/provider-process.ts`: `terminateProviderProcess(pid, signal)` 유틸리티. Unix에서 `-pid`(프로세스 그룹) 킬을 먼저 시도하고 실패 시 직접 PID 킬로 폴백. PR #108과 동일한 구현으로 merge 충돌 방지.
- **수정** `packages/wrapper/src/runtime/provider-session-runner.ts`: `ProviderSessionRunOptions`에 선택적 `onPid?: (pid: number) => void` 추가. runner 내부에서 호출.
- **수정** `packages/wrapper/src/cli.ts`: `cmdRun`에서 `activePid` 클로저 변수로 PID 추적, 세션 실행 중 SIGINT/SIGTERM 핸들러 등록, `invokeProviderForSession` 반환 후 핸들러 해제.
- **신규** `openspec/changes/fix-provider-process-orphan-signal/`: OpenSpec proposal/design/specs/tasks.

## Checklist

- [x] `npm run typecheck --workspace=packages/wrapper` 통과
- [x] `npm test --workspace=packages/wrapper` 통과 (217/217)
- [x] `detached: true` (PR #108 이후) 및 현재 상태 모두에서 동작하는 구현 확인
- [x] `Closes #109` 연결