### PR TITLE
fix(sync,ask): sync manifest 이식성 개선 및 credential guard 추가

### DIFF
--- a/.aco/sync-manifest.json
+++ b/.aco/sync-manifest.json
@@ -1,252 +1,253 @@
 {
-  "version": "2",
-  "generatedAt": "2026-05-03T13:34:09.485Z",
+  "version": "3",
+  "generatedAt": "2026-05-15T05:02:27.588Z",
   "sourceHashes": {
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/CLAUDE.md": "ec13d5f668a2da2088d0ba9519512357d4e014a7a05fbc96a1d16fbae6dc3369",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-issue/SKILL.md": "16eab5668a5520c3cf20864dd635b85a418e957f90c803f75cde1ee3006261ca",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-pr/SKILL.md": "cff001a7c0735dcb6572ed12e3b5738878fbb3279418064c07f6165e56544e3f",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-pr-followup/SKILL.md": "d7cdc4509550a6c73411e306c92e5e76b76e768be895a62014a2beb6b178541f",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-start/SKILL.md": "5b1bbb6dbae9ec49fae6f868020348bfc59f7ba710e494a075716e12e8a42b37",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/github-kanban-ops/SKILL.md": "e865d5f29969060d8c0dee98568e57e0cdd6292690320ebeec70423c8db0ab0d",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-apply-change/SKILL.md": "c30999a1477d6a8377d7aaa02a82ad322206ffa0cca1ddf7d95618c4577ba10f",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-archive-change/SKILL.md": "dd8783f590c0488b2026bee9aae2adbc3cda1d7152ab04e9b9cf2ff3924fce50",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-bulk-archive-change/SKILL.md": "f1636af350b977d465a2361dec5104d487883e8ca6dbaefdf438f59e4b65051d",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-continue-change/SKILL.md": "383848c3fa732a8545b4e5aeb3bd8e83179410c48e47abd1db4afd8b7ddfb6cd",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-explore/SKILL.md": "4f534b22c2e04839f965186a9dd49129dcef318752260f5d67468d0a8d649826",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-ff-change/SKILL.md": "107161f1948f4b2dff754a614d52adb000506568e88559246fd0d5ef2ecf55fc",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-new-change/SKILL.md": "5daea20179a3f93c7ef7ead465d77f3471e827b7640959dabccea6ddfb62f6b2",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-propose/SKILL.md": "a41d8fda28db18ff9afd548fdc4076c89e492460ac3b8ee0fa4cb33b7034a3e0",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-sync-specs/SKILL.md": "eb8e97b97a50a2d7b72252b2c702b07b714b3f6101ae031dcfa086ba9f92eadb",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-verify-change/SKILL.md": "f53dc5d31725d88c1895b5a950a65635276ba321458ae2711ec97c4e82531e0b",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/architect.md": "e4c02d466d90f1b70d77a0ad9c23b048d852a1d4e040d33e55ba1a859801a1f0",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/chief-of-staff.md": "1a1f971e158824a89b7986f6688fe16d7708b88b0a00631b28bd53956c68e9d2",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/code-reviewer.md": "e112e5e0bbc501788e8a3bfd2771d34e31a8564bbd87391bff7401af1509782c",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/doc-updater.md": "a0b96a358534fc9cefc33355b73d8b232132754283c3f335907468cb98ee021d",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/docs-lookup.md": "2e6cb9b0168e83c66b201bc155506d7aa0050108684ec844f79803d9aba4f4fb",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/executor.md": "99b9d9737d56cf07900fb3d392b178ca586bcec9e916af60961753c5ac4323ae",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/go-build-resolver.md": "f331c2a89232b8d24712b4ceb6a63f4180eab6e81cbe75dc13390947ac3fd4a9",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/go-reviewer.md": "979f7047acaad318ccb9bfa2d0704932a8de2b5e98d99a236181214d56ab6b1b",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/harness-optimizer.md": "a0f42e525781a1fc4a2305ef4b5d055f296a04b9814ff81b7d1d99be93c48b58",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/planner.md": "b4ab1263bcd0257cfd7f99075f1cae6ea17cb32f37235fbb76fdf71bc3b21c4e",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/python-reviewer.md": "e2cf129892998841b01817e03736a9b5f9598681a096e28afbc12577d3ed9adf",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/pytorch-build-resolver.md": "7ac671d451e70433514c6f52aa2d0291ec9d40c840488048d6507aaef1cb4533",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/researcher.md": "6c8b1ec034e574b546396503a843261418722f8f83dc84e817d28f35ec29fba3",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/reviewer.md": "e96f310278c514207ae5b1af363fdbfe2550cc4c901983ec395542c3e473db0a",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/tdd-guide.md": "de339a6158d7708000ef796f8bd5e6d7ed45fe744f443d2d84739470ba4c5f2c",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/typescript-reviewer.md": "fd60a12dc5b804ebac6849942e4f08f7063e869ac9fde8576ebda188deefa061",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/settings.json": "42db338ea119564b19ced4ffe9c647201d5197c638e485c059ef80953b335aef"
+    "CLAUDE.md": "557f8f73eaf2b069959b741e343ea6ec416f0307140de80cd7a3b0a4cf5bdc68",
+    ".claude/skills/aco-delegation/SKILL.md": "10b37c0e3489ac5d68ea253cb8d52c2188facaa097b03aa2329deda27bdf3997",
+    ".claude/skills/gh-issue/SKILL.md": "16eab5668a5520c3cf20864dd635b85a418e957f90c803f75cde1ee3006261ca",
+    ".claude/skills/gh-pr/SKILL.md": "cff001a7c0735dcb6572ed12e3b5738878fbb3279418064c07f6165e56544e3f",
+    ".claude/skills/gh-pr-followup/SKILL.md": "d7cdc4509550a6c73411e306c92e5e76b76e768be895a62014a2beb6b178541f",
+    ".claude/skills/gh-start/SKILL.md": "5b1bbb6dbae9ec49fae6f868020348bfc59f7ba710e494a075716e12e8a42b37",
+    ".claude/skills/github-kanban-ops/SKILL.md": "c39313254eb05ede630995778635198c5727f04c8f427f685c2f96a1f04955d9",
+    ".claude/skills/openspec-apply-change/SKILL.md": "c30999a1477d6a8377d7aaa02a82ad322206ffa0cca1ddf7d95618c4577ba10f",
+    ".claude/skills/openspec-archive-change/SKILL.md": "dd8783f590c0488b2026bee9aae2adbc3cda1d7152ab04e9b9cf2ff3924fce50",
+    ".claude/skills/openspec-bulk-archive-change/SKILL.md": "f1636af350b977d465a2361dec5104d487883e8ca6dbaefdf438f59e4b65051d",
+    ".claude/skills/openspec-continue-change/SKILL.md": "383848c3fa732a8545b4e5aeb3bd8e83179410c48e47abd1db4afd8b7ddfb6cd",
+    ".claude/skills/openspec-explore/SKILL.md": "4f534b22c2e04839f965186a9dd49129dcef318752260f5d67468d0a8d649826",
+    ".claude/skills/openspec-ff-change/SKILL.md": "107161f1948f4b2dff754a614d52adb000506568e88559246fd0d5ef2ecf55fc",
+    ".claude/skills/openspec-new-change/SKILL.md": "5daea20179a3f93c7ef7ead465d77f3471e827b7640959dabccea6ddfb62f6b2",
+    ".claude/skills/openspec-propose/SKILL.md": "a41d8fda28db18ff9afd548fdc4076c89e492460ac3b8ee0fa4cb33b7034a3e0",
+    ".claude/skills/openspec-sync-specs/SKILL.md": "eb8e97b97a50a2d7b72252b2c702b07b714b3f6101ae031dcfa086ba9f92eadb",
+    ".claude/skills/openspec-verify-change/SKILL.md": "f53dc5d31725d88c1895b5a950a65635276ba321458ae2711ec97c4e82531e0b",
+    ".claude/agents/architect.md": "e4c02d466d90f1b70d77a0ad9c23b048d852a1d4e040d33e55ba1a859801a1f0",
+    ".claude/agents/chief-of-staff.md": "1a1f971e158824a89b7986f6688fe16d7708b88b0a00631b28bd53956c68e9d2",
+    ".claude/agents/code-reviewer.md": "e112e5e0bbc501788e8a3bfd2771d34e31a8564bbd87391bff7401af1509782c",
+    ".claude/agents/doc-updater.md": "a0b96a358534fc9cefc33355b73d8b232132754283c3f335907468cb98ee021d",
+    ".claude/agents/docs-lookup.md": "2e6cb9b0168e83c66b201bc155506d7aa0050108684ec844f79803d9aba4f4fb",
+    ".claude/agents/executor.md": "99b9d9737d56cf07900fb3d392b178ca586bcec9e916af60961753c5ac4323ae",
+    ".claude/agents/go-build-resolver.md": "f331c2a89232b8d24712b4ceb6a63f4180eab6e81cbe75dc13390947ac3fd4a9",
+    ".claude/agents/go-reviewer.md": "979f7047acaad318ccb9bfa2d0704932a8de2b5e98d99a236181214d56ab6b1b",
+    ".claude/agents/harness-optimizer.md": "a0f42e525781a1fc4a2305ef4b5d055f296a04b9814ff81b7d1d99be93c48b58",
+    ".claude/agents/planner.md": "b4ab1263bcd0257cfd7f99075f1cae6ea17cb32f37235fbb76fdf71bc3b21c4e",
+    ".claude/agents/python-reviewer.md": "e2cf129892998841b01817e03736a9b5f9598681a096e28afbc12577d3ed9adf",
+    ".claude/agents/pytorch-build-resolver.md": "7ac671d451e70433514c6f52aa2d0291ec9d40c840488048d6507aaef1cb4533",
+    ".claude/agents/researcher.md": "6c8b1ec034e574b546396503a843261418722f8f83dc84e817d28f35ec29fba3",
+    ".claude/agents/reviewer.md": "e96f310278c514207ae5b1af363fdbfe2550cc4c901983ec395542c3e473db0a",
+    ".claude/agents/tdd-guide.md": "de339a6158d7708000ef796f8bd5e6d7ed45fe744f443d2d84739470ba4c5f2c",
+    ".claude/agents/typescript-reviewer.md": "fd60a12dc5b804ebac6849942e4f08f7063e869ac9fde8576ebda188deefa061",
+    ".claude/settings.json": "42db338ea119564b19ced4ffe9c647201d5197c638e485c059ef80953b335aef"
   },
   "targetHashes": {
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/AGENTS.md": "bde14d9f733891dd3104aae1557156d7294497512312f49ce552e014dfe183c2",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/GEMINI.md": "b59183d5dcba0bee6f10f1b1460125f512dd5b995fd587e5d42951b439765fa9",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.agents/skills/github-kanban-ops": "03634476f9f4b0ec5e0453eac26de410be9513e835d6c6ec8b8a5cfe7a61c896",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/architect.toml": "6ea336126c152b0a80491e114b033c7f6fddf88a41922528cede75f32c3fa4d5",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/chief-of-staff.toml": "55302ddb595c4534d365658cf439ff7ef458999db191132c0c45f9a81d16baa2",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/code-reviewer.toml": "f2fbf69f92340d46cc5be1f03a81b85fddc7dca8772b189a7da89acc85a5065e",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/doc-updater.toml": "9777056bfb4c9554d5a9179a8e6ac20f8b9dd2b051191b32bed4d4e4e3f4c849",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/docs-lookup.toml": "b453bc451481376e497cf503c823bc2d70fee9f5c0c4b7a109f971267b6d4e88",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/executor.toml": "8a52944e0bb23bb0a7a3f1f7d569950a03400a54acd780ff9eab4dba953bd788",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/go-build-resolver.toml": "923ccc942758f496a792f7f64a21b5fa05d18d778f45b6949679196c14a71432",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/go-reviewer.toml": "dd3a916e0f3ebeee6ffee235314a8b88d651d08c0670bf0f8051c75e11c84b98",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/harness-optimizer.toml": "bfcd41d46634782588a69d188f8ebde881c852a52f4488a6498ca47dd47c123b",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/planner.toml": "93dd1db5cb2e3037cb5088553ebede1af33388fdbc6ce94d660dba67a859e428",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/python-reviewer.toml": "3fcaee94269d55e386e8e9f9df414de3ad6bce922f8c26cd15879c8da68a8d34",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/pytorch-build-resolver.toml": "c8bf2ca9dad8e5815c74131fa2588a42e42a9337201911cdaf5c436ed309b648",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/researcher.toml": "fe0bc4cc5a5b3792d1e875998c91a3d4d1b1a9a1441ead35210c3fefed9f4521",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/reviewer.toml": "0a321de5a768646d1710fde4c91c33e9c30057a41780386605d39528d8023b9d",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/tdd-guide.toml": "f7a0b7a5be0bb90baf445e52a1bd558aa9787fb43d0e434b700ce5d0cae9fc2e",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/typescript-reviewer.toml": "77a6debda380ce64745047f6215865614064c849169087475487acb24b0155ee",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/architect.md": "a717fb721175cf3f43257a267920b90d7ce4e3ea02b15f2f156fc382ef218190",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/chief-of-staff.md": "f8c86abd50041cfd86f8bd79fca3bc679e90ce2f8712b63eb5cca3bf8f01f37b",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/code-reviewer.md": "84f7197044e3e305b3b3a77f032029ddded80ee2d7aaa53d9bc458720131de0a",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/doc-updater.md": "507c850ef719d5d6e720f3ea660bbe8c3791c76fc199f6d90598a6b85524a6d0",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/docs-lookup.md": "261cbb5c373a62bd95bb2631cdf60a0cf4b90cfbda422623fe7d4756558344f9",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/executor.md": "e8263c7c0152bda69ae0f093ad980bdeeca0fa5cb3333a324c2712345192f4ff",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/go-build-resolver.md": "bab4d0d36ab0cc515d6f6d5223084f6ba09530717db5402969f3dbc0d7922a1b",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/go-reviewer.md": "fd11ce3ca3148ad14919b44980a6fd435cb6ff90eeaf3ba36cee5f6237ddeed4",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/harness-optimizer.md": "b881c0593d897eb800c01513ba494b0f92fa121fef42a98f547fb8090f23c6f3",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/planner.md": "315ccfc559f67c655a17108bd01a51cd37aa0ee05fc87b3c2bc4d188abee166d",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/python-reviewer.md": "2465e88f464251d103ac32e6c17634cf175ae1d315abf52e6b4a692547a89be5",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/pytorch-build-resolver.md": "13711587b74364269767a9d8e9d8fef57f5cd0e79a5e837b5ea257e04a18719f",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/researcher.md": "4e9be519fea7308c65f330bf6ff6275689bde18babc40c3957877fcf6718bfca",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/reviewer.md": "4600aab909eac6cf7da40e80de8a089922f3f98bbe83e2cf2d1140a8b65655e8",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/tdd-guide.md": "f00dd6a09e5b68fc2a79e3528354ba7d30b9f779d88d11f9f4ed6fb7eaec10fb",
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/typescript-reviewer.md": "3dd4c43280a7de2264e9c4e517dc7e857a58014f2c3efdb98b990bb978a5dfaf"
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/AGENTS.md": "b9b2cf4d0996d92e22035e3330ccc265aa654da1bb2f58a45609ea5949c22774",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/GEMINI.md": "f43d898af68e78823b70252b90f464365a915307a69de0ddf5c584477f6ffabf",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.agents/skills/github-kanban-ops": "9796d525aaf891ba1a5d030466e3c370274d3e638ff889da0eaee7b83af13482",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/architect.toml": "6ea336126c152b0a80491e114b033c7f6fddf88a41922528cede75f32c3fa4d5",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/chief-of-staff.toml": "55302ddb595c4534d365658cf439ff7ef458999db191132c0c45f9a81d16baa2",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/code-reviewer.toml": "f2fbf69f92340d46cc5be1f03a81b85fddc7dca8772b189a7da89acc85a5065e",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/doc-updater.toml": "9777056bfb4c9554d5a9179a8e6ac20f8b9dd2b051191b32bed4d4e4e3f4c849",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/docs-lookup.toml": "b453bc451481376e497cf503c823bc2d70fee9f5c0c4b7a109f971267b6d4e88",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/executor.toml": "8a52944e0bb23bb0a7a3f1f7d569950a03400a54acd780ff9eab4dba953bd788",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/go-build-resolver.toml": "923ccc942758f496a792f7f64a21b5fa05d18d778f45b6949679196c14a71432",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/go-reviewer.toml": "dd3a916e0f3ebeee6ffee235314a8b88d651d08c0670bf0f8051c75e11c84b98",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/harness-optimizer.toml": "bfcd41d46634782588a69d188f8ebde881c852a52f4488a6498ca47dd47c123b",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/planner.toml": "93dd1db5cb2e3037cb5088553ebede1af33388fdbc6ce94d660dba67a859e428",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/python-reviewer.toml": "3fcaee94269d55e386e8e9f9df414de3ad6bce922f8c26cd15879c8da68a8d34",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/pytorch-build-resolver.toml": "c8bf2ca9dad8e5815c74131fa2588a42e42a9337201911cdaf5c436ed309b648",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/researcher.toml": "fe0bc4cc5a5b3792d1e875998c91a3d4d1b1a9a1441ead35210c3fefed9f4521",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/reviewer.toml": "0a321de5a768646d1710fde4c91c33e9c30057a41780386605d39528d8023b9d",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/tdd-guide.toml": "f7a0b7a5be0bb90baf445e52a1bd558aa9787fb43d0e434b700ce5d0cae9fc2e",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/typescript-reviewer.toml": "77a6debda380ce64745047f6215865614064c849169087475487acb24b0155ee",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/architect.md": "a717fb721175cf3f43257a267920b90d7ce4e3ea02b15f2f156fc382ef218190",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/chief-of-staff.md": "f8c86abd50041cfd86f8bd79fca3bc679e90ce2f8712b63eb5cca3bf8f01f37b",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/code-reviewer.md": "84f7197044e3e305b3b3a77f032029ddded80ee2d7aaa53d9bc458720131de0a",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/doc-updater.md": "507c850ef719d5d6e720f3ea660bbe8c3791c76fc199f6d90598a6b85524a6d0",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/docs-lookup.md": "261cbb5c373a62bd95bb2631cdf60a0cf4b90cfbda422623fe7d4756558344f9",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/executor.md": "e8263c7c0152bda69ae0f093ad980bdeeca0fa5cb3333a324c2712345192f4ff",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/go-build-resolver.md": "bab4d0d36ab0cc515d6f6d5223084f6ba09530717db5402969f3dbc0d7922a1b",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/go-reviewer.md": "fd11ce3ca3148ad14919b44980a6fd435cb6ff90eeaf3ba36cee5f6237ddeed4",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/harness-optimizer.md": "b881c0593d897eb800c01513ba494b0f92fa121fef42a98f547fb8090f23c6f3",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/planner.md": "315ccfc559f67c655a17108bd01a51cd37aa0ee05fc87b3c2bc4d188abee166d",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/python-reviewer.md": "2465e88f464251d103ac32e6c17634cf175ae1d315abf52e6b4a692547a89be5",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/pytorch-build-resolver.md": "13711587b74364269767a9d8e9d8fef57f5cd0e79a5e837b5ea257e04a18719f",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/researcher.md": "4e9be519fea7308c65f330bf6ff6275689bde18babc40c3957877fcf6718bfca",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/reviewer.md": "4600aab909eac6cf7da40e80de8a089922f3f98bbe83e2cf2d1140a8b65655e8",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/tdd-guide.md": "f00dd6a09e5b68fc2a79e3528354ba7d30b9f779d88d11f9f4ed6fb7eaec10fb",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/typescript-reviewer.md": "3dd4c43280a7de2264e9c4e517dc7e857a58014f2c3efdb98b990bb978a5dfaf"
   },
   "targets": {
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/AGENTS.md": {
-      "hash": "bde14d9f733891dd3104aae1557156d7294497512312f49ce552e014dfe183c2",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/AGENTS.md": {
+      "hash": "b9b2cf4d0996d92e22035e3330ccc265aa654da1bb2f58a45609ea5949c22774",
       "owner": "aco",
       "kind": "config"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/GEMINI.md": {
-      "hash": "b59183d5dcba0bee6f10f1b1460125f512dd5b995fd587e5d42951b439765fa9",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/GEMINI.md": {
+      "hash": "f43d898af68e78823b70252b90f464365a915307a69de0ddf5c584477f6ffabf",
       "owner": "aco",
       "kind": "config"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.agents/skills/github-kanban-ops": {
-      "hash": "03634476f9f4b0ec5e0453eac26de410be9513e835d6c6ec8b8a5cfe7a61c896",
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.agents/skills/github-kanban-ops": {
+      "hash": "9796d525aaf891ba1a5d030466e3c370274d3e638ff889da0eaee7b83af13482",
       "owner": "aco",
       "kind": "shared-skill",
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/github-kanban-ops",
+      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.claude/skills/github-kanban-ops",
       "hashFormat": "directory"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/architect.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/architect.toml": {
       "hash": "6ea336126c152b0a80491e114b033c7f6fddf88a41922528cede75f32c3fa4d5",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/chief-of-staff.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/chief-of-staff.toml": {
       "hash": "55302ddb595c4534d365658cf439ff7ef458999db191132c0c45f9a81d16baa2",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/code-reviewer.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/code-reviewer.toml": {
       "hash": "f2fbf69f92340d46cc5be1f03a81b85fddc7dca8772b189a7da89acc85a5065e",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/doc-updater.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/doc-updater.toml": {
       "hash": "9777056bfb4c9554d5a9179a8e6ac20f8b9dd2b051191b32bed4d4e4e3f4c849",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/docs-lookup.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/docs-lookup.toml": {
       "hash": "b453bc451481376e497cf503c823bc2d70fee9f5c0c4b7a109f971267b6d4e88",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/executor.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/executor.toml": {
       "hash": "8a52944e0bb23bb0a7a3f1f7d569950a03400a54acd780ff9eab4dba953bd788",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/go-build-resolver.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/go-build-resolver.toml": {
       "hash": "923ccc942758f496a792f7f64a21b5fa05d18d778f45b6949679196c14a71432",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/go-reviewer.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/go-reviewer.toml": {
       "hash": "dd3a916e0f3ebeee6ffee235314a8b88d651d08c0670bf0f8051c75e11c84b98",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/harness-optimizer.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/harness-optimizer.toml": {
       "hash": "bfcd41d46634782588a69d188f8ebde881c852a52f4488a6498ca47dd47c123b",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/planner.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/planner.toml": {
       "hash": "93dd1db5cb2e3037cb5088553ebede1af33388fdbc6ce94d660dba67a859e428",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/python-reviewer.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/python-reviewer.toml": {
       "hash": "3fcaee94269d55e386e8e9f9df414de3ad6bce922f8c26cd15879c8da68a8d34",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/pytorch-build-resolver.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/pytorch-build-resolver.toml": {
       "hash": "c8bf2ca9dad8e5815c74131fa2588a42e42a9337201911cdaf5c436ed309b648",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/researcher.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/researcher.toml": {
       "hash": "fe0bc4cc5a5b3792d1e875998c91a3d4d1b1a9a1441ead35210c3fefed9f4521",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/reviewer.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/reviewer.toml": {
       "hash": "0a321de5a768646d1710fde4c91c33e9c30057a41780386605d39528d8023b9d",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/tdd-guide.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/tdd-guide.toml": {
       "hash": "f7a0b7a5be0bb90baf445e52a1bd558aa9787fb43d0e434b700ce5d0cae9fc2e",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.codex/agents/typescript-reviewer.toml": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.codex/agents/typescript-reviewer.toml": {
       "hash": "77a6debda380ce64745047f6215865614064c849169087475487acb24b0155ee",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/architect.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/architect.md": {
       "hash": "a717fb721175cf3f43257a267920b90d7ce4e3ea02b15f2f156fc382ef218190",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/chief-of-staff.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/chief-of-staff.md": {
       "hash": "f8c86abd50041cfd86f8bd79fca3bc679e90ce2f8712b63eb5cca3bf8f01f37b",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/code-reviewer.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/code-reviewer.md": {
       "hash": "84f7197044e3e305b3b3a77f032029ddded80ee2d7aaa53d9bc458720131de0a",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/doc-updater.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/doc-updater.md": {
       "hash": "507c850ef719d5d6e720f3ea660bbe8c3791c76fc199f6d90598a6b85524a6d0",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/docs-lookup.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/docs-lookup.md": {
       "hash": "261cbb5c373a62bd95bb2631cdf60a0cf4b90cfbda422623fe7d4756558344f9",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/executor.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/executor.md": {
       "hash": "e8263c7c0152bda69ae0f093ad980bdeeca0fa5cb3333a324c2712345192f4ff",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/go-build-resolver.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/go-build-resolver.md": {
       "hash": "bab4d0d36ab0cc515d6f6d5223084f6ba09530717db5402969f3dbc0d7922a1b",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/go-reviewer.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/go-reviewer.md": {
       "hash": "fd11ce3ca3148ad14919b44980a6fd435cb6ff90eeaf3ba36cee5f6237ddeed4",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/harness-optimizer.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/harness-optimizer.md": {
       "hash": "b881c0593d897eb800c01513ba494b0f92fa121fef42a98f547fb8090f23c6f3",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/planner.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/planner.md": {
       "hash": "315ccfc559f67c655a17108bd01a51cd37aa0ee05fc87b3c2bc4d188abee166d",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/python-reviewer.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/python-reviewer.md": {
       "hash": "2465e88f464251d103ac32e6c17634cf175ae1d315abf52e6b4a692547a89be5",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/pytorch-build-resolver.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/pytorch-build-resolver.md": {
       "hash": "13711587b74364269767a9d8e9d8fef57f5cd0e79a5e837b5ea257e04a18719f",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/researcher.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/researcher.md": {
       "hash": "4e9be519fea7308c65f330bf6ff6275689bde18babc40c3957877fcf6718bfca",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/reviewer.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/reviewer.md": {
       "hash": "4600aab909eac6cf7da40e80de8a089922f3f98bbe83e2cf2d1140a8b65655e8",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/tdd-guide.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/tdd-guide.md": {
       "hash": "f00dd6a09e5b68fc2a79e3528354ba7d30b9f779d88d11f9f4ed6fb7eaec10fb",
       "owner": "aco",
       "kind": "agent"
     },
-    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.gemini/agents/typescript-reviewer.md": {
+    "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.aco-worktrees/fix-106/.gemini/agents/typescript-reviewer.md": {
       "hash": "3dd4c43280a7de2264e9c4e517dc7e857a58014f2c3efdb98b990bb978a5dfaf",
       "owner": "aco",
       "kind": "agent"
@@ -254,85 +255,91 @@
   },
   "skipped": [
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-issue/SKILL.md",
+      "path": ".claude/skills/aco-delegation/SKILL.md",
+      "owner": "unknown",
+      "kind": "external-skill",
+      "reason": "Skill aco-delegation is not explicitly allowed by .aco/sync.yaml or frontmatter; skipped."
+    },
+    {
+      "path": ".claude/skills/gh-issue/SKILL.md",
       "owner": "provider-specific",
       "kind": "command-alias-skill",
       "reason": "Provider-specific command-alias skill gh-issue is not a shared policy skill; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-pr/SKILL.md",
+      "path": ".claude/skills/gh-pr/SKILL.md",
       "owner": "provider-specific",
       "kind": "command-alias-skill",
       "reason": "Provider-specific command-alias skill gh-pr is not a shared policy skill; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-pr-followup/SKILL.md",
+      "path": ".claude/skills/gh-pr-followup/SKILL.md",
       "owner": "provider-specific",
       "kind": "command-alias-skill",
       "reason": "Provider-specific command-alias skill gh-pr-followup is not a shared policy skill; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/gh-start/SKILL.md",
+      "path": ".claude/skills/gh-start/SKILL.md",
       "owner": "provider-specific",
       "kind": "command-alias-skill",
       "reason": "Provider-specific command-alias skill gh-start is not a shared policy skill; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-apply-change/SKILL.md",
+      "path": ".claude/skills/openspec-apply-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-apply-change is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-archive-change/SKILL.md",
+      "path": ".claude/skills/openspec-archive-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-archive-change is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-bulk-archive-change/SKILL.md",
+      "path": ".claude/skills/openspec-bulk-archive-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-bulk-archive-change is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-continue-change/SKILL.md",
+      "path": ".claude/skills/openspec-continue-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-continue-change is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-explore/SKILL.md",
+      "path": ".claude/skills/openspec-explore/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-explore is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-ff-change/SKILL.md",
+      "path": ".claude/skills/openspec-ff-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-ff-change is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-new-change/SKILL.md",
+      "path": ".claude/skills/openspec-new-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-new-change is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-propose/SKILL.md",
+      "path": ".claude/skills/openspec-propose/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-propose is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-sync-specs/SKILL.md",
+      "path": ".claude/skills/openspec-sync-specs/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-sync-specs is not ACO-owned; skipped."
     },
     {
-      "path": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/skills/openspec-verify-change/SKILL.md",
+      "path": ".claude/skills/openspec-verify-change/SKILL.md",
       "owner": "external",
       "kind": "external-skill",
       "reason": "External skill openspec-verify-change is not ACO-owned; skipped."
@@ -340,92 +347,92 @@
   ],
   "warnings": [
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/architect.md",
+      "source": ".claude/agents/architect.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/chief-of-staff.md",
+      "source": ".claude/agents/chief-of-staff.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/code-reviewer.md",
+      "source": ".claude/agents/code-reviewer.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/doc-updater.md",
+      "source": ".claude/agents/doc-updater.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/docs-lookup.md",
+      "source": ".claude/agents/docs-lookup.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/executor.md",
+      "source": ".claude/agents/executor.md",
       "message": "reasoningEffort \"medium\" is not supported by Gemini CLI and was omitted",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/go-build-resolver.md",
+      "source": ".claude/agents/go-build-resolver.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/go-reviewer.md",
+      "source": ".claude/agents/go-reviewer.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/harness-optimizer.md",
+      "source": ".claude/agents/harness-optimizer.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/planner.md",
+      "source": ".claude/agents/planner.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/python-reviewer.md",
+      "source": ".claude/agents/python-reviewer.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/pytorch-build-resolver.md",
+      "source": ".claude/agents/pytorch-build-resolver.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/researcher.md",
+      "source": ".claude/agents/researcher.md",
       "message": "reasoningEffort \"high\" is not supported by Gemini CLI and was omitted",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/researcher.md",
+      "source": ".claude/agents/researcher.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/reviewer.md",
+      "source": ".claude/agents/reviewer.md",
       "message": "reasoningEffort \"high\" is not supported by Gemini CLI and was omitted",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/reviewer.md",
+      "source": ".claude/agents/reviewer.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/tdd-guide.md",
+      "source": ".claude/agents/tdd-guide.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     },
     {
-      "source": "/Users/ddalkak/Projects/ai-cli-orch-wrapper/.claude/agents/typescript-reviewer.md",
+      "source": ".claude/agents/typescript-reviewer.md",
       "message": "Gemini read-only enforcement is best-effort; tool restrictions may not be fully equivalent",
       "severity": "warning"
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,23 @@ Rules:
   - PR URL if created
 
 <!-- BEGIN ACO GENERATED CONTEXT -->
-## Projects/ai-cli-orch-wrapper/CLAUDE.md
+## CLAUDE.md
 
 # ai-cli-orch-wrapper
 
 Claude Code project instructions for this repository. Codex receives the matching
 repo-level instructions from `AGENTS.md`.
+
+## 공통 작업 원칙
+
+이 repo의 세부 규칙은 이 파일의 worktree/context-sync 정책과 root `~/.openclaw/AGENTS.md`의 공통 원칙을 함께 따른다.
+
+- 구현 전에 모호한 가정, 가능한 해석, 위험한 변경 범위를 먼저 드러낸다.
+- 요청받은 문제를 해결하는 최소 변경을 우선하고, 단일 사용처를 위한 추상화나 미래 기능을 만들지 않는다.
+- provider-neutral wrapper 구조와 context-sync surface 경계를 따른다. 관련 없는 리팩터링, 포맷 변경, dead code 삭제는 하지 않는다.
+- 모든 변경 라인은 사용자 요청, runtime compatibility, 또는 검증 필요성과 직접 연결되어야 한다.
+- 비사소한 변경은 성공 기준과 검증 명령을 먼저 정하고, 완료 전에 실제 결과를 확인한다.
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`의 generated block은 sync contract를 먼저 확인하고, 불가피할 때만 손으로 수정한다.
 
 ## Repo Structure
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -51,12 +51,23 @@ GitHub 코드 리뷰에서는 P0/P1 위주로 flag한다. P2/P3는 정말 의미
 확실하지 않은 추측은 blocker로 단정하지 말고 “확인 필요”로 분리한다.
 
 <!-- BEGIN ACO GENERATED CONTEXT -->
-## Projects/ai-cli-orch-wrapper/CLAUDE.md
+## CLAUDE.md
 
 # ai-cli-orch-wrapper
 
 Claude Code project instructions for this repository. Codex receives the matching
 repo-level instructions from `AGENTS.md`.
+
+## 공통 작업 원칙
+
+이 repo의 세부 규칙은 이 파일의 worktree/context-sync 정책과 root `~/.openclaw/AGENTS.md`의 공통 원칙을 함께 따른다.
+
+- 구현 전에 모호한 가정, 가능한 해석, 위험한 변경 범위를 먼저 드러낸다.
+- 요청받은 문제를 해결하는 최소 변경을 우선하고, 단일 사용처를 위한 추상화나 미래 기능을 만들지 않는다.
+- provider-neutral wrapper 구조와 context-sync surface 경계를 따른다. 관련 없는 리팩터링, 포맷 변경, dead code 삭제는 하지 않는다.
+- 모든 변경 라인은 사용자 요청, runtime compatibility, 또는 검증 필요성과 직접 연결되어야 한다.
+- 비사소한 변경은 성공 기준과 검증 명령을 먼저 정하고, 완료 전에 실제 결과를 확인한다.
+- `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`의 generated block은 sync contract를 먼저 확인하고, 불가피할 때만 손으로 수정한다.
 
 ## Repo Structure
 
@@ -115,9 +126,51 @@ Use the repository commit template at `.gitmessage` and the Korean commit-writin
 - Commit messages must use a title plus body format.
 - The title must follow conventional commit style such as `fix(tests): replace echo pipeline with herestrings`.
 - The body must explain the why, what changed, and affected files or areas in Korean by default.
-- When Codex creates a commit, it must follow `docs/guides/commit-message-prompt.md`.
+- When an AI assistant creates a commit, it must follow `docs/guides/commit-message-prompt.md`.
 - Commit messages must include contributor trailers for every AI CLI and model used in development so GitHub Contributors can show the CLI/model identities where GitHub recognizes them.
 - If a CLI or model has no GitHub-recognized identity, still include explicit `AI-CLI:` and `AI-Model:` trailers in addition to any available `Co-authored-by:` trailers.
+  - **How to Add AI as a Co-Author (Manual Method):** Add the corresponding line to the end of the commit message, usually after a blank line:
+  - **Claude Code:** `Co-authored-by: Claude Code {session수행중인 모델명} <noreply@anthropic.com>`
+  - **Codex:** `Co-authored-by: Codex {session수행중인 모델명} <noreply@sourcegraph.com>`
+  - **Gemini CLI:** `Co-authored-by: Gemini CLI {session수행중인 모델명} <gemini-code-assist@google.com>`
+  - 각 CLI에서 커밋이 발생할 때 반드시 위 형식에 맞는 `Co-authored-by` 트레일러가 추가되어야 한다.
+
+## Review Guidelines
+
+리뷰 코멘트는 기본적으로 한국어로 작성한다. 단, 코드, 파일 경로, 명령어, API 이름, 라이브러리 이름은 영어 원문을 유지한다.
+
+사소한 스타일 지적보다 merge 전에 고쳐야 할 correctness, security, runtime behavior, compatibility, CI breakage를 우선한다.
+
+### Severity
+
+- P0: 즉시 수정 필요. 보안 취약점, secret 노출, 데이터 손실, 빌드/배포 불가, 주요 기능 중단.
+- P1: merge 전 수정 권장. 런타임 버그, contract 깨짐, 테스트 실패 가능성, 호환성 문제, 잘못된 에러 처리.
+- P2: follow-up 가능. 테스트 보강, 문서 보강, 작은 UX 개선, 구조 개선.
+- P3: 선택 사항. 취향에 가까운 개선, 장기 리팩터링 제안.
+
+GitHub 코드 리뷰에서는 P0/P1 위주로 flag한다. P2/P3는 정말 의미 있는 경우에만 요약한다.
+
+### Review Focus
+
+- Security: secret leakage, command injection, path traversal, unsafe deserialization, auth/authz bypass, sensitive logging.
+- Correctness: edge cases, null/undefined handling, error handling, data loss, race conditions.
+- Runtime behavior: timeout, cancellation, retries, resource cleanup, concurrency, process/network/file-system behavior.
+- Compatibility: public API, CLI behavior, config format, migration path, backward compatibility.
+- Testing: changed behavior에 맞는 unit/integration/e2e test가 있는지 확인한다.
+- Dependencies: 새 dependency의 필요성, 보안성, 유지보수성, bundle/build 영향 확인.
+- Documentation: 사용자에게 보이는 behavior 변경이면 docs, examples, migration notes 필요 여부 확인.
+
+### Output Expectations
+
+각 finding은 다음 정보를 포함한다.
+
+- 문제 위치
+- 실제 영향
+- 왜 문제가 되는지
+- 수정 방향
+- 검증 방법
+
+확실하지 않은 추측은 blocker로 단정하지 말고 “확인 필요”로 분리한다.
 
 ## Validation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -85,27 +85,59 @@ Timeout and `aco cancel --session <id>` are reliability controls. They best-effo
 
 Real Codex/Gemini smoke commands can require provider credentials, local CLI setup, network access, and real provider latency. Keep those commands opt-in and separate from default CI or deterministic repo tests.
 
+## Currently Implemented Protections
+
+### Input-File Credential Guard
+
+`aco ask --input-file <path>` blocks file paths that match common credential and secret file patterns by default:
+
+- `.env`, `.env.local`, `.env.production`, and similar `.env*` variants
+- `auth.json`, `*_creds.json`, `*_credentials.json`
+- SSH private keys: `id_rsa`, `id_ed25519`, `id_dsa`, `id_ecdsa`
+- Private key files: `*.pem`, `*.key`
+- Certificate bundles: `*.pfx`, `*.p12`
+- Generic secret files: `secrets.json`, `secrets.yaml`, `secrets.yml`
+- Well-known CLI credential files: `.codex/auth.json`, `.gemini/oauth_creds.json`
+
+If a blocked path is supplied, `aco ask` exits with an error. To override explicitly:
+
+```bash
+aco ask --input-file .env --allow-sensitive --task "..."
+```
+
+`--allow-sensitive` prints a warning to stderr and continues. Use it only when you have reviewed the file content and understand the risk.
+
+### Environment Variable Warning
+
+When `aco ask --yes` is about to invoke provider processes, it scans `process.env` for keys whose names end with credential-like suffixes (`_TOKEN`, `_KEY`, `_SECRET`, `_API_KEY`, `_PASSWORD`, `PRIVATE_KEY`). If any are found, a warning listing the key names (not values) is printed to stderr:
+
+```
+[aco] warning: the following environment variables look like credentials and will be
+inherited by the provider process: GITHUB_TOKEN, OPENAI_API_KEY.
+[aco] To suppress this warning, unset these variables before running aco ask.
+```
+
+Provider execution is not blocked; the warning is informational only.
+
+## Planned Improvements
+
+The following protections are planned but not yet implemented:
+
+- **Provider env filtering**: opt-in `--no-inherit-env` or allowlist-based env filtering to prevent credential-like environment variables from being passed to provider child processes at all.
+- **`.acoignore` enforcement**: file-pattern-based blocklist for `--input-file`. Currently `.acoignore.example` is a policy/example only.
+
+Until env filtering exists, unset sensitive environment variables before running `aco ask`, or use a clean environment wrapper (e.g., `env -i HOME=$HOME ... aco ask ...`).
+
 ## Secrets Policy
 
 Do not send secrets, credentials, private tokens, local auth files, or unrelated sensitive files through `--input` or `--input-file`.
 
-Examples to avoid:
-
-```text
-.env
-~/.codex/auth.json
-~/.gemini/oauth_creds.json
-private keys
-production credentials
-```
+The input-file credential guard blocks the most common cases automatically, but it cannot detect all sensitive content. User responsibility remains for:
+- Inline `--input` text containing secrets
+- Custom file formats that happen to contain credentials
+- Files with non-standard names
 
 `aco doctor` does not print secret values. It reports local readiness heuristics only.
-
-## `.acoignore` Status
-
-`.acoignore.example` is provided as a policy/example file only. Goal 2 does not implement `.acoignore` enforcement.
-
-Until enforcement exists, the user is responsible for choosing safe `--input` and `--input-file` content.
 
 ## Inspect Before Sharing
 

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "tsc",
     "prepack": "node -e \"const fs = require('fs'); const path = require('path'); const src = path.resolve(process.cwd(), '../../templates'); const dest = path.resolve(process.cwd(), 'templates'); fs.rmSync(dest, { recursive: true, force: true }); fs.mkdirSync(dest, { recursive: true }); fs.cpSync(src, dest, { recursive: true });\"",
-    "test": "node --require tsx/cjs --test tests/command-output-buffering.test.ts tests/spawn-stream-buffering.test.ts tests/spawn-stream-close-safety.test.ts tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts tests/ask-cli.test.ts tests/doctor-cli.test.ts tests/pack-runtime-contract.test.ts tests/provider-session-reliability.test.ts",
+    "test": "node --require tsx/cjs --test tests/command-output-buffering.test.ts tests/spawn-stream-buffering.test.ts tests/spawn-stream-close-safety.test.ts tests/providers.test.ts tests/session.test.ts tests/runtime-context.test.ts tests/runtime-dashboard.test.ts tests/sentinel.test.ts tests/sync.test.ts tests/sync-conflict.test.ts tests/sync-manifest-portability.test.ts tests/credential-guard.test.ts tests/ask-cli.test.ts tests/doctor-cli.test.ts tests/pack-runtime-contract.test.ts tests/provider-session-reliability.test.ts",
     "test:pack-runtime-contract": "tsx tests/pack-runtime-contract-smoke.ts",
     "test:smoke": "tsx tests/smoke.ts",
     "typecheck": "tsc --noEmit",

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import process from 'node:process';
 import { providerRegistry } from '../providers/registry.js';
+import { isCredentialLikePath, findCredentialEnvKeys } from '../util/credential-guard.js';
 import { sessionStore } from '../session/store.js';
 import type { OutputBufferPolicy, PermissionProfile } from '../providers/interface.js';
 import { invokeProviderForSession } from '../runtime/provider-session-runner.js';
@@ -40,6 +41,7 @@ interface AskOptions {
   task?: string;
   input?: string;
   inputFile?: string;
+  allowSensitive: boolean;
   preset?: string;
   permissionProfile: PermissionProfile;
   outputMode: OutputMode;
@@ -91,6 +93,15 @@ export async function cmdAsk(args: string[]): Promise<void> {
       ].join('\n')
     );
     process.exit(EXIT_ERROR);
+  }
+
+  const credentialEnvKeys = findCredentialEnvKeys(process.env);
+  if (credentialEnvKeys.length > 0) {
+    process.stderr.write(
+      `[aco] warning: the following environment variables look like credentials and will be ` +
+        `inherited by the provider process: ${credentialEnvKeys.join(', ')}.\n` +
+        `[aco] To suppress this warning, unset these variables before running aco ask.\n`
+    );
   }
 
   const runId = randomUUID();
@@ -228,6 +239,7 @@ function parseAskOptions(args: string[]): AskOptions {
     task: parseFlag(args, '--task'),
     input: parseFlag(args, '--input'),
     inputFile: parseFlag(args, '--input-file'),
+    allowSensitive: args.includes('--allow-sensitive'),
     preset: parseFlag(args, '--preset'),
     permissionProfile: parseFlag<PermissionProfile>(args, '--permission-profile') ?? 'restricted',
     outputMode: parseFlag<OutputMode>(args, '--output-mode') ?? 'brief',
@@ -290,6 +302,19 @@ async function collectInput(options: AskOptions): Promise<string> {
   }
 
   if (options.inputFile) {
+    if (isCredentialLikePath(options.inputFile)) {
+      if (options.allowSensitive) {
+        process.stderr.write(
+          `[aco] warning: --input-file '${options.inputFile}' looks like a credential or secret file. ` +
+            `Proceeding because --allow-sensitive was specified.\n`
+        );
+      } else {
+        fail(
+          `Blocked: --input-file '${options.inputFile}' looks like a credential or secret file. ` +
+            `Pass --allow-sensitive to override.`
+        );
+      }
+    }
     const filePath = resolve(process.cwd(), options.inputFile);
     const fileInput = await readFile(filePath, 'utf8').catch((err: unknown) => {
       const message = err instanceof Error ? err.message : String(err);
@@ -429,7 +454,8 @@ Options:
   --providers <list>              Comma-separated providers (default: mock)
   --task <text>                   Natural language task
   --input <text>                  Inline input
-  --input-file <path>             Input file to include
+  --input-file <path>             Input file to include (credential-like paths blocked by default)
+  --allow-sensitive               Allow credential-like --input-file paths (shows warning)
   --preset <name>                 .claude/aco/tasks/<name>.md
   --permission-profile <profile>  restricted|default|unrestricted (default: restricted)
   --output-mode <mode>            brief|save-only|full (default: brief)

--- a/packages/wrapper/src/sync/manifest.ts
+++ b/packages/wrapper/src/sync/manifest.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, relative, isAbsolute } from 'node:path';
 import type { SyncManifest, SyncWarning, ManifestTargetRecord } from './transform-interface.js';
 
 const MANIFEST_DIR = '.aco';
@@ -10,7 +10,7 @@ export async function readManifest(rootPath: string): Promise<SyncManifest | nul
     const path = join(rootPath, MANIFEST_DIR, MANIFEST_FILE);
     const content = await readFile(path, 'utf-8');
     const parsed = JSON.parse(content) as Partial<SyncManifest>;
-    return migrateManifest(parsed);
+    return migrateManifest(parsed, rootPath);
   } catch {
     return null;
   }
@@ -54,44 +54,77 @@ export function calculateDrift(current: SyncManifest | null, updated: SyncManife
 }
 
 /**
- * Migrate a legacy manifest (with only targetHashes) to the ownership-aware format.
+ * Migrate a manifest through version history:
+ *   v1 (targetHashes only) → v2 (ownership-aware targets)
+ *   v2 (absolute sourceHashes) → v3 (repo-relative sourceHashes)
  */
-function migrateManifest(parsed: Partial<SyncManifest>): SyncManifest {
+function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): SyncManifest {
   const legacy = parsed as Record<string, unknown>;
 
-  // If already migrated, return as-is
-  if (legacy.targets && typeof legacy.targets === 'object') {
-    return {
-      version: (legacy.version as string) || '2',
-      generatedAt: (legacy.generatedAt as string) || new Date().toISOString(),
-      sourceHashes: (legacy.sourceHashes as Record<string, string>) || {},
-      targetHashes: (legacy.targetHashes as Record<string, string>) || {},
-      targets: (legacy.targets as Record<string, ManifestTargetRecord>) || {},
-      skipped: (legacy.skipped as SyncManifest['skipped']) || [],
-      warnings: (legacy.warnings as SyncWarning[]) || [],
-    };
+  // v1 → v2: add ownership-aware targets
+  if (!legacy.targets || typeof legacy.targets !== 'object') {
+    const targetHashes = (legacy.targetHashes as Record<string, string>) || {};
+    const targets: Record<string, ManifestTargetRecord> = {};
+    for (const [path, hash] of Object.entries(targetHashes)) {
+      targets[path] = {
+        hash,
+        owner: 'aco',
+        kind: inferKindFromPath(path),
+        hashFormat: 'legacy-v1',
+      };
+    }
+    legacy.targets = targets;
+    legacy.version = '2';
+    legacy.generatedAt = legacy.generatedAt ?? new Date().toISOString();
+    legacy.sourceHashes = legacy.sourceHashes ?? {};
+    legacy.targetHashes = targetHashes;
+    legacy.skipped = [];
+    legacy.warnings = legacy.warnings ?? [];
   }
 
-  // Migrate from legacy v1 format
-  const targetHashes = (legacy.targetHashes as Record<string, string>) || {};
-  const targets: Record<string, ManifestTargetRecord> = {};
+  // v2 → v3: convert absolute sourceHashes keys to repo-relative
+  const rawVersion = (legacy.version as string) || '2';
+  const sourceHashes = (legacy.sourceHashes as Record<string, string>) || {};
+  const warnings: SyncWarning[] = (legacy.warnings as SyncWarning[]) || [];
 
-  for (const [path, hash] of Object.entries(targetHashes)) {
-    targets[path] = {
-      hash,
-      owner: 'aco',
-      kind: inferKindFromPath(path),
-      hashFormat: 'legacy-v1',
-    };
+  if (rawVersion !== '3') {
+    const migratedHashes: Record<string, string> = {};
+    for (const [key, hash] of Object.entries(sourceHashes)) {
+      if (isAbsolute(key)) {
+        if (!rootPath) {
+          warnings.push({
+            severity: 'warning',
+            source: 'manifest-migration',
+            message: `Cannot migrate absolute sourceHash key "${key}": rootPath unavailable`,
+          });
+          continue;
+        }
+        const rel = relative(rootPath, key);
+        if (rel.startsWith('..')) {
+          warnings.push({
+            severity: 'warning',
+            source: 'manifest-migration',
+            message: `Skipping absolute sourceHash key outside repo root: "${key}"`,
+          });
+          continue;
+        }
+        migratedHashes[rel] = hash;
+      } else {
+        migratedHashes[key] = hash;
+      }
+    }
+    legacy.sourceHashes = migratedHashes;
+    legacy.version = '3';
+    legacy.warnings = warnings;
   }
 
   return {
-    version: '2',
-    generatedAt: new Date().toISOString(),
+    version: '3',
+    generatedAt: (legacy.generatedAt as string) || new Date().toISOString(),
     sourceHashes: (legacy.sourceHashes as Record<string, string>) || {},
-    targetHashes,
-    targets,
-    skipped: [],
+    targetHashes: (legacy.targetHashes as Record<string, string>) || {},
+    targets: (legacy.targets as Record<string, ManifestTargetRecord>) || {},
+    skipped: (legacy.skipped as SyncManifest['skipped']) || [],
     warnings: (legacy.warnings as SyncWarning[]) || [],
   };
 }

--- a/packages/wrapper/src/sync/skill-transform.ts
+++ b/packages/wrapper/src/sync/skill-transform.ts
@@ -159,7 +159,7 @@ export async function syncSkills(
   // Sync current skills (deferred to sync-engine)
   for (const classified of classifiedSkills) {
     const { source, skillName, owner, kind } = classified;
-    const sourceDir = dirname(source.path);
+    const sourceDir = dirname(join(repoRoot, source.path));
     const targetDir = join(targetBase, skillName);
 
     // Validate sourcePath is within .claude/skills/

--- a/packages/wrapper/src/sync/source-discovery.ts
+++ b/packages/wrapper/src/sync/source-discovery.ts
@@ -1,16 +1,21 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, relative } from 'node:path';
 import { SyncSource, AssetKind } from './transform-interface.js';
 import { computeHash } from './hash.js';
 
+/**
+ * Discover all sync source files under rootPath.
+ * Returned SyncSource.path values are always repo-relative (e.g. "CLAUDE.md",
+ * ".claude/rules/core.md") so that manifest keys are portable across checkouts.
+ */
 export async function discoverSources(rootPath: string): Promise<SyncSource[]> {
   const sources: SyncSource[] = [];
 
   // 1. CLAUDE.md at repo root
-  await tryAddSource(sources, join(rootPath, 'CLAUDE.md'), 'config');
+  await tryAddSource(sources, rootPath, join(rootPath, 'CLAUDE.md'), 'config');
 
   // 2. .claude/CLAUDE.md (optional)
-  await tryAddSource(sources, join(rootPath, '.claude/CLAUDE.md'), 'config');
+  await tryAddSource(sources, rootPath, join(rootPath, '.claude/CLAUDE.md'), 'config');
 
   // 3. .claude/rules/*.md sorted lexicographically
   const rulesDir = join(rootPath, '.claude/rules');
@@ -18,7 +23,7 @@ export async function discoverSources(rootPath: string): Promise<SyncSource[]> {
     const rules = await readdir(rulesDir);
     const sortedRules = rules.filter((f) => f.endsWith('.md')).sort();
     for (const rule of sortedRules) {
-      await tryAddSource(sources, join(rulesDir, rule), 'rule');
+      await tryAddSource(sources, rootPath, join(rulesDir, rule), 'rule');
     }
   } catch {}
 
@@ -30,7 +35,7 @@ export async function discoverSources(rootPath: string): Promise<SyncSource[]> {
       const skillMdPath = join(skillsDir, skillDir, 'SKILL.md');
       try {
         await stat(skillMdPath); // Check if SKILL.md exists
-        await tryAddSkillSource(sources, skillMdPath);
+        await tryAddSkillSource(sources, rootPath, skillMdPath);
       } catch {}
     }
   } catch {}
@@ -40,21 +45,26 @@ export async function discoverSources(rootPath: string): Promise<SyncSource[]> {
   try {
     const agents = await readdir(agentsDir);
     for (const agent of agents.filter((f) => f.endsWith('.md'))) {
-      await tryAddSource(sources, join(agentsDir, agent), 'agent');
+      await tryAddSource(sources, rootPath, join(agentsDir, agent), 'agent');
     }
   } catch {}
 
   // 6. .claude/settings.json (for hooks)
-  await tryAddSource(sources, join(rootPath, '.claude/settings.json'), 'settings');
+  await tryAddSource(sources, rootPath, join(rootPath, '.claude/settings.json'), 'settings');
 
   return sources;
 }
 
-async function tryAddSource(sources: SyncSource[], path: string, kind: SyncSource['kind']) {
+async function tryAddSource(
+  sources: SyncSource[],
+  rootPath: string,
+  absolutePath: string,
+  kind: SyncSource['kind']
+) {
   try {
-    const content = await readFile(path, 'utf8');
+    const content = await readFile(absolutePath, 'utf8');
     sources.push({
-      path,
+      path: relative(rootPath, absolutePath),
       kind,
       content,
       hash: computeHash(content),
@@ -64,12 +74,12 @@ async function tryAddSource(sources: SyncSource[], path: string, kind: SyncSourc
   }
 }
 
-async function tryAddSkillSource(sources: SyncSource[], path: string) {
+async function tryAddSkillSource(sources: SyncSource[], rootPath: string, absolutePath: string) {
   try {
-    const content = await readFile(path, 'utf8');
+    const content = await readFile(absolutePath, 'utf8');
     const frontmatter = parseSkillFrontmatter(content);
     sources.push({
-      path,
+      path: relative(rootPath, absolutePath),
       kind: 'skill',
       content,
       hash: computeHash(content),

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -445,7 +445,7 @@ async function computeTransformPlan(
   }
 
   const manifest: SyncManifest = {
-    version: '2',
+    version: '3',
     generatedAt: new Date().toISOString(),
     sourceHashes,
     targetHashes,

--- a/packages/wrapper/src/util/credential-guard.ts
+++ b/packages/wrapper/src/util/credential-guard.ts
@@ -7,7 +7,7 @@ import { basename } from 'node:path';
 const CREDENTIAL_PATTERNS: RegExp[] = [
   /^\.env(\.[^/]+)?$/, // .env, .env.local, .env.production, etc.
   /^auth\.json$/, // OAuth token files
-  /_cred(?:s|entials)?\.json$/i, // *_credentials.json, *_creds.json
+  /(?:^|[_-])cred(?:s|entials)?\.json$/i, // credentials.json, *_credentials.json, *_creds.json
   /^(id_rsa|id_ed25519|id_dsa|id_ecdsa)$/, // SSH private keys
   /\.(pem|key)$/i, // TLS/cert private keys
   /\.(pfx|p12)$/i, // PKCS#12 bundles

--- a/packages/wrapper/src/util/credential-guard.ts
+++ b/packages/wrapper/src/util/credential-guard.ts
@@ -1,0 +1,59 @@
+import { basename } from 'node:path';
+
+/**
+ * Patterns that identify credential-like file paths.
+ * Checked against the basename and full normalized path.
+ */
+const CREDENTIAL_PATTERNS: RegExp[] = [
+  /^\.env(\.[^/]+)?$/,              // .env, .env.local, .env.production, etc.
+  /^auth\.json$/,                    // OAuth token files
+  /_cred(?:s|entials)?\.json$/i,      // *_credentials.json, *_creds.json
+  /^(id_rsa|id_ed25519|id_dsa|id_ecdsa)$/, // SSH private keys
+  /\.(pem|key)$/i,                   // TLS/cert private keys
+  /\.(pfx|p12)$/i,                   // PKCS#12 bundles
+  /^secrets?\.(json|ya?ml)$/i,       // secrets.json, secrets.yaml, secrets.yml
+];
+
+/**
+ * Well-known full relative-path credential files (matched against the normalized path).
+ */
+const CREDENTIAL_PATHS: RegExp[] = [
+  /(?:^|\/)\.codex\/auth\.json$/,
+  /(?:^|\/)\.gemini\/oauth_creds\.json$/,
+];
+
+/**
+ * Returns true if the given file path looks like a credential or secret file.
+ */
+export function isCredentialLikePath(filePath: string): boolean {
+  const name = basename(filePath);
+  for (const pattern of CREDENTIAL_PATTERNS) {
+    if (pattern.test(name)) return true;
+  }
+  const normalized = filePath.replace(/\\/g, '/');
+  for (const pattern of CREDENTIAL_PATHS) {
+    if (pattern.test(normalized)) return true;
+  }
+  return false;
+}
+
+/**
+ * Credential-like environment variable key suffixes.
+ */
+const CREDENTIAL_ENV_SUFFIXES = [
+  '_TOKEN',
+  '_KEY',
+  '_SECRET',
+  '_API_KEY',
+  '_PASSWORD',
+  'PRIVATE_KEY',
+];
+
+/**
+ * Returns the list of environment variable keys that appear credential-like.
+ */
+export function findCredentialEnvKeys(env: Record<string, string | undefined>): string[] {
+  return Object.keys(env).filter((key) =>
+    CREDENTIAL_ENV_SUFFIXES.some((suffix) => key.toUpperCase().endsWith(suffix))
+  );
+}

--- a/packages/wrapper/src/util/credential-guard.ts
+++ b/packages/wrapper/src/util/credential-guard.ts
@@ -5,13 +5,13 @@ import { basename } from 'node:path';
  * Checked against the basename and full normalized path.
  */
 const CREDENTIAL_PATTERNS: RegExp[] = [
-  /^\.env(\.[^/]+)?$/,              // .env, .env.local, .env.production, etc.
-  /^auth\.json$/,                    // OAuth token files
-  /_cred(?:s|entials)?\.json$/i,      // *_credentials.json, *_creds.json
+  /^\.env(\.[^/]+)?$/, // .env, .env.local, .env.production, etc.
+  /^auth\.json$/, // OAuth token files
+  /_cred(?:s|entials)?\.json$/i, // *_credentials.json, *_creds.json
   /^(id_rsa|id_ed25519|id_dsa|id_ecdsa)$/, // SSH private keys
-  /\.(pem|key)$/i,                   // TLS/cert private keys
-  /\.(pfx|p12)$/i,                   // PKCS#12 bundles
-  /^secrets?\.(json|ya?ml)$/i,       // secrets.json, secrets.yaml, secrets.yml
+  /\.(pem|key)$/i, // TLS/cert private keys
+  /\.(pfx|p12)$/i, // PKCS#12 bundles
+  /^secrets?\.(json|ya?ml)$/i, // secrets.json, secrets.yaml, secrets.yml
 ];
 
 /**

--- a/packages/wrapper/tests/credential-guard.test.ts
+++ b/packages/wrapper/tests/credential-guard.test.ts
@@ -17,6 +17,8 @@ describe('isCredentialLikePath: credential pattern detection', () => {
     '.env.production',
     '.env.test',
     'auth.json',
+    'credentials.json',
+    'creds.json',
     'api_credentials.json',
     'db_creds.json',
     'id_rsa',

--- a/packages/wrapper/tests/credential-guard.test.ts
+++ b/packages/wrapper/tests/credential-guard.test.ts
@@ -1,0 +1,216 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { execFile } from 'node:child_process';
+import { isCredentialLikePath, findCredentialEnvKeys } from '../src/util/credential-guard.js';
+
+// ---------------------------------------------------------------------------
+// 6.1  isCredentialLikePath: pattern matching
+// ---------------------------------------------------------------------------
+
+describe('isCredentialLikePath: credential pattern detection', () => {
+  const credentialPaths = [
+    '.env',
+    '.env.local',
+    '.env.production',
+    '.env.test',
+    'auth.json',
+    'api_credentials.json',
+    'db_creds.json',
+    'id_rsa',
+    'id_ed25519',
+    'id_dsa',
+    'id_ecdsa',
+    'server.pem',
+    'private.key',
+    'keystore.pfx',
+    'cert.p12',
+    'secrets.json',
+    'secrets.yaml',
+    'secrets.yml',
+    '.codex/auth.json',
+    '.gemini/oauth_creds.json',
+  ];
+
+  for (const p of credentialPaths) {
+    it(`blocks "${p}"`, () => {
+      assert.equal(isCredentialLikePath(p), true, `Expected "${p}" to be credential-like`);
+    });
+  }
+
+  const safePaths = [
+    'CLAUDE.md',
+    'README.md',
+    'src/index.ts',
+    'docs/overview.md',
+    'config.json',
+    'package.json',
+    'tsconfig.json',
+    '.claude/settings.json',
+    'auth-service.ts',
+    'key-value-store.ts',
+  ];
+
+  for (const p of safePaths) {
+    it(`allows "${p}"`, () => {
+      assert.equal(isCredentialLikePath(p), false, `Expected "${p}" to be safe`);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6.2~6.4  CLI integration: --input-file guard behavior
+// ---------------------------------------------------------------------------
+
+async function runAskCli(
+  args: string[],
+  options: { env?: Record<string, string>; cwd?: string } = {}
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  const cliRoot = resolve(__dirname, '..');
+  const cliPath = join(cliRoot, 'src', 'cli.ts');
+  const tsxRegister = require.resolve('tsx/cjs');
+
+  return new Promise((res) => {
+    execFile(
+      process.execPath,
+      ['--require', tsxRegister, cliPath, ...args],
+      {
+        cwd: options.cwd ?? cliRoot,
+        env: { ...process.env, NO_COLOR: '1', ...options.env },
+        timeout: 8000,
+      },
+      (error, stdout, stderr) => {
+        const code = error && 'code' in error ? (error as NodeJS.ErrnoException & { code?: number }).code as number | null : 0;
+        res({ code, stdout, stderr });
+      }
+    );
+  });
+}
+
+describe('ask --input-file credential guard: CLI behavior', () => {
+  it('6.2: blocks .env file without --allow-sensitive', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-guard-test-'));
+    try {
+      const envFile = join(tmpDir, '.env');
+      await writeFile(envFile, 'SECRET=hello');
+
+      const result = await runAskCli([
+        'ask',
+        '--task',
+        'test',
+        '--providers',
+        'mock',
+        '--input-file',
+        envFile,
+        '--yes',
+      ]);
+
+      assert.ok(
+        result.code !== 0,
+        `Expected non-zero exit code, got: ${result.code}\nstdout: ${result.stdout}\nstderr: ${result.stderr}`
+      );
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        output.includes('Blocked') || output.includes('credential'),
+        `Expected blocking message, got:\n${output}`
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('6.3: allows .env file with --allow-sensitive and shows warning', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-guard-allow-'));
+    try {
+      const envFile = join(tmpDir, '.env');
+      await writeFile(envFile, 'SECRET=hello');
+
+      const result = await runAskCli([
+        'ask',
+        '--task',
+        'test',
+        '--providers',
+        'mock',
+        '--input-file',
+        envFile,
+        '--yes',
+        '--allow-sensitive',
+      ]);
+
+      assert.ok(
+        result.stderr.includes('warning') || result.stderr.includes('sensitive'),
+        `Expected warning in stderr, got:\n${result.stderr}`
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('6.4: allows regular .md file without any guard', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-guard-safe-'));
+    try {
+      const mdFile = join(tmpDir, 'overview.md');
+      await writeFile(mdFile, '# Overview\n\nSome safe content.');
+
+      const result = await runAskCli([
+        'ask',
+        '--task',
+        'test',
+        '--providers',
+        'mock',
+        '--input-file',
+        mdFile,
+        '--yes',
+      ]);
+
+      const output = result.stdout + result.stderr;
+      assert.ok(
+        !output.includes('Blocked') && !output.includes('credential-like'),
+        `Expected no blocking for safe file, got:\n${output}`
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8.1~8.2  findCredentialEnvKeys: env var warning detection
+// ---------------------------------------------------------------------------
+
+describe('findCredentialEnvKeys: credential env var detection', () => {
+  it('8.1: detects credential-like env vars by suffix', () => {
+    const env: Record<string, string> = {
+      GITHUB_TOKEN: 'ghp_xxx',
+      OPENAI_API_KEY: 'sk-xxx',
+      DB_PASSWORD: 'secret',
+      MY_SECRET: 'hidden',
+      PRIVATE_KEY: 'pem-data',
+      SAFE_VAR: 'hello',
+      PATH: '/usr/bin',
+      HOME: '/home/user',
+    };
+    const keys = findCredentialEnvKeys(env);
+    assert.ok(keys.includes('GITHUB_TOKEN'), `Expected GITHUB_TOKEN in: ${JSON.stringify(keys)}`);
+    assert.ok(keys.includes('OPENAI_API_KEY'), `Expected OPENAI_API_KEY in: ${JSON.stringify(keys)}`);
+    assert.ok(keys.includes('DB_PASSWORD'), `Expected DB_PASSWORD in: ${JSON.stringify(keys)}`);
+    assert.ok(keys.includes('MY_SECRET'), `Expected MY_SECRET in: ${JSON.stringify(keys)}`);
+    assert.ok(keys.includes('PRIVATE_KEY'), `Expected PRIVATE_KEY in: ${JSON.stringify(keys)}`);
+    assert.ok(!keys.includes('SAFE_VAR'), `SAFE_VAR should not be in: ${JSON.stringify(keys)}`);
+    assert.ok(!keys.includes('PATH'), `PATH should not be in: ${JSON.stringify(keys)}`);
+    assert.ok(!keys.includes('HOME'), `HOME should not be in: ${JSON.stringify(keys)}`);
+  });
+
+  it('8.2: returns empty array when no credential env vars present', () => {
+    const env: Record<string, string> = {
+      PATH: '/usr/bin:/usr/local/bin',
+      HOME: '/home/user',
+      LANG: 'en_US.UTF-8',
+      TERM: 'xterm-256color',
+    };
+    const keys = findCredentialEnvKeys(env);
+    assert.deepEqual(keys, [], `Expected no credential keys, got: ${JSON.stringify(keys)}`);
+  });
+});

--- a/packages/wrapper/tests/sync-manifest-portability.test.ts
+++ b/packages/wrapper/tests/sync-manifest-portability.test.ts
@@ -1,0 +1,271 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { discoverSources } from '../src/sync/source-discovery.js';
+import { readManifest, writeManifest, calculateDrift } from '../src/sync/manifest.js';
+import type { SyncManifest } from '../src/sync/transform-interface.js';
+
+// ---------------------------------------------------------------------------
+// 4.1  source-discovery: SyncSource.path is repo-relative
+// ---------------------------------------------------------------------------
+
+describe('source-discovery: repo-relative paths', () => {
+  it('returns relative paths for discovered sources', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'aco-src-test-'));
+    try {
+      await writeFile(join(rootPath, 'CLAUDE.md'), '# test');
+      await mkdir(join(rootPath, '.claude/rules'), { recursive: true });
+      await writeFile(join(rootPath, '.claude/rules', 'core.md'), '## rule');
+
+      const sources = await discoverSources(rootPath);
+      for (const s of sources) {
+        assert.ok(
+          !s.path.startsWith('/'),
+          `Expected repo-relative path, got absolute: "${s.path}"`
+        );
+        assert.ok(
+          !s.path.startsWith(rootPath),
+          `Expected repo-relative path, got absolute: "${s.path}"`
+        );
+      }
+
+      const paths = sources.map((s) => s.path);
+      assert.ok(paths.includes('CLAUDE.md'), `Expected "CLAUDE.md" in paths, got: ${JSON.stringify(paths)}`);
+      assert.ok(
+        paths.includes('.claude/rules/core.md'),
+        `Expected ".claude/rules/core.md" in paths, got: ${JSON.stringify(paths)}`
+      );
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it('path is stable regardless of rootPath location', async () => {
+    const rootA = await mkdtemp(join(tmpdir(), 'aco-root-a-'));
+    const rootB = await mkdtemp(join(tmpdir(), 'aco-root-b-'));
+    try {
+      await writeFile(join(rootA, 'CLAUDE.md'), '# shared');
+      await writeFile(join(rootB, 'CLAUDE.md'), '# shared');
+
+      const sourcesA = await discoverSources(rootA);
+      const sourcesB = await discoverSources(rootB);
+
+      const pathsA = sourcesA.map((s) => s.path).sort();
+      const pathsB = sourcesB.map((s) => s.path).sort();
+      assert.deepEqual(pathsA, pathsB, 'Source paths should be identical across different rootPaths');
+    } finally {
+      await rm(rootA, { recursive: true, force: true });
+      await rm(rootB, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4.2  manifest: v2 absolute-path → v3 relative-path migration
+// ---------------------------------------------------------------------------
+
+describe('manifest migration: v2 absolute → v3 relative', () => {
+  it('migrates absolute sourceHashes keys to relative on read', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'aco-mig-test-'));
+    try {
+      await mkdir(join(rootPath, '.aco'), { recursive: true });
+
+      const v2Manifest = {
+        version: '2',
+        generatedAt: '2025-01-01T00:00:00.000Z',
+        sourceHashes: {
+          [`${rootPath}/CLAUDE.md`]: 'abc123',
+          [`${rootPath}/.claude/rules/core.md`]: 'def456',
+        },
+        targetHashes: {},
+        targets: { 'AGENTS.md': { hash: 'xyz', owner: 'aco', kind: 'config' } },
+        skipped: [],
+        warnings: [],
+      };
+
+      await writeFile(
+        join(rootPath, '.aco', 'sync-manifest.json'),
+        JSON.stringify(v2Manifest)
+      );
+
+      const manifest = await readManifest(rootPath);
+      assert.ok(manifest, 'Expected manifest to be read');
+      assert.equal(manifest.version, '3', 'Expected version "3" after migration');
+
+      const keys = Object.keys(manifest.sourceHashes);
+      for (const key of keys) {
+        assert.ok(!key.startsWith('/'), `Expected relative key after migration, got: "${key}"`);
+      }
+      assert.ok(
+        manifest.sourceHashes['CLAUDE.md'] === 'abc123',
+        `Expected "CLAUDE.md" key, got: ${JSON.stringify(keys)}`
+      );
+      assert.ok(
+        manifest.sourceHashes['.claude/rules/core.md'] === 'def456',
+        `Expected ".claude/rules/core.md" key, got: ${JSON.stringify(keys)}`
+      );
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it('already-relative keys pass through migration unchanged', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'aco-mig-rel-'));
+    try {
+      await mkdir(join(rootPath, '.aco'), { recursive: true });
+
+      const v2Manifest = {
+        version: '2',
+        generatedAt: '2025-01-01T00:00:00.000Z',
+        sourceHashes: {
+          'CLAUDE.md': 'abc123',
+        },
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+
+      await writeFile(
+        join(rootPath, '.aco', 'sync-manifest.json'),
+        JSON.stringify(v2Manifest)
+      );
+
+      const manifest = await readManifest(rootPath);
+      assert.ok(manifest);
+      assert.equal(manifest.version, '3');
+      assert.equal(manifest.sourceHashes['CLAUDE.md'], 'abc123');
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4.3  manifest: path outside repo root → warning, not migrated
+// ---------------------------------------------------------------------------
+
+describe('manifest migration: outside-root path handling', () => {
+  it('skips absolute keys outside repo root and adds warning', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'aco-outside-'));
+    try {
+      await mkdir(join(rootPath, '.aco'), { recursive: true });
+
+      const outsidePath = '/etc/secret/credentials.json';
+      const v2Manifest = {
+        version: '2',
+        generatedAt: '2025-01-01T00:00:00.000Z',
+        sourceHashes: {
+          [`${rootPath}/CLAUDE.md`]: 'abc123',
+          [outsidePath]: 'danger',
+        },
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+
+      await writeFile(
+        join(rootPath, '.aco', 'sync-manifest.json'),
+        JSON.stringify(v2Manifest)
+      );
+
+      const manifest = await readManifest(rootPath);
+      assert.ok(manifest);
+      assert.equal(manifest.version, '3');
+
+      const keys = Object.keys(manifest.sourceHashes);
+      assert.ok(
+        !keys.includes(outsidePath),
+        `Outside-root key should have been removed, but found: ${JSON.stringify(keys)}`
+      );
+      assert.ok(
+        manifest.warnings.some((w) => w.message.includes(outsidePath)),
+        `Expected warning mentioning outside path, warnings: ${JSON.stringify(manifest.warnings)}`
+      );
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4.4  calculateDrift: relocated checkout produces no false drift
+// ---------------------------------------------------------------------------
+
+describe('calculateDrift: portable across relocated checkouts', () => {
+  it('returns false drift when same files in different rootPath produce same relative manifest', async () => {
+    const rootA = await mkdtemp(join(tmpdir(), 'aco-drift-a-'));
+    const rootB = await mkdtemp(join(tmpdir(), 'aco-drift-b-'));
+    try {
+      const content = '# hello world';
+      await writeFile(join(rootA, 'CLAUDE.md'), content);
+      await writeFile(join(rootB, 'CLAUDE.md'), content);
+
+      const sourcesA = await discoverSources(rootA);
+      const sourcesB = await discoverSources(rootB);
+
+      const hashesA: Record<string, string> = {};
+      for (const s of sourcesA) hashesA[s.path] = s.hash;
+
+      const hashesB: Record<string, string> = {};
+      for (const s of sourcesB) hashesB[s.path] = s.hash;
+
+      const manifestA: SyncManifest = {
+        version: '3',
+        generatedAt: new Date().toISOString(),
+        sourceHashes: hashesA,
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+      const manifestB: SyncManifest = {
+        version: '3',
+        generatedAt: new Date().toISOString(),
+        sourceHashes: hashesB,
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+
+      const drift = calculateDrift(manifestA, manifestB);
+      assert.equal(drift, false, 'Same content in different checkouts should not drift');
+    } finally {
+      await rm(rootA, { recursive: true, force: true });
+      await rm(rootB, { recursive: true, force: true });
+    }
+  });
+
+  it('returns true drift when file content differs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'aco-drift-diff-'));
+    try {
+      const manifestA: SyncManifest = {
+        version: '3',
+        generatedAt: new Date().toISOString(),
+        sourceHashes: { 'CLAUDE.md': 'hash-v1' },
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+      const manifestB: SyncManifest = {
+        version: '3',
+        generatedAt: new Date().toISOString(),
+        sourceHashes: { 'CLAUDE.md': 'hash-v2' },
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+
+      const drift = calculateDrift(manifestA, manifestB);
+      assert.equal(drift, true, 'Different content hashes should trigger drift');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -737,7 +737,7 @@ describe('Skill Sync', () => {
         await readFile(join(tmpDir, '.aco', 'sync-manifest.json'), 'utf-8')
       );
 
-      assert.equal(manifest.version, '2');
+      assert.equal(manifest.version, '3');
       const targetPath = join(tmpDir, '.agents', 'skills', 'github-kanban-ops');
       const record = manifest.targets[targetPath];
       assert.ok(record, 'Manifest should record the target');
@@ -769,7 +769,7 @@ describe('Skill Sync', () => {
       await runSync(tmpDir, { dryRun: false });
       const manifest = JSON.parse(await readFile(join(acoDir, 'sync-manifest.json'), 'utf-8'));
 
-      assert.equal(manifest.version, '2');
+      assert.equal(manifest.version, '3');
       assert.ok(manifest.targets, 'Migrated manifest should have targets');
       assert.ok(manifest.skipped, 'Migrated manifest should have skipped');
     } finally {


### PR DESCRIPTION
## Summary

- `sync-manifest.json`의 `sourceHashes` 키를 절대 경로에서 repo-relative 경로로 전환하여 다른 체크아웃/CI 환경에서의 drift 오탐을 수정
- `aco ask --input-file`에 credential 파일 차단 guard 추가 (`isCredentialLikePath`)
- provider 실행 전 credential-like 환경변수 이름 경고 추가 (`findCredentialEnvKeys`)

Closes #106

## What

### Manifest 이식성

- `source-discovery.ts`: `SyncSource.path`를 `relative(rootPath, absolutePath)`로 저장
- `manifest.ts`: v2 → v3 마이그레이션 추가 — 기존 절대 경로 `sourceHashes` 키를 상대 경로로 자동 변환
- `sync-engine.ts`: 생성 manifest `version` = `'3'`
- `skill-transform.ts`: `sourceDir = dirname(join(repoRoot, source.path))` — path traversal guard를 위해 절대 경로 복원

### Credential Guard

- `src/util/credential-guard.ts` 신규: `.env*`, `auth.json`, `id_rsa`, `*.pem`, `*.key`, `secrets.*` 등 패턴 기반 탐지
- `commands/ask.ts`: `--input-file` credential 감지 시 exit 1 (차단), `--allow-sensitive` 우회 플래그 지원
- provider 실행 직전 `_TOKEN`, `_KEY`, `_SECRET` 등 suffix를 가진 env key 이름 stderr 경고 (실행 차단 없음)

### 문서

- `docs/security.md`: "Currently Implemented Protections" 및 "Planned Improvements" 섹션 추가

## Why

- `sourceHashes`에 절대 경로가 저장되면 다른 사용자/checkout에서 `aco sync --check`가 모든 source를 changed로 오탐함
- `.env`, SSH 개인 키를 provider에 전달하는 것은 의도치 않은 secret 노출 위험

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `src/sync/source-discovery.ts` | relative path 저장 |
| `src/sync/manifest.ts` | v3 마이그레이션 추가 |
| `src/sync/sync-engine.ts` | version `'3'` 쓰기 |
| `src/sync/skill-transform.ts` | sourceDir absolute 복원 |
| `src/util/credential-guard.ts` | 신규 — credential 탐지 유틸 |
| `src/commands/ask.ts` | guard 통합, env 경고 |
| `tests/sync-manifest-portability.test.ts` | 신규 — 7개 테스트 |
| `tests/credential-guard.test.ts` | 신규 — 35개 테스트 |
| `tests/sync.test.ts` | version assertion `'2'` → `'3'` |
| `docs/security.md` | guard 문서화 |

## Checklist

- [x] `npm test` 272/272 통과
- [x] `npm run typecheck` 통과
- [x] `aco sync --check --strict` 통과
- [x] 생성된 manifest의 `sourceHashes` 키 전체 상대 경로 확인
- [x] credential 차단 / `--allow-sensitive` 우회 동작 확인
- [x] `docs/security.md` 업데이트 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)