### PR TITLE
feat(docs): add gray-box language guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@
 > command pack 설치, Claude 기준 자산의 Codex/Gemini target sync, provider 실행, session-aware
 > `result/status/cancel` — 외부 AI CLI를 **하나의 반복 가능한 개발 워크플로우**로 묶는 것이 목표입니다.
 
+용어 기준: provider invocation, run/session artifacts, briefs, advisory output은
+[Ubiquitous Language](docs/reference/ubiquitous-language.md)에 정의되어 있습니다.
+
 <p align="center">
   <img src="docs/images/architecture-overview.svg" alt="System Architecture" width="100%" />
 </p>
@@ -587,7 +590,7 @@ aco sync --force
 </tr>
 <tr>
 <td align="center">🟢</td>
-<td><b>Provider run</b></td>
+<td><b>Provider invocation</b></td>
 <td>provider별 command 실행 · session 생성</td>
 <td><code>aco run gemini review</code></td>
 </tr>

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,6 +123,7 @@ aco result
 4. [contract/README.md](contract/README.md) — 규범 계약 문서 인덱스
 5. [contract/go-node-boundary.md](contract/go-node-boundary.md) — Go/Node.js 책임 경계
 6. [contract/process-execution-contract.md](contract/process-execution-contract.md) — 프로세스 실행 계약
+7. [reference/ubiquitous-language.md](reference/ubiquitous-language.md) — provider invocation과 run/session artifact의 canonical terms
 
 ## 아카이브
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,7 @@ Design constraints:
 
 Artifact reference: [Session And Run Artifacts](reference/session-artifacts.md).
 Security reference: [Security Model](security.md).
+Language reference: [Ubiquitous Language](reference/ubiquitous-language.md).
 
 ## 아키텍처 개요
 

--- a/docs/plans/gray-box-workflows/README.md
+++ b/docs/plans/gray-box-workflows/README.md
@@ -1,0 +1,97 @@
+# Gray Box Workflow Kickoff Index
+
+작성일: 2026-05-12
+
+이 문서는 `ai-cli-orch-wrapper`를 Matt Pocock의 gray box 관점에 더 가깝게 만들기 위한 세 개의 독립 workflow를 시작하는 인덱스다.
+각 workflow는 서로 관련은 있지만 implementation scope가 크므로 별도 OpenSpec change로 진행한다.
+
+## Background
+
+현재 repo는 이미 좋은 방향을 갖고 있다.
+
+- `aco ask`는 consent-gated provider invocation을 제공한다.
+- provider output은 advisory로 취급되고 run/session artifact에 저장된다.
+- `aco sync`는 source surface와 generated target surface를 분리한다.
+- Node wrapper와 Go runtime boundary가 문서화되어 있다.
+
+남은 문제는 gray box의 "box boundary"를 사람이 더 잘 이해하고 검증할 수 있게 만드는 것이다.
+즉, 내부 구현을 모두 읽지 않아도 안전하게 위임할 수 있으려면 공유 언어, 구조화된 결과물, portable sync 상태가 필요하다.
+
+## Workflow Map
+
+| Order | Workflow                     | OpenSpec change                                       | Primary outcome                                               |
+| ----- | ---------------------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| 1     | Ubiquitous language          | `openspec/changes/introduce-ubiquitous-language/`     | repo-wide domain terms and naming rules                       |
+| 2     | Structured findings artifact | `openspec/changes/add-structured-findings-artifacts/` | machine-readable provider findings with human-readable briefs |
+| 3     | Repo-portable sync manifest  | `openspec/changes/make-sync-manifest-portable/`       | clone-safe sync manifest paths and migration behavior         |
+
+## Workflow 1 Implementation Handoff
+
+- Briefing page: [introduce-ubiquitous-language-proposal.html](introduce-ubiquitous-language-proposal.html)
+- Implementation plan: [introduce-ubiquitous-language-implementation-plan.md](introduce-ubiquitous-language-implementation-plan.md)
+
+## Suggested Sequencing
+
+1. Start with ubiquitous language because it defines how future docs and schemas should name concepts.
+2. Then implement structured findings because it depends on stable terms such as `finding`, `advisory`, `session`, `run`, and `provider`.
+3. Then implement repo-portable sync manifest because it touches sync engine compatibility and should reuse the language established by workflow 1.
+
+The workflows can be implemented independently, but changing the order increases rework risk.
+
+## Shared Constraints
+
+- Do not merge these workflows into one giant implementation branch.
+- Preserve the public `aco` CLI contract unless a change document explicitly updates it.
+- Keep provider output advisory. Do not make external providers authoritative.
+- Keep mock-provider paths deterministic and no-auth for CI and local smoke tests.
+- Keep docs truthful about what is implemented versus planned.
+- Use TDD for behavior changes.
+- Run verification before completion claims.
+
+## External Reference Checks
+
+- Context7 lookup for OpenSpec confirmed the repository-compatible change shape: `proposal.md`, `design.md`, `tasks.md`, optional `.openspec.yaml`, and `specs/<capability>/spec.md`.
+- OpenAI developer docs describe Codex as a coding agent that can write, review, debug, and work through IDE/CLI/web surfaces. This repo should still treat Codex output as advisory within `aco`, not as an authoritative replacement for maintainer review.
+
+## Handoff Prompt
+
+Use this prompt when starting a new session for any one workflow:
+
+```text
+/goal
+Goal: Execute exactly one gray-box hardening workflow from ai-cli-orch-wrapper.
+
+Context:
+- Repo: /Users/ddalkak/Projects/ai-cli-orch-wrapper
+- Start from origin/main in an isolated worktree.
+- Pick one OpenSpec change only:
+  - introduce-ubiquitous-language
+  - add-structured-findings-artifacts
+  - make-sync-manifest-portable
+- Read docs/plans/gray-box-workflows/README.md first.
+- Then read the selected change's proposal.md, design.md, tasks.md, and specs/*/spec.md.
+
+Constraints:
+- Do not combine workflows.
+- Keep provider output advisory.
+- Preserve existing CLI contracts unless the selected OpenSpec change explicitly says otherwise.
+- Use failing tests before implementation.
+- Separate implementation verification from runtime/provider verification.
+- Do not touch unrelated local changes.
+
+Required work:
+1. Validate the selected OpenSpec change.
+2. Turn the selected tasks.md into an implementation plan if needed.
+3. Implement only that workflow.
+4. Run focused tests, then repo-appropriate verification.
+5. Update docs and tasks status truthfully.
+
+Progress visibility:
+- Report Implementation progress and Runtime/provider verification progress separately.
+- Call out any verification that remains mock-only or local-only.
+
+Done when:
+- The selected workflow's tests and docs pass.
+- The change can be reviewed without reading unrelated workflow state.
+- Any remaining risks are documented in the selected change.
+```

--- a/docs/plans/gray-box-workflows/introduce-ubiquitous-language-implementation-plan.md
+++ b/docs/plans/gray-box-workflows/introduce-ubiquitous-language-implementation-plan.md
@@ -1,0 +1,870 @@
+# Ubiquitous Language Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a repo-owned ubiquitous language reference for the first gray-box language slice, focused on provider invocation and session artifacts, with an automated terminology drift check from the start.
+
+**Architecture:** The glossary is the human-readable source of truth, and a small repository script enforces a narrow set of high-risk discouraged terms across an explicit documentation surface. The first slice avoids broad code renames: it aligns docs, examples, and review guidance while preserving the public `aco` CLI contract.
+
+**Tech Stack:** Markdown docs, Node.js 18+, TypeScript via `tsx`, Bash test harness under `test/scripts/`, OpenSpec validation, Prettier.
+
+---
+
+## Locked Decisions
+
+- Start narrow: fully define provider invocation and run/session artifacts first.
+- Represent context sync, harness surfaces, consent/permissions, and verification as backlog placeholders in this workflow.
+- Add the automated terminology check in the first implementation slice.
+- Avoid strict rename campaigns. Prefer docs-only alignment, accepted aliases, and targeted naming only when ambiguity affects behavior, emitted artifacts, or tests.
+- Keep provider output advisory. External provider output must never be described as authoritative truth.
+
+## File Structure
+
+### Create
+
+- `docs/reference/ubiquitous-language.md`
+  Human-readable glossary and naming rules. This is the source of truth for the first slice.
+
+- `scripts/check-terminology.ts`
+  Focused terminology drift checker. It scans an explicit file list for discouraged terms and reports preferred replacements.
+
+- `test/scripts/terminology-check.test.sh`
+  Bash test harness for the checker. It uses a temporary fixture repo and verifies allowed terms, discouraged terms, accepted aliases, and allowlisted legacy language.
+
+### Modify
+
+- `package.json`
+  Add `check:terminology` and include `test/scripts/terminology-check.test.sh` in `test:scripts`.
+
+- `README.md`
+  Add a short link to `docs/reference/ubiquitous-language.md` where the `aco` workflow or provider delegation language is introduced.
+
+- `docs/README.md`
+  Add the glossary to the docs index.
+
+- `docs/architecture.md`
+  Link the glossary near the `Goal 2 Consent-Gated Delegation Layer` and artifact terminology.
+
+- `docs/security.md`
+  Link the glossary where provider output, consent, permission profile, or advisory language appears.
+
+- `docs/reference/session-artifacts.md`
+  Add a short note that `run`, `session`, `brief`, `artifact`, and `output.log` are canonical terms defined by the glossary.
+
+- `openspec/changes/introduce-ubiquitous-language/tasks.md`
+  Mark tasks complete only after the implementation and checks pass.
+
+## Initial Terminology Policy
+
+The first checker should scan only this explicit surface:
+
+```ts
+const DEFAULT_SCAN_FILES = [
+  'README.md',
+  'docs/README.md',
+  'docs/architecture.md',
+  'docs/security.md',
+  'docs/reference/session-artifacts.md',
+  'docs/reference/ubiquitous-language.md',
+  'openspec/changes/introduce-ubiquitous-language/proposal.md',
+  'openspec/changes/introduce-ubiquitous-language/design.md',
+  'openspec/changes/introduce-ubiquitous-language/tasks.md',
+  'openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md',
+];
+```
+
+Use this initial discouraged-term map:
+
+```ts
+const DEFAULT_RULES = [
+  {
+    id: 'provider-output-is-advisory',
+    discouraged: 'provider truth',
+    preferred: 'provider advisory output',
+    reason: 'Provider output is evidence for review, not authoritative truth.',
+  },
+  {
+    id: 'provider-output-is-advisory',
+    discouraged: 'raw provider truth',
+    preferred: 'full provider output',
+    reason: 'The raw/full output can be stored, but it is still advisory.',
+  },
+  {
+    id: 'generated-target-not-source',
+    discouraged: 'generated source',
+    preferred: 'generated target',
+    reason: 'Source surfaces are maintained by humans; generated targets are produced by sync.',
+  },
+  {
+    id: 'brief-is-bounded-summary',
+    discouraged: 'brief log',
+    preferred: 'brief',
+    reason: 'Briefs are bounded summaries, while output.log stores full provider output.',
+  },
+];
+```
+
+Accepted aliases:
+
+```ts
+const ACCEPTED_ALIASES = [
+  { alias: 'full provider output', preferred: 'provider advisory output' },
+  { alias: 'bounded summary', preferred: 'brief' },
+  { alias: 'session output', preferred: 'output.log' },
+];
+```
+
+Allowlist behavior:
+
+```text
+<!-- terminology-check allow: raw provider truth -->
+```
+
+The checker should ignore a discouraged term when the same line contains an allow comment for that exact term. This keeps quoted examples and migration notes possible without weakening the default rule.
+
+## Task 1: Add the Failing Terminology Check Test
+
+**Files:**
+
+- Create: `test/scripts/terminology-check.test.sh`
+- Modify: `package.json`
+
+- [ ] **Step 1: Create the failing Bash test**
+
+Add `test/scripts/terminology-check.test.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/docs/reference" "$TMP_DIR/openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language"
+
+write_required_files() {
+  cat >"$TMP_DIR/README.md" <<'DOC'
+# Fixture
+
+Provider advisory output is stored as an artifact.
+DOC
+
+  cat >"$TMP_DIR/docs/README.md" <<'DOC'
+# Docs
+
+See the ubiquitous language reference.
+DOC
+
+  cat >"$TMP_DIR/docs/architecture.md" <<'DOC'
+# Architecture
+
+Full provider output remains advisory.
+DOC
+
+  cat >"$TMP_DIR/docs/security.md" <<'DOC'
+# Security
+
+Provider output is not authoritative.
+DOC
+
+  cat >"$TMP_DIR/docs/reference/session-artifacts.md" <<'DOC'
+# Session Artifacts
+
+A run contains provider sessions and each session stores output.log.
+DOC
+
+  cat >"$TMP_DIR/docs/reference/ubiquitous-language.md" <<'DOC'
+# Ubiquitous Language
+
+Preferred term: provider advisory output.
+Accepted alias: full provider output.
+Discouraged term example: raw provider truth. <!-- terminology-check allow: raw provider truth -->
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/proposal.md" <<'DOC'
+# Proposal
+
+Generated target is the preferred term.
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/design.md" <<'DOC'
+# Design
+
+Brief is the preferred bounded summary.
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/tasks.md" <<'DOC'
+# Tasks
+
+Run terminology checks.
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md" <<'DOC'
+# Spec
+
+Provider invocation terms are defined.
+DOC
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "Expected to find '$expected' in $file" >&2
+    echo "--- $file ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+write_required_files
+
+npx tsx "$ROOT_DIR/scripts/check-terminology.ts" --root "$TMP_DIR" >"$TMP_DIR/pass.out"
+assert_contains "$TMP_DIR/pass.out" "terminology check passed"
+
+printf '\nThis incorrectly calls generated target generated source.\n' >>"$TMP_DIR/docs/architecture.md"
+
+set +e
+npx tsx "$ROOT_DIR/scripts/check-terminology.ts" --root "$TMP_DIR" >"$TMP_DIR/fail.out" 2>"$TMP_DIR/fail.err"
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  echo "Expected terminology check to fail for discouraged terms" >&2
+  exit 1
+fi
+
+assert_contains "$TMP_DIR/fail.err" "generated source"
+assert_contains "$TMP_DIR/fail.err" "generated target"
+assert_contains "$TMP_DIR/fail.err" "docs/architecture.md"
+
+echo "terminology check script tests passed"
+```
+
+- [ ] **Step 2: Make the script executable**
+
+Run:
+
+```bash
+chmod +x test/scripts/terminology-check.test.sh
+```
+
+- [ ] **Step 3: Wire the test into root scripts**
+
+Modify `package.json`:
+
+```json
+{
+  "scripts": {
+    "test:scripts": "bash test/scripts/project-id-validation.test.sh && bash test/scripts/terminology-check.test.sh",
+    "check:terminology": "tsx scripts/check-terminology.ts"
+  }
+}
+```
+
+Keep all existing scripts and only add the new command plus the extra shell test in `test:scripts`.
+
+- [ ] **Step 4: Run the failing test**
+
+Run:
+
+```bash
+npm run test:scripts
+```
+
+Expected result:
+
+```text
+Error: Cannot find module .../scripts/check-terminology.ts
+```
+
+- [ ] **Step 5: Commit the failing test**
+
+Run:
+
+```bash
+git add package.json test/scripts/terminology-check.test.sh
+git commit -m "test: add terminology check coverage" -m "Co-Authored-By: Codex GPT-5 <noreply@openai.com>"
+```
+
+## Task 2: Implement the Focused Terminology Checker
+
+**Files:**
+
+- Create: `scripts/check-terminology.ts`
+- Test: `test/scripts/terminology-check.test.sh`
+
+- [ ] **Step 1: Add the checker implementation**
+
+Create `scripts/check-terminology.ts`:
+
+```ts
+#!/usr/bin/env tsx
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+type Rule = {
+  id: string;
+  discouraged: string;
+  preferred: string;
+  reason: string;
+};
+
+const DEFAULT_SCAN_FILES = [
+  'README.md',
+  'docs/README.md',
+  'docs/architecture.md',
+  'docs/security.md',
+  'docs/reference/session-artifacts.md',
+  'docs/reference/ubiquitous-language.md',
+  'openspec/changes/introduce-ubiquitous-language/proposal.md',
+  'openspec/changes/introduce-ubiquitous-language/design.md',
+  'openspec/changes/introduce-ubiquitous-language/tasks.md',
+  'openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md',
+] as const;
+
+const DEFAULT_RULES: Rule[] = [
+  {
+    id: 'provider-output-is-advisory',
+    discouraged: 'provider truth',
+    preferred: 'provider advisory output',
+    reason: 'Provider output is evidence for review, not authoritative truth.',
+  },
+  {
+    id: 'provider-output-is-advisory',
+    discouraged: 'raw provider truth',
+    preferred: 'full provider output',
+    reason: 'The raw/full output can be stored, but it is still advisory.',
+  },
+  {
+    id: 'generated-target-not-source',
+    discouraged: 'generated source',
+    preferred: 'generated target',
+    reason: 'Source surfaces are maintained by humans; generated targets are produced by sync.',
+  },
+  {
+    id: 'brief-is-bounded-summary',
+    discouraged: 'brief log',
+    preferred: 'brief',
+    reason: 'Briefs are bounded summaries, while output.log stores full provider output.',
+  },
+];
+
+function parseArgs(argv: string[]): { root: string; files: string[] } {
+  let root = process.cwd();
+  const files: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--root') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--root requires a path');
+      }
+      root = path.resolve(value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--file') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--file requires a repo-relative path');
+      }
+      files.push(value);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    root,
+    files: files.length > 0 ? files : [...DEFAULT_SCAN_FILES],
+  };
+}
+
+function includesDiscouragedTerm(line: string, term: string): boolean {
+  return line.toLocaleLowerCase().includes(term.toLocaleLowerCase());
+}
+
+function hasAllowComment(line: string, term: string): boolean {
+  return line.includes(`terminology-check allow: ${term}`);
+}
+
+function main(): void {
+  const { root, files } = parseArgs(process.argv.slice(2));
+  const violations: string[] = [];
+
+  for (const file of files) {
+    const absolutePath = path.join(root, file);
+    if (!existsSync(absolutePath)) {
+      continue;
+    }
+
+    const lines = readFileSync(absolutePath, 'utf8').split(/\r?\n/);
+
+    lines.forEach((line, lineIndex) => {
+      for (const rule of DEFAULT_RULES) {
+        if (!includesDiscouragedTerm(line, rule.discouraged)) {
+          continue;
+        }
+
+        if (hasAllowComment(line, rule.discouraged)) {
+          continue;
+        }
+
+        violations.push(
+          [
+            `${file}:${lineIndex + 1}`,
+            `discouraged term: "${rule.discouraged}"`,
+            `preferred term: "${rule.preferred}"`,
+            `rule: ${rule.id}`,
+            `reason: ${rule.reason}`,
+          ].join('\n  ')
+        );
+      }
+    });
+  }
+
+  if (violations.length > 0) {
+    console.error(`terminology check failed with ${violations.length} violation(s):`);
+    console.error(violations.join('\n\n'));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`terminology check passed (${files.length} files scanned)`);
+}
+
+main();
+```
+
+- [ ] **Step 2: Run the focused test**
+
+Run:
+
+```bash
+bash test/scripts/terminology-check.test.sh
+```
+
+Expected result:
+
+```text
+terminology check script tests passed
+```
+
+- [ ] **Step 3: Run all script tests**
+
+Run:
+
+```bash
+npm run test:scripts
+```
+
+Expected result includes:
+
+```text
+project ID validation script tests passed
+terminology check script tests passed
+```
+
+- [ ] **Step 4: Run the checker on the current repo**
+
+Run:
+
+```bash
+npm run check:terminology
+```
+
+Expected result:
+
+```text
+terminology check passed
+```
+
+If it fails on existing prose, fix the prose when the replacement is clearly correct. Use a same-line allow comment only for quoted discouraged examples inside the glossary.
+
+- [ ] **Step 5: Commit the checker**
+
+Run:
+
+```bash
+git add scripts/check-terminology.ts test/scripts/terminology-check.test.sh package.json
+git commit -m "feat: add terminology drift check" -m "Co-Authored-By: Codex GPT-5 <noreply@openai.com>"
+```
+
+## Task 3: Add the Ubiquitous Language Reference
+
+**Files:**
+
+- Create: `docs/reference/ubiquitous-language.md`
+- Test: `scripts/check-terminology.ts`
+
+- [ ] **Step 1: Create the glossary**
+
+Create `docs/reference/ubiquitous-language.md`:
+
+```markdown
+# Ubiquitous Language
+
+작성일: 2026-05-14
+
+This reference defines the first `aco` domain language slice for humans and AI agents. The initial scope is intentionally narrow: provider invocation and run/session artifacts.
+
+## Purpose
+
+`ai-cli-orch-wrapper` is a gray-box orchestration wrapper. Maintainers should not need to read every implementation detail to understand what a provider invocation did, what evidence was saved, and where review responsibility remains with the human.
+
+The glossary keeps LLM-assisted documentation and implementation work aligned with repo-owned terms.
+
+## Scope
+
+In scope for this slice:
+
+- provider invocation
+- run/session artifacts
+- advisory provider output
+- brief and output artifact naming
+
+Backlog placeholders:
+
+- context sync terms such as `source surface`, `generated target`, `sync manifest`, and `managed block`
+- harness boundary terms such as `harness`, `wrapper`, and `generated surface`
+- consent and permission profile terms beyond the current examples
+- verification terms beyond the current examples
+
+## Provider Invocation
+
+| Term                       | Definition                                                         | Example                                                        |
+| -------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------- |
+| `provider`                 | External AI CLI or local mock implementation invoked by `aco`.     | `mock`, `gemini`, and `codex` are providers.                   |
+| `provider invocation`      | One execution of a provider command through `aco`.                 | `aco ask --provider mock --yes` creates a provider invocation. |
+| `provider advisory output` | Provider output saved as review evidence, not authoritative truth. | `output.log` stores full provider advisory output.             |
+| `permission profile`       | The permission posture attached to a run or session.               | The default permission profile is `restricted`.                |
+
+## Run And Session Artifacts
+
+| Term         | Definition                                                                         | Example                                                                              |
+| ------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `run`        | One high-level `aco ask` operation that may include one or more provider sessions. | A multi-provider `aco ask` creates one run with multiple sessions.                   |
+| `session`    | One provider-specific execution record under a run or low-level provider command.  | Each provider session stores `task.json`, `prompt.md`, `output.log`, and `brief.md`. |
+| `artifact`   | File persisted by `aco` so the result can be reviewed after stdout has returned.   | `ledger.json`, `brief.md`, and `output.log` are artifacts.                           |
+| `brief`      | Bounded human-readable summary for stdout or stored review.                        | `brief.md` includes run ID, session ID, status, and bounded summary.                 |
+| `output.log` | Full provider advisory output for a session.                                       | `aco result` reads the latest `output.log` unless a session is specified.            |
+
+## Discouraged Synonyms
+
+| Avoid                | Prefer                     | Why                                                                 |
+| -------------------- | -------------------------- | ------------------------------------------------------------------- |
+| `provider truth`     | `provider advisory output` | Provider output is evidence for maintainer review, not final truth. |
+| `raw provider truth` | `full provider output`     | Full output may be raw, but it is still advisory.                   |
+| `generated source`   | `generated target`         | Generated files are not the human-owned source surface.             |
+| `brief log`          | `brief`                    | A brief is a bounded summary; `output.log` is the log artifact.     |
+
+## Accepted Aliases
+
+| Alias                  | Canonical term             | Usage                                                    |
+| ---------------------- | -------------------------- | -------------------------------------------------------- |
+| `full provider output` | `provider advisory output` | Use when contrasting full output with bounded summaries. |
+| `bounded summary`      | `brief`                    | Use when explaining why brief output saves tokens.       |
+| `session output`       | `output.log`               | Use when the file name is introduced immediately nearby. |
+
+## Naming Rules
+
+- Use `provider advisory output` when discussing trust and review responsibility.
+- Use `full provider output` when discussing artifact completeness.
+- Use `brief` for bounded summaries and `output.log` for full provider output.
+- Use `run` for the high-level `aco ask` unit.
+- Use `session` for provider-specific execution state.
+- Keep public command names such as `aco ask`, `aco run`, and `aco sync` unchanged.
+
+## Review Checklist
+
+- Does the change describe provider output as advisory?
+- Does the change distinguish `brief` from `output.log`?
+- Does the change distinguish `run` from `session`?
+- Does the change avoid broad renames that do not improve runtime behavior or artifact clarity?
+- Does the terminology check pass without unnecessary allow comments?
+```
+
+- [ ] **Step 2: Run the checker**
+
+Run:
+
+```bash
+npm run check:terminology
+```
+
+Expected result:
+
+```text
+terminology check passed
+```
+
+- [ ] **Step 3: Commit the glossary**
+
+Run:
+
+```bash
+git add docs/reference/ubiquitous-language.md
+git commit -m "docs: add ubiquitous language reference" -m "Co-Authored-By: Codex GPT-5 <noreply@openai.com>"
+```
+
+## Task 4: Link the Glossary from Reader-Facing Docs
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/README.md`
+- Modify: `docs/architecture.md`
+- Modify: `docs/security.md`
+- Modify: `docs/reference/session-artifacts.md`
+
+- [ ] **Step 1: Add a README pointer**
+
+Add a short sentence near the first explanation of `aco ask` or provider delegation:
+
+```markdown
+Terminology note: provider invocation, run/session artifacts, briefs, and advisory output are defined in [Ubiquitous Language](docs/reference/ubiquitous-language.md).
+```
+
+- [ ] **Step 2: Add a docs index pointer**
+
+Add `docs/reference/ubiquitous-language.md` to the reference section in `docs/README.md`:
+
+```markdown
+- [Ubiquitous Language](reference/ubiquitous-language.md): canonical terms for provider invocation and run/session artifacts.
+```
+
+- [ ] **Step 3: Add an architecture pointer**
+
+Add this after the existing artifact/security references in `docs/architecture.md`:
+
+```markdown
+Language reference: [Ubiquitous Language](reference/ubiquitous-language.md).
+```
+
+- [ ] **Step 4: Add a security pointer**
+
+Add this near the advisory provider output or permission profile discussion in `docs/security.md`:
+
+```markdown
+For canonical language around provider advisory output, permission profiles, runs, sessions, and briefs, see [Ubiquitous Language](reference/ubiquitous-language.md).
+```
+
+- [ ] **Step 5: Add a session artifact pointer**
+
+Add this near the top of `docs/reference/session-artifacts.md`:
+
+```markdown
+Terminology reference: [Ubiquitous Language](ubiquitous-language.md) defines `run`, `session`, `artifact`, `brief`, and `output.log`.
+```
+
+- [ ] **Step 6: Run documentation checks**
+
+Run:
+
+```bash
+npm run check:terminology
+npx prettier --check README.md docs/README.md docs/architecture.md docs/security.md docs/reference/session-artifacts.md docs/reference/ubiquitous-language.md
+```
+
+Expected result:
+
+```text
+terminology check passed
+All matched files use Prettier code style!
+```
+
+- [ ] **Step 7: Commit the doc links**
+
+Run:
+
+```bash
+git add README.md docs/README.md docs/architecture.md docs/security.md docs/reference/session-artifacts.md
+git commit -m "docs: link ubiquitous language reference" -m "Co-Authored-By: Codex GPT-5 <noreply@openai.com>"
+```
+
+## Task 5: Update OpenSpec Task State and Verification Evidence
+
+**Files:**
+
+- Modify: `openspec/changes/introduce-ubiquitous-language/tasks.md`
+
+- [ ] **Step 1: Mark completed tasks**
+
+After Tasks 1-4 pass, update checkboxes in `openspec/changes/introduce-ubiquitous-language/tasks.md` for:
+
+```markdown
+- [x] 1.1 Create `docs/reference/ubiquitous-language.md` with core terms, discouraged synonyms, naming rules, and examples.
+- [x] 1.2 Scope the first slice to provider execution and run/session artifacts.
+- [x] 1.3 Add backlog placeholders for context sync, harness surfaces, consent/permissions, and verification without trying to fully define them in this workflow.
+- [x] 1.4 Add a review checklist for future OpenSpec changes and PRs.
+- [x] 2.1 Link the vocabulary from `README.md`, `docs/README.md`, and `docs/architecture.md`.
+- [x] 2.2 Update `docs/security.md` and `docs/reference/session-artifacts.md` only where terminology clarification improves safety.
+- [x] 2.3 Keep doc edits scoped; avoid broad prose rewrites unrelated to vocabulary.
+- [x] 3.1 Add a small focused automated terminology check for high-risk discouraged synonyms in the initial documentation surface.
+- [x] 3.2 Include tests or fixtures that cover allowed terms, discouraged terms, accepted aliases, and allowlisted legacy language.
+- [x] 3.3 Document how to update the check without turning it into broad prose policing.
+- [x] 4.1 Avoid a strict code rename campaign.
+- [x] 4.2 Only adjust implementation names when ambiguity affects behavior, emitted artifacts, or tests.
+- [x] 4.3 Prefer aliases or docs-only alignment when a legacy name is stable and not misleading at runtime.
+```
+
+Leave verification tasks unchecked until the final commands below have passed.
+
+- [ ] **Step 2: Run final verification**
+
+Run:
+
+```bash
+openspec validate introduce-ubiquitous-language --type change --strict
+npm run test:scripts
+npm run check:terminology
+npx prettier --check README.md docs/README.md docs/architecture.md docs/security.md docs/reference/session-artifacts.md docs/reference/ubiquitous-language.md openspec/changes/introduce-ubiquitous-language/proposal.md openspec/changes/introduce-ubiquitous-language/design.md openspec/changes/introduce-ubiquitous-language/tasks.md openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md
+```
+
+Expected result:
+
+```text
+Change 'introduce-ubiquitous-language' is valid
+project ID validation script tests passed
+terminology check script tests passed
+terminology check passed
+All matched files use Prettier code style!
+```
+
+- [ ] **Step 3: Mark verification tasks**
+
+After all final verification commands pass, mark:
+
+```markdown
+- [x] 5.1 Run `openspec validate introduce-ubiquitous-language --type change --strict`.
+- [x] 5.2 Run formatter/checks for touched Markdown files.
+- [x] 5.3 Run the terminology guard and its focused tests.
+```
+
+For `5.4`, use a fresh agent or separate reader pass. If no fresh reader was used, leave it unchecked and add a short note below the task:
+
+```markdown
+Reader-test note: pending fresh-agent review.
+```
+
+- [ ] **Step 4: Commit OpenSpec status**
+
+Run:
+
+```bash
+git add openspec/changes/introduce-ubiquitous-language/tasks.md
+git commit -m "docs: record ubiquitous language verification" -m "Co-Authored-By: Codex GPT-5 <noreply@openai.com>"
+```
+
+## Task 6: Final Review Gate
+
+**Files:**
+
+- Review: all files changed by Tasks 1-5
+
+- [ ] **Step 1: Inspect changed files**
+
+Run:
+
+```bash
+git status --short
+git diff --stat origin/main...HEAD
+git diff --check
+```
+
+Expected result:
+
+```text
+git diff --check
+```
+
+prints no output.
+
+- [ ] **Step 2: Confirm no unintended workflow bleed**
+
+Run:
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected changed files are limited to:
+
+```text
+README.md
+docs/README.md
+docs/architecture.md
+docs/security.md
+docs/reference/session-artifacts.md
+docs/reference/ubiquitous-language.md
+package.json
+scripts/check-terminology.ts
+test/scripts/terminology-check.test.sh
+openspec/changes/introduce-ubiquitous-language/tasks.md
+```
+
+The implementation should not modify structured findings artifacts or repo-portable sync manifest workflow files.
+
+- [ ] **Step 3: Commit any final doc-only adjustments**
+
+If final review finds small doc wording fixes, commit them separately:
+
+```bash
+git add <changed-files>
+git commit -m "docs: refine ubiquitous language rollout notes" -m "Co-Authored-By: Codex GPT-5 <noreply@openai.com>"
+```
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Initial glossary scope is provider invocation and run/session artifacts.
+  - Context sync and harness language is represented as backlog placeholders, not fully implemented.
+  - Automated terminology check exists from the first slice.
+  - Public `aco` CLI contract is preserved.
+  - Code rename policy is soft and targeted.
+- Placeholder scan:
+  - The implementation should contain no unresolved placeholder text in docs or tests.
+  - Allow comments must appear only for quoted discouraged examples.
+- Verification:
+  - `openspec validate introduce-ubiquitous-language --type change --strict`
+  - `npm run test:scripts`
+  - `npm run check:terminology`
+  - `npx prettier --check ...`
+
+## Execution Handoff
+
+Recommended execution mode: subagent-driven implementation, one task at a time, with review between tasks.
+
+Use this start command in a fresh session:
+
+```text
+/goal
+Goal: Execute docs/plans/gray-box-workflows/introduce-ubiquitous-language-implementation-plan.md task-by-task.
+
+Context:
+- Repo: /Users/ddalkak/Projects/ai-cli-orch-wrapper/.worktrees/gray-box-kickoff-docs
+- OpenSpec change: openspec/changes/introduce-ubiquitous-language/
+- Plan: docs/plans/gray-box-workflows/introduce-ubiquitous-language-implementation-plan.md
+
+Constraints:
+- Implement only the ubiquitous language workflow.
+- Start with failing tests for terminology check.
+- Keep the first glossary slice narrow: provider invocation and session artifacts.
+- Add automated terminology checking from the first slice.
+- Avoid strict rename campaigns and preserve public CLI contracts.
+- Do not touch structured findings or repo-portable sync manifest workflows.
+
+Done when:
+- OpenSpec validation passes.
+- Script tests pass.
+- Terminology check passes.
+- Formatter check passes on touched docs.
+- OpenSpec tasks.md reflects only verified completion.
+```

--- a/docs/plans/gray-box-workflows/introduce-ubiquitous-language-proposal.html
+++ b/docs/plans/gray-box-workflows/introduce-ubiquitous-language-proposal.html
@@ -1,0 +1,969 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ubiquitous Language Kick-off | ai-cli-orch-wrapper Gray Box</title>
+    <meta
+      name="description"
+      content="ai-cli-orch-wrapper의 ubiquitous language OpenSpec proposal을 요약하고, gray box 경계를 선명하게 만들기 위한 범위, 영향, 착수 순서를 시각화한 kick-off 문서입니다."
+    />
+    <meta
+      name="keywords"
+      content="ai-cli-orch-wrapper, ubiquitous language, gray box, OpenSpec, ACO, AI CLI orchestration, technical documentation"
+    />
+    <meta name="author" content="ai-cli-orch-wrapper maintainers" />
+    <meta name="robots" content="index,follow" />
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="Ubiquitous Language Kick-off for ai-cli-orch-wrapper" />
+    <meta
+      property="og:description"
+      content="도메인 용어를 하나의 공통 언어로 정리해 AI agent와 maintainer가 같은 gray box 경계를 보고 작업하도록 만드는 proposal 요약입니다."
+    />
+    <meta property="og:site_name" content="ai-cli-orch-wrapper" />
+    <meta name="twitter:card" content="summary" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": "Ubiquitous Language Kick-off for ai-cli-orch-wrapper",
+        "description": "ai-cli-orch-wrapper의 ubiquitous language proposal을 요약하고 gray box 경계를 선명하게 만들기 위한 구현 착수 문서입니다.",
+        "author": {
+          "@type": "Organization",
+          "name": "ai-cli-orch-wrapper maintainers"
+        },
+        "datePublished": "2026-05-12",
+        "dateModified": "2026-05-14",
+        "inLanguage": "ko",
+        "keywords": [
+          "ubiquitous language",
+          "gray box",
+          "OpenSpec",
+          "AI CLI orchestration",
+          "technical documentation"
+        ],
+        "about": [
+          "Domain language",
+          "Session artifacts",
+          "Provider invocation",
+          "Context sync",
+          "Harness boundary"
+        ]
+      }
+    </script>
+    <style>
+      :root {
+        color-scheme: light;
+        --page: #f4f6f8;
+        --surface: #ffffff;
+        --surface-strong: #f9fafb;
+        --ink: #202124;
+        --ink-soft: #3b3f45;
+        --muted: #5f6873;
+        --line: #d8dde3;
+        --line-strong: #b8c0ca;
+        --teal: #0f766e;
+        --teal-soft: #dff5f1;
+        --amber: #b45309;
+        --amber-soft: #fff1d6;
+        --red: #b42318;
+        --red-soft: #ffe4df;
+        --blue: #2563eb;
+        --blue-soft: #e5edff;
+        --graphite: #24272c;
+        --shadow: 0 20px 48px rgba(26, 32, 44, 0.12);
+        --radius: 8px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        background:
+          linear-gradient(90deg, rgba(15, 118, 110, 0.08) 1px, transparent 1px),
+          linear-gradient(180deg, rgba(37, 99, 235, 0.06) 1px, transparent 1px), var(--page);
+        background-size: 56px 56px;
+        color: var(--ink);
+        font-family: 'Aptos', 'Segoe UI', 'Apple SD Gothic Neo', 'Malgun Gothic', sans-serif;
+        line-height: 1.65;
+      }
+
+      a {
+        color: var(--teal);
+        text-underline-offset: 3px;
+      }
+
+      a:hover {
+        color: var(--blue);
+      }
+
+      .skip-link {
+        position: absolute;
+        left: 16px;
+        top: -48px;
+        z-index: 10;
+        padding: 10px 14px;
+        border-radius: var(--radius);
+        background: var(--ink);
+        color: #fff;
+        transition: top 160ms ease;
+      }
+
+      .skip-link:focus {
+        top: 16px;
+      }
+
+      .hero {
+        background:
+          linear-gradient(135deg, rgba(15, 118, 110, 0.88), rgba(36, 39, 44, 0.96)), #24302f;
+        color: #fff;
+      }
+
+      .hero-inner,
+      main,
+      .footer-inner {
+        width: min(1120px, calc(100% - 40px));
+        margin: 0 auto;
+      }
+
+      .hero-inner {
+        display: grid;
+        grid-template-columns: 1.25fr 0.75fr;
+        gap: 34px;
+        align-items: end;
+        min-height: 460px;
+        padding: 56px 0 44px;
+      }
+
+      .eyebrow {
+        margin: 0 0 14px;
+        color: #b8f1e8;
+        font-size: 14px;
+        font-weight: 800;
+      }
+
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+        letter-spacing: 0;
+        line-height: 1.18;
+      }
+
+      h1 {
+        max-width: 800px;
+        font-family: 'Iowan Old Style', 'Georgia', 'Apple SD Gothic Neo', serif;
+        font-size: 52px;
+        font-weight: 800;
+      }
+
+      .lead {
+        max-width: 760px;
+        margin: 22px 0 0;
+        color: #edf9f7;
+        font-size: 19px;
+      }
+
+      .hero-panel {
+        border: 1px solid rgba(255, 255, 255, 0.28);
+        border-radius: var(--radius);
+        background: rgba(255, 255, 255, 0.08);
+        padding: 20px;
+        box-shadow: var(--shadow);
+      }
+
+      .hero-panel strong {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 15px;
+      }
+
+      .hero-panel p {
+        margin: 0;
+        color: #edf9f7;
+        font-size: 15px;
+      }
+
+      .meta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 28px;
+      }
+
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        min-height: 34px;
+        padding: 6px 11px;
+        border: 1px solid rgba(255, 255, 255, 0.26);
+        border-radius: 999px;
+        color: #fff;
+        font-size: 13px;
+        font-weight: 700;
+      }
+
+      main {
+        padding: 34px 0 60px;
+      }
+
+      .toc {
+        position: sticky;
+        top: 0;
+        z-index: 3;
+        margin: -34px 0 34px;
+        border-bottom: 1px solid var(--line);
+        background: rgba(244, 246, 248, 0.94);
+        backdrop-filter: blur(12px);
+      }
+
+      .toc nav {
+        width: min(1120px, calc(100% - 40px));
+        margin: 0 auto;
+        display: flex;
+        gap: 8px;
+        overflow-x: auto;
+        padding: 12px 0;
+      }
+
+      .toc a {
+        flex: 0 0 auto;
+        padding: 8px 12px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: var(--surface);
+        color: var(--ink-soft);
+        font-size: 13px;
+        font-weight: 800;
+        text-decoration: none;
+      }
+
+      section {
+        margin-top: 34px;
+      }
+
+      .section-head {
+        display: flex;
+        align-items: end;
+        justify-content: space-between;
+        gap: 24px;
+        margin-bottom: 16px;
+      }
+
+      .section-kicker {
+        margin: 0 0 8px;
+        color: var(--teal);
+        font-size: 13px;
+        font-weight: 900;
+      }
+
+      h2 {
+        font-size: 31px;
+      }
+
+      h3 {
+        font-size: 19px;
+      }
+
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+      }
+
+      .summary-card,
+      .note,
+      .flow-box,
+      .term-group,
+      .matrix-card,
+      .decision-card,
+      .source-card {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--surface);
+        box-shadow: 0 8px 24px rgba(26, 32, 44, 0.06);
+      }
+
+      .summary-card {
+        padding: 18px;
+      }
+
+      .summary-card .number {
+        display: inline-grid;
+        place-items: center;
+        width: 34px;
+        height: 34px;
+        margin-bottom: 14px;
+        border-radius: 999px;
+        background: var(--teal-soft);
+        color: var(--teal);
+        font-weight: 900;
+      }
+
+      .summary-card p,
+      .term-group p,
+      .matrix-card p,
+      .decision-card p,
+      .source-card p {
+        margin: 10px 0 0;
+        color: var(--muted);
+      }
+
+      .note {
+        display: grid;
+        grid-template-columns: 18px 1fr;
+        gap: 12px;
+        padding: 16px 18px;
+        background: var(--amber-soft);
+        border-color: #f2ca85;
+      }
+
+      .note-marker {
+        width: 18px;
+        height: 18px;
+        margin-top: 4px;
+        border-radius: 50%;
+        background: var(--amber);
+      }
+
+      .note p {
+        margin: 0;
+      }
+
+      .boundary {
+        display: grid;
+        grid-template-columns: 1fr 1.08fr 1fr;
+        gap: 14px;
+        align-items: stretch;
+      }
+
+      .flow-box {
+        position: relative;
+        min-height: 250px;
+        padding: 18px;
+      }
+
+      .flow-box.source {
+        border-top: 5px solid var(--teal);
+      }
+
+      .flow-box.gray {
+        border-top: 5px solid var(--graphite);
+        background:
+          linear-gradient(45deg, rgba(36, 39, 44, 0.06) 25%, transparent 25%),
+          linear-gradient(-45deg, rgba(36, 39, 44, 0.06) 25%, transparent 25%), var(--surface);
+        background-size: 18px 18px;
+      }
+
+      .flow-box.target {
+        border-top: 5px solid var(--blue);
+      }
+
+      .flow-label {
+        display: inline-block;
+        margin-bottom: 12px;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 900;
+      }
+
+      .flow-box ul,
+      .compact-list {
+        margin: 12px 0 0;
+        padding-left: 20px;
+      }
+
+      .flow-box li,
+      .compact-list li {
+        margin: 7px 0;
+      }
+
+      .diagram-wrap {
+        margin-top: 18px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--surface);
+        overflow: hidden;
+      }
+
+      .diagram-wrap svg {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+
+      .term-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 16px;
+      }
+
+      .term-group {
+        padding: 18px;
+      }
+
+      .term-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 14px;
+      }
+
+      .term {
+        display: inline-flex;
+        align-items: center;
+        min-height: 32px;
+        padding: 5px 10px;
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: var(--surface-strong);
+        color: var(--ink-soft);
+        font-size: 13px;
+        font-weight: 800;
+      }
+
+      .matrix {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 14px;
+      }
+
+      .matrix-card {
+        padding: 16px;
+      }
+
+      .tag {
+        display: inline-flex;
+        padding: 4px 8px;
+        border-radius: 999px;
+        font-size: 12px;
+        font-weight: 900;
+      }
+
+      .tag.new {
+        background: var(--teal-soft);
+        color: var(--teal);
+      }
+
+      .tag.touch {
+        background: var(--blue-soft);
+        color: var(--blue);
+      }
+
+      .tag.guard {
+        background: var(--amber-soft);
+        color: var(--amber);
+      }
+
+      .tag.stop {
+        background: var(--red-soft);
+        color: var(--red);
+      }
+
+      .decision-grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 16px;
+      }
+
+      .decision-card {
+        padding: 18px;
+      }
+
+      .decision-card h3 {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .dot {
+        display: inline-block;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: var(--teal);
+      }
+
+      .source-card {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 14px;
+        align-items: center;
+        padding: 18px;
+      }
+
+      .source-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        justify-content: flex-end;
+      }
+
+      .source-card code,
+      .inline-code {
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--surface-strong);
+        padding: 2px 6px;
+        color: var(--ink-soft);
+        font-family: 'SFMono-Regular', 'Cascadia Code', 'Consolas', monospace;
+        font-size: 0.92em;
+      }
+
+      .button-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 40px;
+        padding: 8px 13px;
+        border-radius: var(--radius);
+        background: var(--ink);
+        color: #fff;
+        font-weight: 900;
+        text-decoration: none;
+      }
+
+      .button-link:hover {
+        background: var(--teal);
+        color: #fff;
+      }
+
+      .footer {
+        border-top: 1px solid var(--line);
+        background: var(--surface);
+      }
+
+      .footer-inner {
+        padding: 24px 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      @media (max-width: 900px) {
+        .hero-inner,
+        .boundary,
+        .summary-grid,
+        .term-grid,
+        .matrix,
+        .decision-grid,
+        .source-card {
+          grid-template-columns: 1fr;
+        }
+
+        .hero-inner {
+          min-height: auto;
+          padding: 42px 0 34px;
+        }
+
+        h1 {
+          font-size: 38px;
+        }
+
+        h2 {
+          font-size: 27px;
+        }
+      }
+
+      @media (max-width: 560px) {
+        .hero-inner,
+        main,
+        .footer-inner,
+        .toc nav {
+          width: min(100% - 28px, 1120px);
+        }
+
+        h1 {
+          font-size: 32px;
+        }
+
+        .lead {
+          font-size: 17px;
+        }
+
+        .section-head {
+          display: block;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">본문으로 이동</a>
+
+    <header class="hero">
+      <div class="hero-inner">
+        <div>
+          <p class="eyebrow">OpenSpec proposal digest</p>
+          <h1>Ubiquitous Language로 gray box의 회색을 선명하게 만든다</h1>
+          <p class="lead">
+            이 문서는 <span class="inline-code">introduce-ubiquitous-language</span>
+            proposal을 구현 착수자가 빠르게 이해하도록 재구성한 HTML kick-off입니다. 핵심은 코드만이
+            아니라 용어, 문서, artifact 이름까지 같은 경계 언어로 맞추는 것입니다.
+          </p>
+          <div class="meta-row" aria-label="문서 속성">
+            <span class="chip">대상: maintainer와 AI agent</span>
+            <span class="chip">범위: docs first</span>
+            <span class="chip">금지: public CLI rename</span>
+          </div>
+        </div>
+        <aside class="hero-panel" aria-label="핵심 요약">
+          <strong>한 문장 요약</strong>
+          <p>
+            흩어진 도메인 용어를 하나의 repo-owned glossary로 묶어
+            <span class="inline-code">aco ask</span>, <span class="inline-code">aco run</span>,
+            <span class="inline-code">aco sync</span>가 같은 의미 체계에서 계획되고 검증되게 만든다.
+          </p>
+        </aside>
+      </div>
+    </header>
+
+    <div class="toc" aria-label="문서 목차">
+      <nav>
+        <a href="#summary">요약</a>
+        <a href="#gray-box">Gray Box 시각화</a>
+        <a href="#terms">용어 지도</a>
+        <a href="#impact">영향 범위</a>
+        <a href="#kickoff">착수 질문</a>
+        <a href="#source">원문</a>
+      </nav>
+    </div>
+
+    <main id="main">
+      <section id="summary" aria-labelledby="summary-title">
+        <div class="section-head">
+          <div>
+            <p class="section-kicker">01. Executive Summary</p>
+            <h2 id="summary-title">proposal의 핵심은 세 가지입니다</h2>
+          </div>
+        </div>
+        <div class="summary-grid">
+          <article class="summary-card">
+            <span class="number">1</span>
+            <h3>언어도 interface다</h3>
+            <p>
+              현재 용어는 README, architecture, security, tests, implementation에 흩어져 있습니다.
+              문서 작성과 갱신을 LLM이 보조하더라도 최종 기준은 repo 안에 남아야 하며, agent가 매번
+              의미를 다시 추론하면 gray box 경계가 흐려집니다.
+            </p>
+          </article>
+          <article class="summary-card">
+            <span class="number">2</span>
+            <h3>repo-owned glossary를 만든다</h3>
+            <p>
+              <span class="inline-code">docs/reference/ubiquitous-language.md</span>
+              를 source of truth로 두고, provider invocation, session artifact, context sync,
+              harness boundary 용어를 정렬합니다.
+            </p>
+          </article>
+          <article class="summary-card">
+            <span class="number">3</span>
+            <h3>작게 연결하고 drift를 막는다</h3>
+            <p>
+              모든 문서를 한 번에 다시 쓰지 않습니다. 용어가 처음 등장하는 문서에 링크를 추가하고,
+              처음부터 자동 terminology check를 붙여 LLM-assisted 문서 갱신의 drift를 잡습니다.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="gray-box" aria-labelledby="gray-box-title">
+        <div class="section-head">
+          <div>
+            <p class="section-kicker">02. Boundary Model</p>
+            <h2 id="gray-box-title">gray box에서 “회색”이 의미하는 것</h2>
+          </div>
+        </div>
+        <div class="note">
+          <span class="note-marker" aria-hidden="true"></span>
+          <p>
+            회색은 완전한 black box도, 완전한 white box도 아닙니다. 내부 구현을 모두 노출하지
+            않더라도, maintainer와 agent가 같은 용어로 입력, 출력, evidence, artifact를 추적할 수
+            있어야 합니다.
+          </p>
+        </div>
+        <div class="boundary" aria-label="gray box boundary cards">
+          <article class="flow-box source">
+            <span class="flow-label">SOURCE SURFACE</span>
+            <h3>repo가 관리하고 LLM이 보조하는 기준</h3>
+            <ul>
+              <li>README와 architecture docs</li>
+              <li>security와 session artifact reference</li>
+              <li>LLM-assisted docs와 review notes</li>
+              <li>OpenSpec capabilities와 scenarios</li>
+              <li>public CLI contract</li>
+            </ul>
+          </article>
+          <article class="flow-box gray">
+            <span class="flow-label">GRAY BOX LANGUAGE LAYER</span>
+            <h3>공통 언어가 통과시키는 것</h3>
+            <ul>
+              <li>
+                동일한 의미의 <span class="inline-code">run</span>과
+                <span class="inline-code">session</span>
+              </li>
+              <li>provider output을 advisory로 다루는 규칙</li>
+              <li>artifact와 brief의 책임 분리</li>
+              <li>harness와 generated target의 경계</li>
+            </ul>
+          </article>
+          <article class="flow-box target">
+            <span class="flow-label">GENERATED TARGET</span>
+            <h3>agent가 생성하거나 수정하는 표면</h3>
+            <ul>
+              <li>provider prompts와 review notes</li>
+              <li>tests와 emitted artifact names</li>
+              <li>future OpenSpec changes</li>
+              <li>terminology-sensitive runtime output</li>
+            </ul>
+          </article>
+        </div>
+        <div class="diagram-wrap">
+          <svg viewBox="0 0 1120 360" role="img" aria-labelledby="diagram-title diagram-desc">
+            <title id="diagram-title">Ubiquitous language flow diagram</title>
+            <desc id="diagram-desc">
+              Glossary에서 docs, provider prompts, artifacts, tests로 용어가 흐르고 다시 review
+              gate를 통해 drift가 감지되는 흐름입니다.
+            </desc>
+            <rect width="1120" height="360" fill="#ffffff" />
+            <g font-family="Aptos, Segoe UI, sans-serif" font-size="18" fill="#202124">
+              <rect x="48" y="72" width="248" height="112" rx="8" fill="#dff5f1" stroke="#0f766e" />
+              <text x="72" y="116" font-weight="800">Glossary</text>
+              <text x="72" y="148" font-size="15" fill="#3b3f45">
+                docs/reference/ubiquitous-language.md
+              </text>
+
+              <rect x="436" y="42" width="248" height="78" rx="8" fill="#e5edff" stroke="#2563eb" />
+              <text x="460" y="86" font-weight="800">Docs and OpenSpec</text>
+
+              <rect
+                x="436"
+                y="142"
+                width="248"
+                height="78"
+                rx="8"
+                fill="#fff1d6"
+                stroke="#b45309"
+              />
+              <text x="460" y="186" font-weight="800">Provider Prompts</text>
+
+              <rect
+                x="436"
+                y="242"
+                width="248"
+                height="78"
+                rx="8"
+                fill="#f9fafb"
+                stroke="#b8c0ca"
+              />
+              <text x="460" y="286" font-weight="800">Artifacts and Tests</text>
+
+              <rect
+                x="824"
+                y="112"
+                width="248"
+                height="136"
+                rx="8"
+                fill="#ffe4df"
+                stroke="#b42318"
+              />
+              <text x="848" y="160" font-weight="800">Review Gate</text>
+              <text x="848" y="194" font-size="15" fill="#3b3f45">preferred terms pass</text>
+              <text x="848" y="220" font-size="15" fill="#3b3f45">
+                conflicting terms get flagged
+              </text>
+            </g>
+            <g stroke="#5f6873" stroke-width="3" fill="none" marker-end="url(#arrow)">
+              <path d="M 296 128 C 350 128, 376 82, 436 82" />
+              <path d="M 296 128 C 350 128, 376 181, 436 181" />
+              <path d="M 296 128 C 350 128, 376 282, 436 282" />
+              <path d="M 684 82 C 748 82, 766 152, 824 152" />
+              <path d="M 684 181 C 748 181, 766 181, 824 181" />
+              <path d="M 684 282 C 748 282, 766 214, 824 214" />
+              <path d="M 824 240 C 662 340, 262 332, 174 184" stroke-dasharray="8 8" />
+            </g>
+            <defs>
+              <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+                <path d="M0,0 L0,6 L9,3 z" fill="#5f6873" />
+              </marker>
+            </defs>
+          </svg>
+        </div>
+      </section>
+
+      <section id="terms" aria-labelledby="terms-title">
+        <div class="section-head">
+          <div>
+            <p class="section-kicker">03. Term Map</p>
+            <h2 id="terms-title">먼저 정렬해야 할 용어 묶음</h2>
+          </div>
+        </div>
+        <div class="term-grid">
+          <article class="term-group">
+            <h3>Provider Invocation</h3>
+            <p>외부 AI CLI를 호출하고 결과를 advisory evidence로 다루는 영역입니다.</p>
+            <div class="term-list">
+              <span class="term">provider</span>
+              <span class="term">advisory</span>
+              <span class="term">permission profile</span>
+              <span class="term">aco ask</span>
+              <span class="term">aco run</span>
+            </div>
+          </article>
+          <article class="term-group">
+            <h3>Session Artifacts</h3>
+            <p>실행 결과가 사람이 검토 가능한 증거로 남는 영역입니다.</p>
+            <div class="term-list">
+              <span class="term">run</span>
+              <span class="term">session</span>
+              <span class="term">artifact</span>
+              <span class="term">brief</span>
+              <span class="term">output log</span>
+            </div>
+          </article>
+          <article class="term-group">
+            <h3>Context Sync</h3>
+            <p>repo source와 generated target이 어떻게 연결되는지 설명하는 영역입니다.</p>
+            <div class="term-list">
+              <span class="term">source surface</span>
+              <span class="term">generated target</span>
+              <span class="term">sync manifest</span>
+              <span class="term">managed block</span>
+              <span class="term">drift</span>
+            </div>
+          </article>
+          <article class="term-group">
+            <h3>Harness Boundary</h3>
+            <p>agent와 wrapper가 어디까지 책임지는지 구분하는 영역입니다.</p>
+            <div class="term-list">
+              <span class="term">harness</span>
+              <span class="term">wrapper</span>
+              <span class="term">CLI contract</span>
+              <span class="term">review gate</span>
+              <span class="term">verification</span>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="impact" aria-labelledby="impact-title">
+        <div class="section-head">
+          <div>
+            <p class="section-kicker">04. Scope and Impact</p>
+            <h2 id="impact-title">바뀌는 곳과 바꾸지 않는 곳</h2>
+          </div>
+        </div>
+        <div class="matrix">
+          <article class="matrix-card">
+            <span class="tag new">New</span>
+            <h3>새 기준 문서</h3>
+            <p>
+              <span class="inline-code">docs/reference/ubiquitous-language.md</span>
+              를 glossary와 naming rules의 기준점으로 추가합니다.
+            </p>
+          </article>
+          <article class="matrix-card">
+            <span class="tag touch">Touch</span>
+            <h3>기존 문서 링크</h3>
+            <p>
+              README, architecture, security, session artifact docs에서 용어가 처음 등장하는 지점에
+              짧은 설명이나 링크를 붙입니다.
+            </p>
+          </article>
+          <article class="matrix-card">
+            <span class="tag guard">Guard</span>
+            <h3>가벼운 drift 방지</h3>
+            <p>
+              broad rename 대신 초기 자동 terminology check와 review checklist를 함께 두고, 충돌
+              용어를 조기에 잡습니다.
+            </p>
+          </article>
+          <article class="matrix-card">
+            <span class="tag stop">Non-goal</span>
+            <h3>공개 contract 보존</h3>
+            <p>
+              <span class="inline-code">aco</span> CLI 이름 변경, 스타일성 대규모 rename, 전 문서
+              일괄 rewrite는 이번 범위가 아닙니다.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="kickoff" aria-labelledby="kickoff-title">
+        <div class="section-head">
+          <div>
+            <p class="section-kicker">05. Kick-off Questions</p>
+            <h2 id="kickoff-title">구현 세션을 시작할 때 적용할 결정</h2>
+          </div>
+        </div>
+        <div class="decision-grid">
+          <article class="decision-card">
+            <h3><span class="dot"></span>1차 glossary 범위</h3>
+            <p>
+              좁게 시작합니다. 1차 범위는 provider invocation과 session artifacts로 제한하고, 나머지
+              용어는 placeholder와 backlog로 남겨 2차 확장에서 다룹니다.
+            </p>
+          </article>
+          <article class="decision-card">
+            <h3><span class="dot"></span>자동 check 시작점</h3>
+            <p>
+              처음부터 자동 terminology check를 넣습니다. PR review checklist는 보조 채널로 두고,
+              false positive는 alias나 allowlist로 조정합니다.
+            </p>
+          </article>
+          <article class="decision-card">
+            <h3><span class="dot"></span>code rename 강도</h3>
+            <p>
+              너무 엄격한 rename campaign은 피합니다. public contract는 보존하되 혼란을 줄이는
+              targeted naming, alias, docs-only 정렬을 우선합니다.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section id="source" aria-labelledby="source-title">
+        <div class="section-head">
+          <div>
+            <p class="section-kicker">06. Source</p>
+            <h2 id="source-title">원문 proposal과 다음 읽을거리</h2>
+          </div>
+        </div>
+        <div class="source-card">
+          <div>
+            <h3>OpenSpec proposal</h3>
+            <p>
+              이 HTML은 아래 원문을 읽기 쉬운 briefing 형식으로 재구성한 보조 문서입니다. 이
+              페이지의 결정 사항은 다음 implementation plan에 반영할 입력이며, 최종 변경 기준은
+              OpenSpec change directory의 proposal, design, tasks, spec입니다.
+            </p>
+            <p>
+              <code>openspec/changes/introduce-ubiquitous-language/proposal.md</code>
+            </p>
+          </div>
+          <div class="source-actions">
+            <a class="button-link" href="introduce-ubiquitous-language-implementation-plan.md">
+              Plan 열기
+            </a>
+            <a
+              class="button-link"
+              href="../../../openspec/changes/introduce-ubiquitous-language/proposal.md"
+            >
+              원문 열기
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="footer-inner">
+        Last reviewed: 2026-05-14. This page is a kick-off briefing for the
+        <span class="inline-code">introduce-ubiquitous-language</span> OpenSpec change.
+      </div>
+    </footer>
+  </body>
+</html>

--- a/docs/reference/session-artifacts.md
+++ b/docs/reference/session-artifacts.md
@@ -4,6 +4,8 @@
 
 `aco ask`와 `aco run`은 provider output을 stdout에만 남기지 않고 사용자 홈의 `~/.aco/` 아래에 저장한다. Goal 2 기준 artifact contract는 `aco ask`의 run/session layout을 문서화하는 v1이다.
 
+Terminology reference: [Ubiquitous Language](ubiquitous-language.md) defines `run`, `session`, `artifact`, `brief`, and `output.log`.
+
 ## Why Artifacts Exist
 
 Claude Code 세션 안에서는 token-saving이 중요하다. `aco ask --output-mode brief`는 bounded summary만 보여 주고, full provider output은 artifact로 저장한다. Claude Code는 필요한 경우 `aco result` 또는 artifact 파일을 통해 full output을 다시 확인한다.

--- a/docs/reference/ubiquitous-language.md
+++ b/docs/reference/ubiquitous-language.md
@@ -1,0 +1,80 @@
+# Ubiquitous Language
+
+작성일: 2026-05-14
+
+This reference defines the first `aco` domain language slice for humans and AI agents. The initial scope is intentionally narrow: provider invocation and run/session artifacts.
+
+## Purpose
+
+`ai-cli-orch-wrapper` is a gray-box orchestration wrapper. Maintainers should not need to read every implementation detail to understand what a provider invocation did, what evidence was saved, and where review responsibility remains with the human.
+
+The glossary keeps LLM-assisted documentation and implementation work aligned with repo-owned terms.
+
+## Scope
+
+In scope for this slice:
+
+- provider invocation
+- run/session artifacts
+- provider advisory output
+- brief and output artifact naming
+
+Backlog placeholders:
+
+- context sync terms such as `source surface`, `generated target`, `sync manifest`, and `managed block`
+- harness boundary terms such as `harness`, `wrapper`, and `generated surface`
+- consent and permission profile terms beyond the current examples
+- verification terms beyond the current examples
+
+## Provider Invocation
+
+| Term                       | Definition                                                         | Example                                                        |
+| -------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------- |
+| `provider`                 | External AI CLI or local mock implementation invoked by `aco`.     | `mock`, `gemini`, and `codex` are providers.                   |
+| `provider invocation`      | One execution of a provider command through `aco`.                 | `aco ask --provider mock --yes` creates a provider invocation. |
+| `provider advisory output` | Provider output saved as review evidence, not authoritative truth. | `output.log` stores full provider advisory output.             |
+| `permission profile`       | The permission posture attached to a run or session.               | The default permission profile is `restricted`.                |
+
+## Run And Session Artifacts
+
+| Term         | Definition                                                                         | Example                                                                                  |
+| ------------ | ---------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `run`        | One high-level `aco ask` operation that may include one or more provider sessions. | A multi-provider `aco ask` creates one run with multiple sessions.                       |
+| `session`    | One provider-specific execution record under a run or low-level provider command.  | Each provider session stores `task.json`, `prompt.md`, `output.log`, and `brief.md`.     |
+| `artifact`   | File persisted by `aco` so the result can be reviewed after stdout has returned.   | `ledger.json`, `brief.md`, and `output.log` are artifacts.                               |
+| `brief`      | Bounded human-readable summary for stdout or stored review.                        | Run-level and session-level `brief.md` files include IDs, status, and bounded summaries. |
+| `output.log` | Full provider advisory output for a session.                                       | `aco result` reads the latest `output.log` unless a session is specified.                |
+
+## Discouraged Synonyms
+
+| Avoid                                                                     | Prefer                     | Why                                                                 |
+| ------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------- |
+| `provider truth` <!-- terminology-check allow: provider truth -->         | `provider advisory output` | Provider output is evidence for maintainer review, not final truth. |
+| `raw provider truth` <!-- terminology-check allow: raw provider truth --> | `full provider output`     | Full output may be raw, but it is still advisory.                   |
+| `generated source` <!-- terminology-check allow: generated source -->     | `generated target`         | Generated files are not the human-owned source surface.             |
+| `brief log` <!-- terminology-check allow: brief log -->                   | `brief`                    | A brief is a bounded summary; `output.log` is the log artifact.     |
+
+## Accepted Aliases
+
+| Alias                  | Canonical term             | Usage                                                    |
+| ---------------------- | -------------------------- | -------------------------------------------------------- |
+| `full provider output` | `provider advisory output` | Use when contrasting full output with bounded summaries. |
+| `bounded summary`      | `brief`                    | Use when explaining why brief output saves tokens.       |
+| `session output`       | `output.log`               | Use when the file name is introduced immediately nearby. |
+
+## Naming Rules
+
+- Use `provider advisory output` when discussing trust and review responsibility.
+- Use `full provider output` when discussing artifact completeness.
+- Use `brief` for bounded summaries and `output.log` for full provider output.
+- Use `run` for the high-level `aco ask` unit.
+- Use `session` for provider-specific execution state.
+- Keep public command names such as `aco ask`, `aco run`, and `aco sync` unchanged.
+
+## Review Checklist
+
+- Does the change describe provider output as advisory?
+- Does the change distinguish `brief` from `output.log`?
+- Does the change distinguish `run` from `session`?
+- Does the change avoid broad renames that do not improve runtime behavior or artifact clarity?
+- Does the terminology check pass without unnecessary allow comments?

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,6 +4,8 @@
 
 `ai-cli-orch-wrapper` is a consent-gated external AI delegation wrapper for Claude Code. It helps Claude Code ask external AI CLIs for advisory work, but it is not a sandbox, secret scanner, or remote auth verifier.
 
+For canonical language around provider advisory output, permission profiles, runs, sessions, and briefs, see [Ubiquitous Language](reference/ubiquitous-language.md).
+
 ## Consent-Gated Execution
 
 `aco ask` never invokes providers unless the user gives explicit execution consent.

--- a/openspec/changes/add-structured-findings-artifacts/.openspec.yaml
+++ b/openspec/changes/add-structured-findings-artifacts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/add-structured-findings-artifacts/design.md
+++ b/openspec/changes/add-structured-findings-artifacts/design.md
@@ -1,0 +1,100 @@
+## Context
+
+The current artifact model is intentionally conservative: full output is saved, bounded summaries protect the active Claude Code context, and `mock` enables deterministic tests. The missing piece is a structured review boundary.
+
+Structured findings should let maintainers inspect "what the provider claims" without reading the entire provider transcript. The artifact must remain advisory, reproducible, and safe to ignore if parsing fails.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a stable `findings.json` schema for `aco ask` session artifacts.
+- Support provider-specific structured extraction where available.
+- Fall back safely when output is unstructured or malformed.
+- Keep run-level `ledger.json` aware of findings count and artifact path.
+- Preserve current `brief`, `save-only`, and `full` output modes.
+
+**Non-Goals:**
+
+- No automatic remediation.
+- No automatic GitHub issue or review comment creation.
+- No claim that a finding is true without maintainer validation.
+- No full provider prompt redesign in the first slice.
+
+## Candidate Schema
+
+```json
+{
+  "schemaVersion": "1",
+  "sessionId": "uuid",
+  "provider": "mock",
+  "command": "ask",
+  "generatedAt": "2026-05-12T00:00:00.000Z",
+  "source": {
+    "outputLog": "~/.aco/sessions/<id>/output.log",
+    "parser": "mock-v1"
+  },
+  "findings": [
+    {
+      "id": "F001",
+      "severity": "P1",
+      "title": "Brief title",
+      "summary": "One-paragraph advisory claim.",
+      "evidence": [
+        {
+          "path": "packages/wrapper/src/commands/ask.ts",
+          "line": 120,
+          "quote": "Short bounded excerpt"
+        }
+      ],
+      "suggestedFix": "What a maintainer should consider changing.",
+      "validation": "Focused command or manual check to verify the claim.",
+      "confidence": "medium"
+    }
+  ],
+  "parseStatus": "ok"
+}
+```
+
+## Decisions
+
+1. **Findings are session-scoped**
+   - Option A: Only run-level findings.
+   - Option B: Session-level findings with run-level aggregation metadata.
+   - Decision: choose B. Provider output is session-scoped today, and multi-provider runs need provider attribution.
+
+2. **Parsing failure is not provider failure**
+   - Option A: Fail the session when findings parsing fails.
+   - Option B: Mark `parseStatus` as `failed` and keep the provider session status based on invocation result.
+   - Decision: choose B. Structured parsing is a boundary improvement, not proof that provider execution failed.
+
+3. **Use deterministic mock provider as the first parser target**
+   - Option A: Start with real Codex/Gemini parsing.
+   - Option B: Start with `mock` and a generic fallback, then add real provider prompt/extraction later.
+   - Decision: choose B. This preserves no-auth CI and lets the schema stabilize.
+
+4. **Keep Markdown brief as a reader artifact**
+   - Option A: Replace `brief.md` with JSON.
+   - Option B: Keep `brief.md` and add `findings.json`.
+   - Decision: choose B. Humans still need a compact narrative artifact.
+
+## Risks / Trade-offs
+
+- [Risk] JSON schema creates false confidence. [Mitigation] Every artifact includes advisory language and confidence fields.
+- [Risk] Providers hallucinate file paths or lines. [Mitigation] Store findings as claims and add validation guidance; do not auto-apply.
+- [Risk] Schema churn breaks consumers. [Mitigation] Include `schemaVersion` and avoid changing v1 fields after release.
+- [Risk] Structured artifacts duplicate `brief.md`. [Mitigation] Use JSON for machine-readable findings and brief for human summary only.
+
+## Validation Strategy
+
+- Add tests for `aco ask --providers mock --yes --output-mode brief` creating `findings.json`.
+- Add tests for malformed parser output producing `parseStatus: failed` without losing `output.log`.
+- Add tests for empty findings.
+- Add tests that `save-only` does not print findings body to stdout.
+- Run `npm test --workspace=packages/wrapper` and focused artifact tests.
+
+## Open Questions
+
+- Should `findings.json` be required for every successful `aco ask` session, even when there are zero findings?
+- Should `aco result --format json` be part of this workflow or a follow-up?
+- Should severity use repo review levels `P0` to `P3`, or a provider-neutral scale such as `critical/high/medium/low`?

--- a/openspec/changes/add-structured-findings-artifacts/proposal.md
+++ b/openspec/changes/add-structured-findings-artifacts/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+`aco ask` currently stores full provider output in `output.log` and summarizes it into bounded briefs. This is useful for token control, but it is still mostly prose. A maintainer or supervising agent must read unstructured output to know which issues were found, how severe they are, what files are implicated, and what validation is suggested.
+
+That weakens gray box operation. To treat provider output as a reviewable advisory artifact without trusting its internals blindly, findings need a structured boundary.
+
+## What Changes
+
+- Add a structured findings artifact for `aco ask` provider sessions.
+- Keep `output.log` as the full raw provider output.
+- Keep `brief.md` as the human-readable summary.
+- Add a machine-readable artifact such as `findings.json` with a stable schema.
+- Provide parser behavior for providers that can emit structured findings and conservative fallback behavior for providers that cannot.
+
+## Capabilities
+
+### New Capabilities
+
+- `structured-findings-artifacts`: `aco ask` sessions can persist structured advisory findings with severity, evidence, suggested fix, and validation metadata.
+
+### Modified Capabilities
+
+- `aco ask` artifact layout expands from raw output plus brief to raw output plus brief plus optional or required structured findings.
+- `aco result` may gain an option to display structured findings, but the default output contract should remain backward compatible.
+
+## Impact
+
+- `packages/wrapper/src/commands/ask.ts`: write findings artifact and ledger references.
+- `packages/wrapper/src/runtime/provider-session-runner.ts`: no broad changes expected unless structured parsing is centralized.
+- `packages/wrapper/src/providers/*`: provider-specific summarization or parsing hooks may be added.
+- `packages/wrapper/src/session/store.ts`: may expose paths for findings artifacts.
+- `docs/reference/session-artifacts.md`: document the new artifact and schema.
+- `docs/security.md`: clarify that structured findings are advisory and not redacted.
+- Tests: add fixture coverage for valid findings, malformed provider output, empty findings, and backwards compatibility.
+
+## Non-Goals
+
+- Do not make provider findings authoritative.
+- Do not remove `output.log`.
+- Do not require every real provider to emit perfect JSON in the first slice.
+- Do not implement automatic issue creation or PR comments in this workflow.
+- Do not add secret scanning unless a separate security workflow is approved.

--- a/openspec/changes/add-structured-findings-artifacts/specs/structured-findings-artifacts/spec.md
+++ b/openspec/changes/add-structured-findings-artifacts/specs/structured-findings-artifacts/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Structured findings artifact
+
+`aco ask` SHALL persist machine-readable structured findings for provider sessions while preserving raw provider output and human-readable briefs.
+
+#### Scenario: Successful provider session writes findings artifact
+
+- **WHEN** `aco ask` invokes a provider successfully
+- **THEN** the session artifact directory SHALL include a structured findings artifact
+- **AND** the artifact SHALL include schema version, session id, provider, command, generated timestamp, parse status, and findings list.
+
+#### Scenario: Findings remain advisory
+
+- **WHEN** a structured finding is recorded
+- **THEN** the finding SHALL be represented as an advisory provider claim
+- **AND** it SHALL include enough validation guidance for a maintainer or supervising agent to verify it before acting.
+
+#### Scenario: Raw output remains available
+
+- **WHEN** structured findings are created
+- **THEN** the full provider output SHALL still be stored in `output.log`
+- **AND** existing `aco result` behavior SHALL remain backward compatible unless an explicit new option is used.
+
+#### Scenario: Malformed structured output is handled conservatively
+
+- **WHEN** structured extraction fails or provider output is malformed
+- **THEN** provider invocation status SHALL remain based on the provider process result
+- **AND** the findings artifact SHALL record a non-ok parse status or equivalent error metadata.
+
+#### Scenario: Output modes preserve token-saving behavior
+
+- **WHEN** `aco ask` runs in `brief` or `save-only` mode
+- **THEN** structured findings SHALL NOT cause unbounded provider output to be printed to stdout.

--- a/openspec/changes/add-structured-findings-artifacts/tasks.md
+++ b/openspec/changes/add-structured-findings-artifacts/tasks.md
@@ -1,0 +1,26 @@
+## 1. Schema and artifact contract
+
+- [ ] 1.1 Define `findings.json` v1 schema in docs and TypeScript types.
+- [ ] 1.2 Decide whether `findings.json` is always created or only created when findings exist.
+- [ ] 1.3 Document advisory status, parse status, severity scale, confidence, evidence, and validation fields.
+
+## 2. Parser and writer behavior
+
+- [ ] 2.1 Add deterministic mock-provider structured findings extraction.
+- [ ] 2.2 Add generic fallback behavior for unstructured provider output.
+- [ ] 2.3 Persist session-level `findings.json` and reference it from run-level `ledger.json`.
+- [ ] 2.4 Ensure parse errors are captured without changing successful provider invocation status.
+
+## 3. CLI and docs integration
+
+- [ ] 3.1 Update `aco result` only if needed for discoverability; preserve default behavior.
+- [ ] 3.2 Update `docs/reference/session-artifacts.md`.
+- [ ] 3.3 Update `docs/security.md` to state structured findings are advisory and not redacted.
+- [ ] 3.4 Add README or runbook examples using mock provider only.
+
+## 4. Verification
+
+- [ ] 4.1 Add focused tests for valid, empty, and malformed findings.
+- [ ] 4.2 Verify `brief`, `save-only`, and `full` output modes still behave as documented.
+- [ ] 4.3 Run `openspec validate add-structured-findings-artifacts --type change --strict`.
+- [ ] 4.4 Run `npm run build`, `npm test --workspace=packages/wrapper`, and `npm run typecheck`.

--- a/openspec/changes/introduce-ubiquitous-language/.openspec.yaml
+++ b/openspec/changes/introduce-ubiquitous-language/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/introduce-ubiquitous-language/design.md
+++ b/openspec/changes/introduce-ubiquitous-language/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The repo already has strong architectural boundaries, but the language boundary is implicit. This is risky for AI-assisted development because agents and LLM-assisted documentation depend on names to infer intent. If `run`, `session`, `artifact`, and `brief` are used inconsistently, future changes can look correct locally while weakening the overall design.
+
+This workflow should make the vocabulary explicit without turning it into a heavy taxonomy project. The first implementation slice should stay narrow: provider invocation and session artifacts first, then context sync and harness/generated boundaries later.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a compact glossary of terms that are already central to provider invocation and session artifacts.
+- Classify terms by domain area: provider execution, artifacts, context sync, harness surfaces, permissions, and verification.
+- Provide naming rules that future code, docs, tests, and OpenSpec changes can follow.
+- Add an automated terminology check from the first slice, with aliases or allowlists for intentional legacy language.
+- Add reader-facing links so contributors can discover the vocabulary before implementing changes.
+
+**Non-Goals:**
+
+- Exhaustively document every function, test helper, or file.
+- Rename stable public commands unless there is a correctness issue.
+- Add a custom parser, strict rename campaign, or large lint framework in the first slice.
+
+## Decisions
+
+1. **Create a Markdown reference first**
+   - Option A: Add code-level linting first.
+   - Option B: Add `docs/reference/ubiquitous-language.md` first, with a focused automated terminology check in the same slice.
+   - Decision: choose B. The repo needs a shared human and AI reference, but the first slice should still include an automated drift guard.
+
+2. **Use domain sections instead of alphabetic-only glossary**
+   - Option A: Alphabetical terms only.
+   - Option B: Domain sections plus an alphabetical index.
+   - Decision: choose B. Gray box reasoning depends on understanding relationships, not just definitions.
+
+3. **Separate preferred terms from rejected synonyms**
+   - Option A: Only define accepted terms.
+   - Option B: Also list discouraged terms such as `raw provider truth` or `generated source`. <!-- terminology-check allow: raw provider truth --><!-- terminology-check allow: generated source -->
+   - Decision: choose B. Rejected synonyms prevent subtle design drift.
+
+4. **Automate narrowly from the start**
+   - Option A: Add broad linting over all Markdown and TypeScript immediately.
+   - Option B: Add a small script or test for high-risk discouraged terms in the initial documentation surface.
+   - Decision: choose B. Do add automation from the first slice, but avoid brittle text policing across the whole repo.
+
+5. **Keep code renames soft**
+   - Option A: Treat every preferred term mismatch as a required code rename.
+   - Option B: Prefer docs-only alignment, aliases, and targeted naming where ambiguity affects behavior or artifacts.
+   - Decision: choose B. The ubiquitous language should clarify the gray box, not create churn or break public contracts.
+
+## Proposed Document Shape
+
+```text
+docs/reference/ubiquitous-language.md
+├── Purpose
+├── Domain Model
+├── Core Terms
+│   ├── Provider execution
+│   ├── Run/session artifacts
+│   ├── Context sync (backlog placeholders)
+│   ├── Harness and generated surfaces (backlog placeholders)
+│   ├── Permission and consent
+│   └── Verification
+├── Discouraged Synonyms
+├── Naming Rules
+├── Examples
+└── Review Checklist
+```
+
+## Risks / Trade-offs
+
+- [Risk] Glossary becomes stale. [Mitigation] Add a focused terminology check from the first slice and link it from OpenSpec workflow docs.
+- [Risk] Overzealous renaming causes churn. [Mitigation] Limit initial changes to docs, aliases, and targeted naming only when ambiguity affects behavior or artifacts.
+- [Risk] The glossary is too abstract for new contributors. [Mitigation] Include concrete examples from `aco ask`, `aco run`, `aco sync`, and `aco doctor`.
+
+## Validation Strategy
+
+- Run `openspec validate introduce-ubiquitous-language --type change --strict`.
+- Run Markdown formatting checks for touched docs.
+- Include a focused terminology check with allowed, discouraged, alias, and allowlist examples.
+- Reader-test the glossary by asking whether a fresh agent can explain the difference between `run`, `session`, `brief`, and `output.log`.
+
+## Open Questions
+
+- Which exact file set should the first terminology check cover: glossary only, touched docs, or a small allowlisted docs subset?
+- Should artifact field names be considered part of the ubiquitous language contract in the first slice, or deferred until structured findings artifacts land?
+- Should the glossary live only under `docs/reference/`, or should a shorter generated excerpt be included in `AGENTS.md`/`GEMINI.md` through `aco sync` later?

--- a/openspec/changes/introduce-ubiquitous-language/proposal.md
+++ b/openspec/changes/introduce-ubiquitous-language/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`ai-cli-orch-wrapper` has grown a dense domain language: `run`, `session`, `provider`, `advisory`, `brief`, `artifact`, `harness`, `source surface`, `generated target`, `sync manifest`, `permission profile`, and more.
+
+Those terms are currently scattered across README, architecture docs, security docs, tests, and implementation names. Human maintainers can infer the model, but AI agents and LLM-assisted docs must rediscover it every time unless the repo owns the vocabulary explicitly. That weakens the gray box boundary because the interface is not only code; it is also the language used to plan, review, and verify changes.
+
+## What Changes
+
+- Add a repo-owned ubiquitous language reference for `aco` domain terms, starting narrowly with provider invocation and session artifacts.
+- Define required and discouraged terms for the first slice, then leave context sync and harness/generated boundaries as explicit backlog areas.
+- Add an automated terminology check in the first slice so new docs and code do not drift into conflicting terminology.
+- Link the vocabulary from README, architecture, security, and workflow docs where it helps readers.
+
+## Capabilities
+
+### New Capabilities
+
+- `ubiquitous-language`: Maintainers and agents can use one domain vocabulary across docs, specs, code, tests, and provider prompts.
+
+### Modified Capabilities
+
+- Documentation and workflow guidance should reference the vocabulary when explaining `aco ask`, `aco run`, `aco sync`, and artifact behavior.
+
+## Impact
+
+- `docs/reference/ubiquitous-language.md`: new source-of-truth glossary and naming rules, initially scoped to provider invocation and session artifacts.
+- `docs/architecture.md`, `docs/security.md`, `docs/reference/session-artifacts.md`, `README.md`: add links or short references where terminology is introduced.
+- `packages/wrapper/src/**`: avoid a strict rename campaign; only use targeted naming, aliases, or docs-only alignment where they reduce ambiguity without breaking public API.
+- `packages/wrapper/tests/**`: add terminology-sensitive tests only where runtime behavior relies on names in emitted artifacts.
+- Terminology check script or test: add a focused automated guard for high-risk discouraged terms in the initial documentation surface.
+- OpenSpec docs: future changes should use the vocabulary in capability names and scenarios.
+
+## Non-Goals
+
+- Do not rename the public `aco` CLI.
+- Do not perform broad code renames for style only.
+- Do not rewrite all docs in one pass.
+- Do not make the glossary a marketing page; it is an operator and implementer reference.

--- a/openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md
+++ b/openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Ubiquitous language reference
+
+The project SHALL provide a maintained ubiquitous language reference for `aco` domain terms used by humans and AI agents.
+
+#### Scenario: Initial glossary scope stays narrow
+
+- **WHEN** the first ubiquitous language implementation is planned
+- **THEN** the initial glossary SHALL fully define provider invocation and run/session artifact terms
+- **AND** context sync, harness surfaces, consent/permissions, and verification terms SHALL be represented as backlog placeholders unless they are required to explain the first slice.
+
+#### Scenario: Contributor discovers term definitions
+
+- **WHEN** a contributor needs to understand first-slice terms such as `run`, `session`, `brief`, `artifact`, or `provider`
+- **THEN** the contributor SHALL be able to find those terms in `docs/reference/ubiquitous-language.md`
+- **AND** each term SHALL include a definition, scope, and at least one repo-specific example.
+- **AND** backlog terms such as `harness` and `generated target` SHALL be listed as placeholders until their workflow slice fully defines them.
+
+#### Scenario: Preferred terms are distinguished from discouraged synonyms
+
+- **WHEN** a term has common but misleading synonyms
+- **THEN** the language reference SHALL identify the preferred term
+- **AND** explain why the discouraged synonym should not be used.
+
+#### Scenario: Future workflow docs reuse the vocabulary
+
+- **WHEN** a new OpenSpec change describes provider execution, artifacts, context sync, or harness surfaces
+- **THEN** it SHALL use the preferred terms from the ubiquitous language reference unless the change explicitly introduces a new term.
+
+#### Scenario: Terminology drift is checked automatically
+
+- **WHEN** the first ubiquitous language slice is implemented
+- **THEN** the project SHALL include a focused automated terminology check for high-risk discouraged terms
+- **AND** the check SHALL support accepted aliases or allowlisted legacy language so it does not become broad prose policing.
+
+#### Scenario: Public contract is protected
+
+- **WHEN** terminology cleanup touches public commands, artifact fields, or documented file layouts
+- **THEN** the change SHALL preserve backward compatibility unless a separate migration plan and tests are included.
+- **AND** code renames SHALL remain targeted to ambiguity that affects behavior, emitted artifacts, or tests.

--- a/openspec/changes/introduce-ubiquitous-language/tasks.md
+++ b/openspec/changes/introduce-ubiquitous-language/tasks.md
@@ -1,0 +1,33 @@
+## 1. Vocabulary source of truth
+
+- [x] 1.1 Create `docs/reference/ubiquitous-language.md` with core terms, discouraged synonyms, naming rules, and examples.
+- [x] 1.2 Scope the first slice to provider execution and run/session artifacts.
+- [x] 1.3 Add backlog placeholders for context sync, harness surfaces, consent/permissions, and verification without trying to fully define them in this workflow.
+- [x] 1.4 Add a review checklist for future OpenSpec changes and PRs.
+
+## 2. Documentation integration
+
+- [x] 2.1 Link the vocabulary from `README.md`, `docs/README.md`, and `docs/architecture.md`.
+- [x] 2.2 Update `docs/security.md` and `docs/reference/session-artifacts.md` only where terminology clarification improves safety.
+- [x] 2.3 Keep doc edits scoped; avoid broad prose rewrites unrelated to vocabulary.
+
+## 3. Automated terminology guard
+
+- [x] 3.1 Add a small focused automated terminology check for high-risk discouraged synonyms in the initial documentation surface.
+- [x] 3.2 Include tests or fixtures that cover allowed terms, discouraged terms, accepted aliases, and allowlisted legacy language.
+- [x] 3.3 Document how to update the check without turning it into broad prose policing.
+
+## 4. Code naming guardrails
+
+- [x] 4.1 Avoid a strict code rename campaign.
+- [x] 4.2 Only adjust implementation names when ambiguity affects behavior, emitted artifacts, or tests.
+- [x] 4.3 Prefer aliases or docs-only alignment when a legacy name is stable and not misleading at runtime.
+
+## 5. Verification
+
+- [x] 5.1 Run `openspec validate introduce-ubiquitous-language --type change --strict`.
+- [x] 5.2 Run formatter/checks for touched Markdown files.
+- [x] 5.3 Run the terminology guard and its focused tests.
+- [x] 5.4 Reader-test the glossary with a fresh agent or sub-agent and record any confusing terms.
+
+Reader-test note: completed with sub-agent `Newton` on 2026-05-14. The reader could explain `run`, `session`, `brief`, `output.log`, `provider`, and `provider advisory output`. Non-blocking drift candidates were addressed by aligning the canonical `provider advisory output` term, renaming the README table label from `Provider run` to `Provider invocation`, clarifying run/session brief examples, and narrowing the spec scenario to first-slice terms plus backlog placeholders.

--- a/openspec/changes/make-sync-manifest-portable/.openspec.yaml
+++ b/openspec/changes/make-sync-manifest-portable/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/make-sync-manifest-portable/design.md
+++ b/openspec/changes/make-sync-manifest-portable/design.md
@@ -1,0 +1,112 @@
+## Context
+
+Context sync has two different questions:
+
+1. Are generated targets current relative to source files?
+2. Does the manifest describe the current checkout in a portable way?
+
+The current absolute-path manifest blends these concerns. A clone-safe manifest should use stable repo-relative keys while still accepting old manifests for migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Store source and target manifest paths relative to repo root where possible.
+- Read legacy absolute-path manifests without data loss.
+- Migrate legacy records to relative keys on write.
+- Keep conflict detection and ownership semantics intact.
+- Add tests that simulate checking the same repo content from a different checkout path.
+
+**Non-Goals:**
+
+- No broad rewrite of the sync engine.
+- No change to which files are generated.
+- No change to duplicate detection policy beyond path-key normalization.
+- No automatic deletion of user-modified generated targets.
+
+## Data Model Direction
+
+Current manifest shape uses absolute path keys:
+
+```json
+{
+  "sourceHashes": {
+    "/Users/name/project/CLAUDE.md": "..."
+  },
+  "targetHashes": {
+    "/Users/name/project/AGENTS.md": "..."
+  },
+  "targets": {
+    "/Users/name/project/AGENTS.md": {
+      "owner": "aco",
+      "kind": "config"
+    }
+  }
+}
+```
+
+Portable manifest shape should use repo-relative keys:
+
+```json
+{
+  "version": "3",
+  "pathMode": "repo-relative",
+  "sourceHashes": {
+    "CLAUDE.md": "..."
+  },
+  "targetHashes": {
+    "AGENTS.md": "..."
+  },
+  "targets": {
+    "AGENTS.md": {
+      "owner": "aco",
+      "kind": "config"
+    }
+  }
+}
+```
+
+If a record needs to reference an external path, it should be explicitly marked rather than silently stored as a normal repo target.
+
+## Decisions
+
+1. **Introduce manifest version 3**
+   - Option A: Keep version 2 and silently change key semantics.
+   - Option B: Introduce version 3 with `pathMode: repo-relative`.
+   - Decision: choose B. Readers need to distinguish legacy absolute-path manifests from portable manifests.
+
+2. **Normalize at the manifest boundary**
+   - Option A: Convert paths throughout sync engine internals.
+   - Option B: Keep internal absolute paths where useful, but serialize and compare manifest keys through a normalization helper.
+   - Decision: choose B. This minimizes behavioral churn.
+
+3. **Doctor reports portability separately**
+   - Option A: Treat non-portable paths as ordinary sync drift.
+   - Option B: Report `manifest portability` separately from content drift.
+   - Decision: choose B. The fix and risk are different.
+
+4. **Migration is explicit but low-friction**
+   - Option A: Fail until a manual migration command is run.
+   - Option B: `aco sync --check` reports legacy path mode; `aco sync` rewrites to portable manifest if content is otherwise valid.
+   - Decision: choose B, unless implementation discovers a compatibility risk.
+
+## Risks / Trade-offs
+
+- [Risk] Key normalization breaks conflict detection. [Mitigation] Add tests for user-modified target drift under both legacy and v3 manifests.
+- [Risk] Migration hides real content drift. [Mitigation] Keep portability warning distinct from source/target hash mismatch.
+- [Risk] CI and local worktrees disagree on path separators. [Mitigation] Normalize keys to POSIX-style repo-relative paths in manifest JSON.
+- [Risk] Existing consumers expect absolute keys. [Mitigation] Preserve read compatibility and document version 3.
+
+## Validation Strategy
+
+- Fixture with legacy absolute manifest copied into a new checkout path.
+- Fixture with v3 relative manifest in two different checkout paths.
+- Conflict detection test where generated target is manually edited.
+- Check mode test where only path portability differs.
+- `aco doctor` output test for legacy path mode.
+
+## Open Questions
+
+- Should v3 migration happen on any `aco sync`, or only with `--force`/new `--migrate-manifest`?
+- Should `.aco/sync-manifest.json` remain committed after v3, or should generated target verification move to CI-only regeneration?
+- Should manifest source paths include `./` prefixes or plain relative paths?

--- a/openspec/changes/make-sync-manifest-portable/proposal.md
+++ b/openspec/changes/make-sync-manifest-portable/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+`.aco/sync-manifest.json` currently records absolute paths from the checkout where `aco sync` last ran. When the repo is cloned, archived, or evaluated in a different path, the manifest can point at another checkout. `aco doctor` can detect this, but the committed manifest itself is not portable.
+
+That undermines the gray box boundary for context sync. A generated target should be verifiable from the current repo, not from the path where another maintainer generated it.
+
+## What Changes
+
+- Change sync manifest records to use repo-relative paths where possible.
+- Add compatibility handling for existing absolute-path manifests.
+- Add migration behavior so a local sync can rewrite the manifest into portable form.
+- Update `aco doctor` and `aco sync --check` messaging to distinguish stale content drift from non-portable path metadata.
+
+## Capabilities
+
+### New Capabilities
+
+- `sync-manifest-portability`: Context sync manifests can be committed and verified across clones, worktrees, and CI checkouts without embedding maintainer-specific absolute paths.
+
+### Modified Capabilities
+
+- `aco sync --check` and `aco doctor` should report portable-manifest status separately from content drift.
+- Manifest read/write code should remain backward compatible with version 2 absolute-path records.
+
+## Impact
+
+- `packages/wrapper/src/sync/manifest.ts`: path normalization, read/write migration, version handling.
+- `packages/wrapper/src/sync/sync-engine.ts`: compare current repo paths against manifest records through normalized keys.
+- `packages/wrapper/src/commands/doctor.ts`: improve diagnostics for portability versus drift.
+- `.aco/sync-manifest.json`: migrate to portable paths after implementation.
+- Tests: add clone/worktree-path fixtures and legacy manifest migration cases.
+- Docs: update `docs/reference/context-sync.md` and troubleshooting/runbook guidance.
+
+## Non-Goals
+
+- Do not remove manifest ownership tracking.
+- Do not change generated target content semantics.
+- Do not make `aco sync --force` silently overwrite user drift.
+- Do not solve unrelated duplicate skill cleanup behavior.

--- a/openspec/changes/make-sync-manifest-portable/specs/sync-manifest-portability/spec.md
+++ b/openspec/changes/make-sync-manifest-portable/specs/sync-manifest-portability/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Repo-portable sync manifest
+
+The context sync manifest SHALL be portable across repo clones, worktrees, and CI checkouts by avoiding maintainer-specific absolute repo paths in current manifest records.
+
+#### Scenario: New manifest uses repo-relative paths
+
+- **WHEN** `aco sync` writes the current manifest format
+- **THEN** source and target manifest keys SHALL be repo-relative paths
+- **AND** the manifest SHALL identify its path mode so readers can distinguish it from legacy absolute-path manifests.
+
+#### Scenario: Legacy manifest remains readable
+
+- **WHEN** `aco sync` or `aco doctor` reads a legacy manifest with absolute paths
+- **THEN** it SHALL preserve enough information to evaluate current checkout sync state
+- **AND** it SHALL report or perform migration according to documented behavior.
+
+#### Scenario: Portability is distinct from content drift
+
+- **WHEN** a manifest points at another checkout but generated target contents are otherwise current
+- **THEN** diagnostics SHALL distinguish non-portable path metadata from stale generated target content.
+
+#### Scenario: User drift remains protected
+
+- **WHEN** a manifest-owned generated target has been manually modified in the current checkout
+- **THEN** `aco sync --check` SHALL still report a conflict or drift
+- **AND** normal sync SHALL NOT silently overwrite the target unless the documented force path is used.
+
+#### Scenario: Manifest keys are platform-stable
+
+- **WHEN** the manifest is written on different supported platforms
+- **THEN** repo-relative keys SHALL use a stable path format that does not depend on the local absolute checkout path.

--- a/openspec/changes/make-sync-manifest-portable/tasks.md
+++ b/openspec/changes/make-sync-manifest-portable/tasks.md
@@ -1,0 +1,27 @@
+## 1. Manifest model
+
+- [ ] 1.1 Add manifest version 3 with `pathMode: repo-relative`.
+- [ ] 1.2 Add helpers for converting repo paths to stable POSIX-style relative manifest keys.
+- [ ] 1.3 Preserve read compatibility for version 2 absolute-path manifests.
+
+## 2. Sync engine behavior
+
+- [ ] 2.1 Update manifest read/write paths to use normalized keys.
+- [ ] 2.2 Ensure conflict detection still compares actual current-checkout target files.
+- [ ] 2.3 Ensure missing manifest-owned targets are recreated as before.
+- [ ] 2.4 Define migration behavior for legacy manifests and document whether `--force` is required.
+
+## 3. Diagnostics and docs
+
+- [ ] 3.1 Update `aco doctor` to report manifest portability separately from sync content drift.
+- [ ] 3.2 Update `docs/reference/context-sync.md` with v3 path semantics.
+- [ ] 3.3 Update runbook troubleshooting for clones, worktrees, and CI checkouts.
+- [ ] 3.4 Migrate committed `.aco/sync-manifest.json` only after tests prove v3 behavior.
+
+## 4. Verification
+
+- [ ] 4.1 Add tests for v2 absolute manifest migration.
+- [ ] 4.2 Add tests for v3 manifest verification from a different checkout path.
+- [ ] 4.3 Add tests for user-modified generated target conflicts under v3.
+- [ ] 4.4 Run `openspec validate make-sync-manifest-portable --type change --strict`.
+- [ ] 4.5 Run `npm run build`, `npm test --workspace=packages/wrapper`, and targeted sync tests.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:smoke": "npm run test:smoke --workspace=packages/wrapper --if-present",
     "test:fixtures": "go build -o aco ./cmd/aco && npx tsx test/fixtures/harness.ts --binary ./aco",
     "test:fixtures:node": "npm run build --workspace=packages/wrapper && chmod +x packages/wrapper/dist/cli.js && npx tsx test/fixtures/harness.ts --binary packages/wrapper/dist/cli.js",
-    "test:scripts": "bash test/scripts/project-id-validation.test.sh",
+    "test:scripts": "bash test/scripts/project-id-validation.test.sh && bash test/scripts/terminology-check.test.sh",
+    "check:terminology": "tsx scripts/check-terminology.ts",
     "typecheck": "npm run typecheck --workspace=packages/wrapper",
     "format:check": "prettier --check \"packages/*/src/**/*.ts\"",
     "release": "npm run build && changeset publish"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:smoke": "npm run test:smoke --workspace=packages/wrapper --if-present",
     "test:fixtures": "go build -o aco ./cmd/aco && npx tsx test/fixtures/harness.ts --binary ./aco",
     "test:fixtures:node": "npm run build --workspace=packages/wrapper && chmod +x packages/wrapper/dist/cli.js && npx tsx test/fixtures/harness.ts --binary packages/wrapper/dist/cli.js",
-    "test:scripts": "bash test/scripts/project-id-validation.test.sh && bash test/scripts/terminology-check.test.sh",
+    "test:scripts": "bash test/scripts/project-id-validation.test.sh && bash test/scripts/terminology-check.test.sh && npm run check:terminology",
     "check:terminology": "tsx scripts/check-terminology.ts",
     "typecheck": "npm run typecheck --workspace=packages/wrapper",
     "format:check": "prettier --check \"packages/*/src/**/*.ts\"",

--- a/scripts/check-terminology.ts
+++ b/scripts/check-terminology.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env tsx
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+type Rule = {
+  id: string;
+  discouraged: string;
+  preferred: string;
+  reason: string;
+};
+
+const DEFAULT_SCAN_FILES = [
+  'README.md',
+  'docs/README.md',
+  'docs/architecture.md',
+  'docs/security.md',
+  'docs/reference/session-artifacts.md',
+  'docs/reference/ubiquitous-language.md',
+  'openspec/changes/introduce-ubiquitous-language/proposal.md',
+  'openspec/changes/introduce-ubiquitous-language/design.md',
+  'openspec/changes/introduce-ubiquitous-language/tasks.md',
+  'openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md',
+] as const;
+
+const DEFAULT_RULES: Rule[] = [
+  {
+    id: 'provider-output-is-advisory',
+    discouraged: 'provider truth',
+    preferred: 'provider advisory output',
+    reason: 'Provider output is evidence for review, not authoritative truth.',
+  },
+  {
+    id: 'provider-output-is-advisory',
+    discouraged: 'raw provider truth',
+    preferred: 'full provider output',
+    reason: 'The raw/full output can be stored, but it is still advisory.',
+  },
+  {
+    id: 'generated-target-not-source',
+    discouraged: 'generated source',
+    preferred: 'generated target',
+    reason: 'Source surfaces are maintained by humans; generated targets are produced by sync.',
+  },
+  {
+    id: 'brief-is-bounded-summary',
+    discouraged: 'brief log',
+    preferred: 'brief',
+    reason: 'Briefs are bounded summaries, while output.log stores full provider output.',
+  },
+].sort((left, right) => right.discouraged.length - left.discouraged.length);
+
+function parseArgs(argv: string[]): { root: string; files: string[] } {
+  let root = process.cwd();
+  const files: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--root requires a path');
+      }
+
+      root = path.resolve(value);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--file') {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error('--file requires a repo-relative path');
+      }
+
+      files.push(value);
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return {
+    root,
+    files: files.length > 0 ? files : [...DEFAULT_SCAN_FILES],
+  };
+}
+
+function includesDiscouragedTerm(line: string, term: string): boolean {
+  return line.toLocaleLowerCase().includes(term.toLocaleLowerCase());
+}
+
+function allowedTermsForLine(line: string): string[] {
+  const matches = line.matchAll(/terminology-check allow:\s*([^-><]+)/g);
+  return [...matches].map((match) => match[1].trim().toLocaleLowerCase());
+}
+
+function hasAllowComment(line: string, term: string): boolean {
+  const normalizedTerm = term.toLocaleLowerCase();
+  return allowedTermsForLine(line).some(
+    (allowed) => allowed === normalizedTerm || allowed.includes(normalizedTerm)
+  );
+}
+
+function main(): void {
+  const { root, files } = parseArgs(process.argv.slice(2));
+  const violations: string[] = [];
+
+  for (const file of files) {
+    const absolutePath = path.join(root, file);
+    if (!existsSync(absolutePath)) {
+      continue;
+    }
+
+    const lines = readFileSync(absolutePath, 'utf8').split(/\r?\n/);
+
+    lines.forEach((line, lineIndex) => {
+      for (const rule of DEFAULT_RULES) {
+        if (!includesDiscouragedTerm(line, rule.discouraged)) {
+          continue;
+        }
+
+        if (hasAllowComment(line, rule.discouraged)) {
+          continue;
+        }
+
+        violations.push(
+          [
+            `${file}:${lineIndex + 1}`,
+            `discouraged term: "${rule.discouraged}"`,
+            `preferred term: "${rule.preferred}"`,
+            `rule: ${rule.id}`,
+            `reason: ${rule.reason}`,
+          ].join('\n  ')
+        );
+      }
+    });
+  }
+
+  if (violations.length > 0) {
+    console.error(`terminology check failed with ${violations.length} violation(s):`);
+    console.error(violations.join('\n\n'));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`terminology check passed (${files.length} files scanned)`);
+}
+
+main();

--- a/scripts/check-terminology.ts
+++ b/scripts/check-terminology.ts
@@ -116,8 +116,10 @@ function main(): void {
     const lines = readFileSync(absolutePath, 'utf8').split(/\r?\n/);
 
     lines.forEach((line, lineIndex) => {
+      let lineForMatching = line.toLocaleLowerCase();
       for (const rule of DEFAULT_RULES) {
-        if (!includesDiscouragedTerm(line, rule.discouraged)) {
+        const discouragedLower = rule.discouraged.toLocaleLowerCase();
+        if (!lineForMatching.includes(discouragedLower)) {
           continue;
         }
 
@@ -134,6 +136,8 @@ function main(): void {
             `reason: ${rule.reason}`,
           ].join('\n  ')
         );
+
+        lineForMatching = lineForMatching.split(discouragedLower).join(' '.repeat(discouragedLower.length));
       }
     });
   }

--- a/scripts/check-terminology.ts
+++ b/scripts/check-terminology.ts
@@ -92,7 +92,7 @@ function includesDiscouragedTerm(line: string, term: string): boolean {
 }
 
 function allowedTermsForLine(line: string): string[] {
-  const matches = line.matchAll(/terminology-check allow:\s*([^-><]+)/g);
+  const matches = line.matchAll(/terminology-check allow:\s*(.*?)\s*-->/g);
   return [...matches].map((match) => match[1].trim().toLocaleLowerCase());
 }
 

--- a/scripts/check-terminology.ts
+++ b/scripts/check-terminology.ts
@@ -49,7 +49,7 @@ const DEFAULT_RULES: Rule[] = [
   },
 ].sort((left, right) => right.discouraged.length - left.discouraged.length);
 
-function parseArgs(argv: string[]): { root: string; files: string[] } {
+function parseArgs(argv: string[]): { root: string; files: string[]; userSpecified: boolean } {
   let root = process.cwd();
   const files: string[] = [];
 
@@ -84,6 +84,7 @@ function parseArgs(argv: string[]): { root: string; files: string[] } {
   return {
     root,
     files: files.length > 0 ? files : [...DEFAULT_SCAN_FILES],
+    userSpecified: files.length > 0,
   };
 }
 
@@ -102,12 +103,16 @@ function hasAllowComment(line: string, term: string): boolean {
 }
 
 function main(): void {
-  const { root, files } = parseArgs(process.argv.slice(2));
+  const { root, files, userSpecified } = parseArgs(process.argv.slice(2));
   const violations: string[] = [];
+  const missingFiles: string[] = [];
 
   for (const file of files) {
     const absolutePath = path.join(root, file);
     if (!existsSync(absolutePath)) {
+      if (!userSpecified) {
+        missingFiles.push(file);
+      }
       continue;
     }
 
@@ -138,9 +143,15 @@ function main(): void {
     });
   }
 
-  if (violations.length > 0) {
-    console.error(`terminology check failed with ${violations.length} violation(s):`);
-    console.error(violations.join('\n\n'));
+  if (violations.length > 0 || missingFiles.length > 0) {
+    if (violations.length > 0) {
+      console.error(`terminology check failed with ${violations.length} violation(s):`);
+      console.error(violations.join('\n\n'));
+    }
+    if (missingFiles.length > 0) {
+      console.error(`terminology check: ${missingFiles.length} default scan file(s) missing:`);
+      console.error(missingFiles.map((f) => `  ${f}`).join('\n'));
+    }
     process.exitCode = 1;
     return;
   }

--- a/scripts/check-terminology.ts
+++ b/scripts/check-terminology.ts
@@ -98,9 +98,7 @@ function allowedTermsForLine(line: string): string[] {
 
 function hasAllowComment(line: string, term: string): boolean {
   const normalizedTerm = term.toLocaleLowerCase();
-  return allowedTermsForLine(line).some(
-    (allowed) => allowed === normalizedTerm || allowed.includes(normalizedTerm)
-  );
+  return allowedTermsForLine(line).some((allowed) => allowed === normalizedTerm);
 }
 
 function main(): void {
@@ -123,19 +121,17 @@ function main(): void {
           continue;
         }
 
-        if (hasAllowComment(line, rule.discouraged)) {
-          continue;
+        if (!hasAllowComment(line, rule.discouraged)) {
+          violations.push(
+            [
+              `${file}:${lineIndex + 1}`,
+              `discouraged term: "${rule.discouraged}"`,
+              `preferred term: "${rule.preferred}"`,
+              `rule: ${rule.id}`,
+              `reason: ${rule.reason}`,
+            ].join('\n  ')
+          );
         }
-
-        violations.push(
-          [
-            `${file}:${lineIndex + 1}`,
-            `discouraged term: "${rule.discouraged}"`,
-            `preferred term: "${rule.preferred}"`,
-            `rule: ${rule.id}`,
-            `reason: ${rule.reason}`,
-          ].join('\n  ')
-        );
 
         lineForMatching = lineForMatching.split(discouragedLower).join(' '.repeat(discouragedLower.length));
       }

--- a/test/scripts/terminology-check.test.sh
+++ b/test/scripts/terminology-check.test.sh
@@ -104,4 +104,25 @@ assert_contains "$TMP_DIR/fail.err" "generated source"
 assert_contains "$TMP_DIR/fail.err" "generated target"
 assert_contains "$TMP_DIR/fail.err" "docs/architecture.md"
 
+MISSING_DIR="$(mktemp -d)"
+trap 'rm -rf "$MISSING_DIR"' EXIT
+mkdir -p "$MISSING_DIR/docs/reference"
+
+cat >"$MISSING_DIR/README.md" <<'DOC'
+# Fixture
+Provider advisory output is stored as an artifact.
+DOC
+
+set +e
+npx tsx "$ROOT_DIR/scripts/check-terminology.ts" --root "$MISSING_DIR" >"$MISSING_DIR/miss.out" 2>"$MISSING_DIR/miss.err"
+miss_status=$?
+set -e
+
+if [[ "$miss_status" -eq 0 ]]; then
+  echo "Expected terminology check to fail when default scan files are missing" >&2
+  exit 1
+fi
+
+assert_contains "$MISSING_DIR/miss.err" "default scan file"
+
 echo "terminology check script tests passed"

--- a/test/scripts/terminology-check.test.sh
+++ b/test/scripts/terminology-check.test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/docs/reference" "$TMP_DIR/openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language"
+
+write_required_files() {
+  cat >"$TMP_DIR/README.md" <<'DOC'
+# Fixture
+
+Provider advisory output is stored as an artifact.
+DOC
+
+  cat >"$TMP_DIR/docs/README.md" <<'DOC'
+# Docs
+
+See the ubiquitous language reference.
+DOC
+
+  cat >"$TMP_DIR/docs/architecture.md" <<'DOC'
+# Architecture
+
+Full provider output remains advisory.
+DOC
+
+  cat >"$TMP_DIR/docs/security.md" <<'DOC'
+# Security
+
+Provider output is not authoritative.
+DOC
+
+  cat >"$TMP_DIR/docs/reference/session-artifacts.md" <<'DOC'
+# Session Artifacts
+
+A run contains provider sessions and each session stores output.log.
+DOC
+
+  cat >"$TMP_DIR/docs/reference/ubiquitous-language.md" <<'DOC'
+# Ubiquitous Language
+
+Preferred term: provider advisory output.
+Accepted alias: full provider output.
+Discouraged term example: raw provider truth. <!-- terminology-check allow: raw provider truth -->
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/proposal.md" <<'DOC'
+# Proposal
+
+Generated target is the preferred term.
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/design.md" <<'DOC'
+# Design
+
+Brief is the preferred bounded summary.
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/tasks.md" <<'DOC'
+# Tasks
+
+Run terminology checks.
+DOC
+
+  cat >"$TMP_DIR/openspec/changes/introduce-ubiquitous-language/specs/ubiquitous-language/spec.md" <<'DOC'
+# Spec
+
+Provider invocation terms are defined.
+DOC
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  if ! grep -Fq "$expected" "$file"; then
+    echo "Expected to find '$expected' in $file" >&2
+    echo "--- $file ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+write_required_files
+
+npx tsx "$ROOT_DIR/scripts/check-terminology.ts" --root "$TMP_DIR" >"$TMP_DIR/pass.out"
+assert_contains "$TMP_DIR/pass.out" "terminology check passed"
+
+printf '\nThis incorrectly calls generated target generated source.\n' >>"$TMP_DIR/docs/architecture.md"
+
+set +e
+npx tsx "$ROOT_DIR/scripts/check-terminology.ts" --root "$TMP_DIR" >"$TMP_DIR/fail.out" 2>"$TMP_DIR/fail.err"
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  echo "Expected terminology check to fail for discouraged terms" >&2
+  exit 1
+fi
+
+assert_contains "$TMP_DIR/fail.err" "generated source"
+assert_contains "$TMP_DIR/fail.err" "generated target"
+assert_contains "$TMP_DIR/fail.err" "docs/architecture.md"
+
+echo "terminology check script tests passed"


### PR DESCRIPTION
Closes #114

## What

Gray-box hardening을 세 개의 독립 workflow kickoff로 분리하고, 첫 번째 workflow인 ubiquitous language를 실제 repo 문서와 guard로 구현했습니다. `docs/reference/ubiquitous-language.md`, `scripts/check-terminology.ts`, `test/scripts/terminology-check.test.sh`를 추가해 provider invocation과 run/session artifact 용어를 repo-owned 기준으로 관리합니다.

## Why

LLM-assisted 문서와 agent 작업이 같은 용어를 쓰지 않으면 gray box 경계가 흐려지고, provider output을 authoritative truth처럼 오해할 수 있습니다. 이 PR은 용어 기준과 자동 drift check를 먼저 세워 이후 structured findings artifact와 repo-portable sync manifest workflow의 명명 기준을 안정화합니다.

## Changes

- gray-box workflow kickoff index와 ubiquitous language briefing/implementation plan 문서 추가
- `introduce-ubiquitous-language`, `add-structured-findings-artifacts`, `make-sync-manifest-portable` OpenSpec change 문서 추가
- `docs/reference/ubiquitous-language.md`로 provider invocation/run/session artifact 용어 정의
- `check:terminology` 스크립트와 shell test 추가
- README, docs index, architecture, security, session artifact docs에서 glossary 링크 연결

## Verification

- [x] `npm test`
- [x] `npm run check:terminology`
- [x] `openspec validate introduce-ubiquitous-language --type change --strict`
- [x] `openspec validate add-structured-findings-artifacts --type change --strict`
- [x] `openspec validate make-sync-manifest-portable --type change --strict`
- [x] `git diff --check origin/main`

## Checklist

- [x] 관련 테스트 또는 smoke check 통과
- [x] 동작 변경 시 문서 업데이트 완료
- [x] Project 상태와 label 확인 완료
