### PR TITLE
fix(sync): convert manifest target keys to repo-relative paths

### DIFF
--- a/openspec/changes/sync-manifest-targets-relative-paths/.openspec.yaml
+++ b/openspec/changes/sync-manifest-targets-relative-paths/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/sync-manifest-targets-relative-paths/design.md
+++ b/openspec/changes/sync-manifest-targets-relative-paths/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`sync-engine.ts`의 `computeTransformPlan`은 manifest를 빌드할 때 `output.targetPath`(절대 경로)를 그대로 `targetHashes`/`targets` 키로 사용한다. `sourceHashes`는 이미 PR #117에서 relative 경로로 전환됐으나, target 키는 절대 경로를 유지해 체크아웃 경로가 달라지면(다른 CI 에이전트, clone 위치 변경 등) drift 오탐이 발생한다.
+
+영향 범위:
+- `computeTransformPlan` 내 6개 섹션의 `targetHashes[o.targetPath]`, `targets[o.targetPath]` 할당 (lines 351–439)
+- `runSync`의 conflict 탐지 및 action 결정 로직에서 `existingManifest.targets[output.targetPath]` 읽기 (lines 98–122)
+- `runSync`의 cleanup 로직에서 `delete plan.manifest.targets[path]` (lines 227–234) — `path`는 현재 어디서 오는가에 따라 달라짐
+- `manifest.ts`의 `migrateManifest` — v1 절대 경로 manifest를 v2로 올릴 때도 키가 절대 경로 그대로 유지됨
+
+## Goals / Non-Goals
+
+**Goals:**
+- `targetHashes`/`targets` 키를 `relative(repoRoot, targetPath)`로 저장
+- 읽기 경로(conflict 탐지, action 결정, cleanup)에서 `resolve(repoRoot, relKey)`로 절대 경로 복원
+- `migrateManifest`에서 기존 절대 경로 키를 자동으로 상대 경로로 전환
+- `calculateDrift`가 일관된 경로 형식(상대)으로 비교하도록 보장
+
+**Non-Goals:**
+- `SyncManifest` 타입 인터페이스 변경 없음 (키 형식은 런타임 계약이므로 타입에 별도 인코딩 불필요)
+- `sourceHashes` 경로 처리 변경 없음 (이미 relative)
+- `output.targetPath` 자체를 바꾸지 않음 — 내부 작업 중에는 절대 경로 유지, manifest 직렬화 시점에만 변환
+
+## Decisions
+
+### D1. 변환 위치: 빌드 시점 vs. 직렬화 시점
+
+`computeTransformPlan` 내부의 `targetHashes`/`targets` 빌드 직후 변환한다 (빌드 시점). `writeManifest`나 `calculateDrift`에서 변환하는 대안보다 변환 책임이 한 곳에 집중되어 읽기 경로에서 어떤 형식을 기대하는지 명확하다.
+
+**대안 고려**: `writeManifest`에서 직렬화 시 변환 → 읽기 경로도 변환 필요하지만 `readManifest`에서 복원하면 되므로 가능하나, `computeTransformPlan`이 내부적으로 절대/상대 섞인 구조를 만들어 코드 추적이 어려워짐.
+
+### D2. 읽기 경로의 경로 복원
+
+`runSync`에서 `existingManifest.targets[output.targetPath]`를 읽기 전에 `output.targetPath`에 대응하는 manifest 키를 얻으려면 `relative(repoRoot, output.targetPath)`를 키로 사용해야 한다. 모든 읽기 접근을 헬퍼 함수로 래핑한다:
+
+```ts
+function resolveManifestKey(repoRoot: string, absolutePath: string): string {
+  return relative(repoRoot, absolutePath);
+}
+```
+
+이 헬퍼를 사용하면 절대/상대 혼용 접근이 컴파일 타임에 드러나지 않더라도 단일 경로를 통해 일관성이 보장된다.
+
+### D3. migrateManifest에서의 자동 마이그레이션
+
+v1 manifest의 `targetHashes` 키가 절대 경로인지 판별하여 상대 경로로 전환한다. 판별 기준: `path.isAbsolute(key)`. `repoRoot`를 `migrateManifest`에 전달하여 `relative(repoRoot, key)`를 수행한다. `readManifest`가 `repoRoot`를 받으므로 시그니처 변경 최소화.
+
+### D4. calculateDrift 경로 일관성
+
+`calculateDrift`는 두 manifest를 비교하므로 현재 manifest(relative)와 기존 manifest(마이그레이션 후 relative)가 동일한 형식이면 추가 변환 불필요. 마이그레이션이 `readManifest`에서 보장되므로 `calculateDrift`는 변경 없음.
+
+## Risks / Trade-offs
+
+- **기존 absolute manifest와의 호환성** → `migrateManifest`에서 `path.isAbsolute` 체크로 자동 전환. 롤백 시 이전 버전이 상대 경로 manifest를 읽으면 키를 찾지 못해 `targetHashes` 빈 객체로 처리(= 모든 타겟을 신규로 인식). full `aco sync`를 한 번 실행하면 복구됨.
+- **경로 구분자(Windows)** → repo는 macOS/Linux only. `relative()`/`resolve()`가 POSIX 경로를 반환하므로 문제 없음.
+- **cleanup 로직의 `path` 변수** → `cleanedOwned`/`cleanedForced`에 담긴 경로가 현재 어떤 형식인지 확인 필요. 읽기 경로에서 relative 키를 사용하면 delete도 relative 키로 수행되므로 일관성 유지.
+
+## Migration Plan
+
+1. `computeTransformPlan` 내 `targetHashes`/`targets` 할당 시 relative 경로로 전환
+2. `readManifest` → `migrateManifest` 시그니처에 `repoRoot` 추가, 절대 경로 키 감지 및 전환
+3. `runSync`의 manifest 읽기 경로를 relative 키 기반으로 수정
+4. 기존 `.aco/sync-manifest.json`은 `aco sync` 한 번 실행으로 자동 재생성 (또는 `readManifest` 시 마이그레이션으로 투명하게 처리)
+
+롤백: `git revert` 후 `aco sync`로 manifest 재생성.
+
+## Open Questions
+
+없음.

--- a/openspec/changes/sync-manifest-targets-relative-paths/proposal.md
+++ b/openspec/changes/sync-manifest-targets-relative-paths/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`aco sync --check`가 체크아웃 경로에 따라 drift 오탐을 발생시킨다. PR #117에서 `sourceHashes`는 repo-relative 경로로 전환됐으나 `targetHashes`/`targets` 키는 절대 경로(`output.targetPath`)로 유지되어, CI 환경이나 다른 머신에서 체크아웃 위치가 달라지면 동일한 파일도 변경된 것으로 잘못 감지된다.
+
+## What Changes
+
+- `sync-engine.ts`에서 manifest를 빌드할 때 `targetHashes`/`targets` 키를 `relative(repoRoot, targetPath)`로 변환하여 저장
+- `sync-engine.ts`에서 manifest를 읽을 때 (drift 체크, conflict 탐지, cleanup) 상대 경로를 `resolve(repoRoot, path)`로 절대 경로로 복원
+- `manifest.ts`의 `calculateDrift`가 상대 경로 키를 올바르게 비교할 수 있도록 일관된 경로 형식 보장
+- 기존 절대 경로 manifest에 대한 자동 마이그레이션 경로 제공 (`migrateManifest` 함수 확장)
+
+## Capabilities
+
+### New Capabilities
+
+- `manifest-portable-keys`: manifest의 `targetHashes`/`targets` 키를 repo-relative 경로로 저장·복원하는 메커니즘. 체크아웃 경로가 달라져도 일관된 drift 결과를 보장한다.
+
+### Modified Capabilities
+
+없음. 기존 스펙(`openspec/specs/aco-v2-spec.md`)에는 manifest 키 형식에 대한 명시적 요구사항이 없으므로 spec-level 요구사항 변경 없음.
+
+## Impact
+
+- `packages/wrapper/src/sync/sync-engine.ts`: manifest 빌드 로직(7곳 이상의 `targetPath` 할당) 및 읽기 로직(drift 체크, conflict 탐지, cleanup)
+- `packages/wrapper/src/sync/manifest.ts`: `migrateManifest` 함수 — 절대 경로 기존 manifest를 상대 경로로 자동 변환
+- `.aco/sync-manifest.json`: 기록 형식 변경 (절대 → 상대 경로). 기존 manifest는 마이그레이션으로 자동 처리
+- 외부 API 없음; `aco sync`, `aco sync --check` CLI 동작의 정확성 개선

--- a/openspec/changes/sync-manifest-targets-relative-paths/specs/manifest-portable-keys/spec.md
+++ b/openspec/changes/sync-manifest-targets-relative-paths/specs/manifest-portable-keys/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Manifest target keys stored as repo-relative paths
+The sync engine SHALL store `targetHashes` and `targets` keys in `.aco/sync-manifest.json` as repo-relative POSIX paths (e.g., `AGENTS.md`, `.agents/skills/foo/SKILL.md`) rather than absolute filesystem paths.
+
+#### Scenario: New manifest written after sync
+- **WHEN** `aco sync` completes successfully
+- **THEN** every key in `targetHashes` and `targets` within `.aco/sync-manifest.json` MUST be a relative path with no leading `/`
+
+#### Scenario: Consistent check result across checkout locations
+- **WHEN** `.aco/sync-manifest.json` was written in one checkout location and `aco sync --check` is run from a different checkout location
+- **THEN** the command MUST exit with code 0 (no drift) when no source files have changed
+
+### Requirement: Relative manifest keys resolved to absolute paths during sync execution
+The sync engine SHALL internally resolve relative manifest keys back to absolute paths when comparing against in-memory `SyncOutput.targetPath` values during conflict detection, action determination, and cleanup.
+
+#### Scenario: Conflict detection uses correct absolute path
+- **WHEN** an existing manifest has relative target keys and a new sync plan is computed
+- **THEN** conflict detection MUST correctly match each `SyncOutput.targetPath` (absolute) to its manifest record by resolving the relative key against `repoRoot`
+
+#### Scenario: Cleanup deletes correct manifest entries
+- **WHEN** stale manifest entries are cleaned (owned or forced cleanup)
+- **THEN** `delete plan.manifest.targets[key]` MUST use the same relative-path key format as what was stored
+
+### Requirement: Automatic migration of legacy absolute-path manifests
+The `readManifest` function SHALL detect existing manifests whose `targetHashes`/`targets` keys are absolute paths and transparently convert them to repo-relative paths.
+
+#### Scenario: Legacy absolute-path manifest read on first run after upgrade
+- **WHEN** `.aco/sync-manifest.json` contains absolute-path keys (e.g., `/Users/alice/project/AGENTS.md`)
+- **THEN** `readManifest` MUST return a manifest with all target keys converted to relative paths (e.g., `AGENTS.md`) before returning to callers
+
+#### Scenario: Already-relative manifest unchanged by migration
+- **WHEN** `.aco/sync-manifest.json` already contains relative-path keys
+- **THEN** `readManifest` MUST return the manifest without modification to any key

--- a/openspec/changes/sync-manifest-targets-relative-paths/tasks.md
+++ b/openspec/changes/sync-manifest-targets-relative-paths/tasks.md
@@ -1,0 +1,30 @@
+## 1. manifest.ts — 마이그레이션 및 읽기 경로
+
+- [x] 1.1 `readManifest` 시그니처에 `repoRoot: string` 파라미터 추가
+- [x] 1.2 `migrateManifest`에 `repoRoot` 파라미터 추가하고, `targetHashes`/`targets` 키 중 `path.isAbsolute(key)`인 경우 `relative(repoRoot, key)`로 변환
+- [x] 1.3 `readManifest` 호출부(`sync-engine.ts`)에서 `repoRoot` 인자 전달
+
+## 2. sync-engine.ts — manifest 빌드(쓰기 경로)
+
+- [x] 2.1 `computeTransformPlan` 내 AGENTS.md/GEMINI.md 섹션의 `targetHashes[agentsMdPath]`, `targets[agentsMdPath]` 할당을 `relative(repoRoot, agentsMdPath)` 키로 변경
+- [x] 2.2 skills, Codex agents, Gemini agents, Codex hooks, Gemini hooks 각 섹션의 `targetHashes[o.targetPath]`, `targets[o.targetPath]` 할당을 `relative(repoRoot, o.targetPath)` 키로 변경 (총 5개 섹션)
+
+## 3. sync-engine.ts — manifest 읽기 경로(conflict 탐지, action 결정, cleanup)
+
+- [x] 3.1 conflict 탐지 루프에서 `existingManifest.targets[output.targetPath]` → `existingManifest.targets[relative(repoRoot, output.targetPath)]`로 수정 (line ~98)
+- [x] 3.2 `existingManifest.targetHashes[output.targetPath]` 참조도 relative 키로 수정 (line ~99)
+- [x] 3.3 action 결정 루프에서 `existingManifest?.targets[output.targetPath]` → relative 키로 수정 (line ~121–122)
+- [x] 3.4 cleanup 로직에서 `cleanedOwned`/`cleanedForced` 경로가 어떤 형식인지 확인하고, `delete plan.manifest.targets[path]`/`targetHashes[path]`를 일관된 relative 키로 수정 (lines ~227–234)
+
+## 4. 테스트
+
+- [x] 4.1 `manifest.ts` 단위 테스트: 절대 경로 키를 가진 legacy manifest를 `readManifest`에 전달하면 relative 키로 변환되는지 검증
+- [x] 4.2 `sync-engine.ts` 통합 테스트: 다른 `repoRoot` 값으로 `aco sync --check`를 실행했을 때 false positive drift가 발생하지 않는지 검증
+- [x] 4.3 기존 fixture 테스트(`npm run test:fixtures`) 통과 확인
+
+## 5. 검증
+
+- [x] 5.1 `npm run typecheck` 통과
+- [x] 5.2 `npm test` 통과
+- [x] 5.3 `aco sync` 실행 후 `.aco/sync-manifest.json`에서 `targetHashes`/`targets` 키가 relative 경로인지 직접 확인
+- [x] 5.4 `aco sync --check`가 재실행 시 exit 0 반환 확인

--- a/packages/wrapper/src/sync/manifest.ts
+++ b/packages/wrapper/src/sync/manifest.ts
@@ -59,7 +59,7 @@ export function calculateDrift(current: SyncManifest | null, updated: SyncManife
  *   v2 (absolute sourceHashes) → v3 (repo-relative sourceHashes)
  *   v3 (absolute targetHashes/targets keys) → v4 (repo-relative targetHashes/targets keys)
  */
-function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): SyncManifest {
+function migrateManifest(parsed: Partial<SyncManifest>, rootPath: string): SyncManifest {
   const legacy = parsed as Record<string, unknown>;
 
   // v1 → v2: add ownership-aware targets
@@ -93,14 +93,6 @@ function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): Sync
     const migratedHashes: Record<string, string> = {};
     for (const [key, hash] of Object.entries(sourceHashes)) {
       if (isAbsolute(key)) {
-        if (!rootPath) {
-          warnings.push({
-            severity: 'warning',
-            source: 'manifest-migration',
-            message: `Cannot migrate absolute sourceHash key "${key}": rootPath unavailable`,
-          });
-          continue;
-        }
         const rel = relative(rootPath, key);
         if (rel.startsWith('..')) {
           warnings.push({
@@ -120,33 +112,34 @@ function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): Sync
     legacy.warnings = warnings;
   }
 
-  // → v4: convert absolute targetHashes/targets keys to repo-relative
+  // → v4: convert absolute targetHashes/targets keys to repo-relative.
+  // aco가 생성하는 target은 항상 repoRoot 내부이므로 relative()의 `../` 분기는
+  // 실무상 도달 불가하다. 방어적으로 원본 절대 키를 유지하지만 sourceHashes처럼
+  // drop+warning하지는 않는다.
   if (versionNum < 4) {
-    if (rootPath) {
-      const targetHashes = (legacy.targetHashes as Record<string, string>) || {};
-      const migratedTargetHashes: Record<string, string> = {};
-      for (const [key, hash] of Object.entries(targetHashes)) {
-        if (isAbsolute(key)) {
-          const rel = relative(rootPath, key);
-          migratedTargetHashes[rel.startsWith('..') ? key : rel] = hash;
-        } else {
-          migratedTargetHashes[key] = hash;
-        }
+    const targetHashes = (legacy.targetHashes as Record<string, string>) || {};
+    const migratedTargetHashes: Record<string, string> = {};
+    for (const [key, hash] of Object.entries(targetHashes)) {
+      if (isAbsolute(key)) {
+        const rel = relative(rootPath, key);
+        migratedTargetHashes[rel.startsWith('..') ? key : rel] = hash;
+      } else {
+        migratedTargetHashes[key] = hash;
       }
-      legacy.targetHashes = migratedTargetHashes;
-
-      const targets = (legacy.targets as Record<string, ManifestTargetRecord>) || {};
-      const migratedTargets: Record<string, ManifestTargetRecord> = {};
-      for (const [key, record] of Object.entries(targets)) {
-        if (isAbsolute(key)) {
-          const rel = relative(rootPath, key);
-          migratedTargets[rel.startsWith('..') ? key : rel] = record;
-        } else {
-          migratedTargets[key] = record;
-        }
-      }
-      legacy.targets = migratedTargets;
     }
+    legacy.targetHashes = migratedTargetHashes;
+
+    const targets = (legacy.targets as Record<string, ManifestTargetRecord>) || {};
+    const migratedTargets: Record<string, ManifestTargetRecord> = {};
+    for (const [key, record] of Object.entries(targets)) {
+      if (isAbsolute(key)) {
+        const rel = relative(rootPath, key);
+        migratedTargets[rel.startsWith('..') ? key : rel] = record;
+      } else {
+        migratedTargets[key] = record;
+      }
+    }
+    legacy.targets = migratedTargets;
     legacy.version = '4';
   }
 

--- a/packages/wrapper/src/sync/manifest.ts
+++ b/packages/wrapper/src/sync/manifest.ts
@@ -57,6 +57,7 @@ export function calculateDrift(current: SyncManifest | null, updated: SyncManife
  * Migrate a manifest through version history:
  *   v1 (targetHashes only) → v2 (ownership-aware targets)
  *   v2 (absolute sourceHashes) → v3 (repo-relative sourceHashes)
+ *   v3 (absolute targetHashes/targets keys) → v4 (repo-relative targetHashes/targets keys)
  */
 function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): SyncManifest {
   const legacy = parsed as Record<string, unknown>;
@@ -82,12 +83,13 @@ function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): Sync
     legacy.warnings = legacy.warnings ?? [];
   }
 
-  // v2 → v3: convert absolute sourceHashes keys to repo-relative
-  const rawVersion = (legacy.version as string) || '2';
-  const sourceHashes = (legacy.sourceHashes as Record<string, string>) || {};
+  // Numeric version gate: each step runs when the manifest predates that step.
+  const versionNum = Number.parseInt((legacy.version as string) || '2', 10) || 0;
   const warnings: SyncWarning[] = (legacy.warnings as SyncWarning[]) || [];
 
-  if (rawVersion !== '3') {
+  // → v3: convert absolute sourceHashes keys to repo-relative
+  if (versionNum < 3) {
+    const sourceHashes = (legacy.sourceHashes as Record<string, string>) || {};
     const migratedHashes: Record<string, string> = {};
     for (const [key, hash] of Object.entries(sourceHashes)) {
       if (isAbsolute(key)) {
@@ -118,8 +120,38 @@ function migrateManifest(parsed: Partial<SyncManifest>, rootPath?: string): Sync
     legacy.warnings = warnings;
   }
 
+  // → v4: convert absolute targetHashes/targets keys to repo-relative
+  if (versionNum < 4) {
+    if (rootPath) {
+      const targetHashes = (legacy.targetHashes as Record<string, string>) || {};
+      const migratedTargetHashes: Record<string, string> = {};
+      for (const [key, hash] of Object.entries(targetHashes)) {
+        if (isAbsolute(key)) {
+          const rel = relative(rootPath, key);
+          migratedTargetHashes[rel.startsWith('..') ? key : rel] = hash;
+        } else {
+          migratedTargetHashes[key] = hash;
+        }
+      }
+      legacy.targetHashes = migratedTargetHashes;
+
+      const targets = (legacy.targets as Record<string, ManifestTargetRecord>) || {};
+      const migratedTargets: Record<string, ManifestTargetRecord> = {};
+      for (const [key, record] of Object.entries(targets)) {
+        if (isAbsolute(key)) {
+          const rel = relative(rootPath, key);
+          migratedTargets[rel.startsWith('..') ? key : rel] = record;
+        } else {
+          migratedTargets[key] = record;
+        }
+      }
+      legacy.targets = migratedTargets;
+    }
+    legacy.version = '4';
+  }
+
   return {
-    version: '3',
+    version: '4',
     generatedAt: (legacy.generatedAt as string) || new Date().toISOString(),
     sourceHashes: (legacy.sourceHashes as Record<string, string>) || {},
     targetHashes: (legacy.targetHashes as Record<string, string>) || {},

--- a/packages/wrapper/src/sync/skill-transform.ts
+++ b/packages/wrapper/src/sync/skill-transform.ts
@@ -76,8 +76,13 @@ export async function syncSkills(
   // Determine which skills to remove: previously synced but source no longer exists or is no longer eligible
   const staleTargets: string[] = [];
 
+  // Manifest target keys are repo-relative; resolve them to absolute filesystem
+  // paths for hash checks and removal. Tolerate legacy absolute keys defensively.
+  const toAbsoluteTarget = (key: string): string => (isAbsolute(key) ? key : join(repoRoot, key));
+
   if (manifest) {
-    for (const [targetPath, record] of Object.entries(manifest.targets ?? {})) {
+    for (const [targetKey, record] of Object.entries(manifest.targets ?? {})) {
+      const targetPath = toAbsoluteTarget(targetKey);
       if (!targetPath.startsWith(targetBase)) continue;
       // Find if this target corresponds to a skill that still exists and is still eligible
       const skillName = basename(targetPath);
@@ -111,16 +116,17 @@ export async function syncSkills(
     }
 
     // Also check legacy targetHashes
-    for (const [targetPath] of Object.entries(manifest.targetHashes)) {
+    for (const [targetKey] of Object.entries(manifest.targetHashes)) {
+      const targetPath = toAbsoluteTarget(targetKey);
       if (!targetPath.startsWith(targetBase)) continue;
-      if (manifest.targets?.[targetPath]) continue; // already handled above
+      if (manifest.targets?.[targetKey]) continue; // already handled above
       const skillName = basename(targetPath);
       const stillExistsAndEligible = classifiedSkills.some(
         (c) => c.skillName === skillName && c.owner === 'aco'
       );
       if (!stillExistsAndEligible) {
         // Legacy: assume it was ACO-owned; check hash
-        const legacyHash = manifest.targetHashes[targetPath];
+        const legacyHash = manifest.targetHashes[targetKey];
         const match = await legacySkillHashMatches(targetPath, legacyHash);
         if (match) {
           const stat = await lstat(targetPath);

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -48,6 +48,14 @@ function isPathWithinRepo(root: string, target: string, allowed: string[]): bool
 }
 
 /**
+ * Convert an absolute target path to a repo-relative manifest key.
+ * Manifest keys are always stored as repo-relative paths (no leading slash).
+ */
+function resolveManifestKey(repoRoot: string, absolutePath: string): string {
+  return relative(repoRoot, absolutePath);
+}
+
+/**
  * Run the context sync engine.
  *
  * @param repoRoot - The repository root path.
@@ -95,8 +103,9 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
   // 6. Detect conflicts for planned outputs against existing manifest
   if (existingManifest) {
     for (const output of plan.outputs) {
-      const existingRecord = existingManifest.targets[output.targetPath];
-      const existingHash = existingRecord?.hash ?? existingManifest.targetHashes[output.targetPath];
+      const manifestKey = resolveManifestKey(repoRoot, output.targetPath);
+      const existingRecord = existingManifest.targets[manifestKey];
+      const existingHash = existingRecord?.hash ?? existingManifest.targetHashes[manifestKey];
       if (existingHash && (output.kind === 'file' || output.kind === 'managed-block')) {
         try {
           const diskContent = await readFile(output.targetPath, 'utf8');
@@ -118,8 +127,9 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
     if (output.action === 'conflict') continue;
     if (output.action === 'removed') continue;
 
-    const existingRecord = existingManifest?.targets[output.targetPath];
-    const existingHash = existingRecord?.hash ?? existingManifest?.targetHashes[output.targetPath];
+    const manifestKey = resolveManifestKey(repoRoot, output.targetPath);
+    const existingRecord = existingManifest?.targets[manifestKey];
+    const existingHash = existingRecord?.hash ?? existingManifest?.targetHashes[manifestKey];
     if (!existingHash) {
       output.action = 'created';
     } else if (existingHash === output.hash) {
@@ -186,7 +196,8 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
       const targets = warning.cleanupTargets;
       if (targets && targets.length > 0) {
         for (const targetPath of targets) {
-          const isOwned = existingManifest?.targets?.[targetPath]?.owner === 'aco';
+          const targetKey = resolveManifestKey(repoRoot, targetPath);
+          const isOwned = existingManifest?.targets?.[targetKey]?.owner === 'aco';
           if (!dryRun && (isOwned || forceClean)) {
             const allowedDirs = ['.agents/skills', '.codex/skills'];
             if (!isPathWithinRepo(repoRoot, targetPath, allowedDirs)) {
@@ -226,12 +237,14 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
 
     // Remove cleaned paths from plan.manifest.targets
     for (const path of cleanedOwned) {
-      delete plan.manifest.targetHashes[path];
-      delete plan.manifest.targets[path];
+      const key = resolveManifestKey(repoRoot, path);
+      delete plan.manifest.targetHashes[key];
+      delete plan.manifest.targets[key];
     }
     for (const path of cleanedForced) {
-      delete plan.manifest.targetHashes[path];
-      delete plan.manifest.targets[path];
+      const key = resolveManifestKey(repoRoot, path);
+      delete plan.manifest.targetHashes[key];
+      delete plan.manifest.targets[key];
     }
     if (cleanedPaths.size > 0) {
       plan.outputs = plan.outputs.filter(
@@ -348,8 +361,9 @@ async function computeTransformPlan(
       owner: 'aco',
       assetKind: 'config',
     });
-    targetHashes[agentsMdPath] = agentsHash;
-    targets[agentsMdPath] = { hash: agentsHash, owner: 'aco', kind: 'config' };
+    const agentsMdKey = relative(repoRoot, agentsMdPath);
+    targetHashes[agentsMdKey] = agentsHash;
+    targets[agentsMdKey] = { hash: agentsHash, owner: 'aco', kind: 'config' };
 
     const updatedGemini = await getManagedBlockUpdate(geminiMdPath, contextContent);
     const geminiHash = computeHash(updatedGemini);
@@ -362,8 +376,9 @@ async function computeTransformPlan(
       owner: 'aco',
       assetKind: 'config',
     });
-    targetHashes[geminiMdPath] = geminiHash;
-    targets[geminiMdPath] = { hash: geminiHash, owner: 'aco', kind: 'config' };
+    const geminiMdKey = relative(repoRoot, geminiMdPath);
+    targetHashes[geminiMdKey] = geminiHash;
+    targets[geminiMdKey] = { hash: geminiHash, owner: 'aco', kind: 'config' };
   }
 
   // 2. Skills
@@ -373,8 +388,9 @@ async function computeTransformPlan(
   skipped.push(...skillResult.skipped);
   for (const o of skillResult.outputs) {
     if (o.hash) {
-      targetHashes[o.targetPath] = o.hash;
-      targets[o.targetPath] = {
+      const key = relative(repoRoot, o.targetPath);
+      targetHashes[key] = o.hash;
+      targets[key] = {
         hash: o.hash,
         owner: o.owner ?? 'aco',
         kind: o.assetKind ?? 'shared-skill',
@@ -390,8 +406,9 @@ async function computeTransformPlan(
   warnings.push(...codexAgentResult.warnings);
   for (const o of codexAgentResult.outputs) {
     if (o.hash) {
-      targetHashes[o.targetPath] = o.hash;
-      targets[o.targetPath] = {
+      const key = relative(repoRoot, o.targetPath);
+      targetHashes[key] = o.hash;
+      targets[key] = {
         hash: o.hash,
         owner: 'aco',
         kind: o.assetKind ?? 'agent',
@@ -405,8 +422,9 @@ async function computeTransformPlan(
   warnings.push(...geminiAgentResult.warnings);
   for (const o of geminiAgentResult.outputs) {
     if (o.hash) {
-      targetHashes[o.targetPath] = o.hash;
-      targets[o.targetPath] = {
+      const key = relative(repoRoot, o.targetPath);
+      targetHashes[key] = o.hash;
+      targets[key] = {
         hash: o.hash,
         owner: 'aco',
         kind: o.assetKind ?? 'agent',
@@ -420,8 +438,9 @@ async function computeTransformPlan(
   warnings.push(...codexHookResult.warnings);
   for (const o of codexHookResult.outputs) {
     if (o.hash) {
-      targetHashes[o.targetPath] = o.hash;
-      targets[o.targetPath] = {
+      const key = relative(repoRoot, o.targetPath);
+      targetHashes[key] = o.hash;
+      targets[key] = {
         hash: o.hash,
         owner: 'aco',
         kind: o.assetKind ?? 'provider-command',
@@ -435,8 +454,9 @@ async function computeTransformPlan(
   warnings.push(...geminiHookResult.warnings);
   for (const o of geminiHookResult.outputs) {
     if (o.hash) {
-      targetHashes[o.targetPath] = o.hash;
-      targets[o.targetPath] = {
+      const key = relative(repoRoot, o.targetPath);
+      targetHashes[key] = o.hash;
+      targets[key] = {
         hash: o.hash,
         owner: 'aco',
         kind: o.assetKind ?? 'provider-command',
@@ -445,7 +465,7 @@ async function computeTransformPlan(
   }
 
   const manifest: SyncManifest = {
-    version: '3',
+    version: '4',
     generatedAt: new Date().toISOString(),
     sourceHashes,
     targetHashes,

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -51,7 +51,7 @@ function isPathWithinRepo(root: string, target: string, allowed: string[]): bool
  * Convert an absolute target path to a repo-relative manifest key.
  * Manifest keys are always stored as repo-relative paths (no leading slash).
  */
-function resolveManifestKey(repoRoot: string, absolutePath: string): string {
+function toManifestKey(repoRoot: string, absolutePath: string): string {
   return relative(repoRoot, absolutePath);
 }
 
@@ -103,7 +103,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
   // 6. Detect conflicts for planned outputs against existing manifest
   if (existingManifest) {
     for (const output of plan.outputs) {
-      const manifestKey = resolveManifestKey(repoRoot, output.targetPath);
+      const manifestKey = toManifestKey(repoRoot, output.targetPath);
       const existingRecord = existingManifest.targets[manifestKey];
       const existingHash = existingRecord?.hash ?? existingManifest.targetHashes[manifestKey];
       if (existingHash && (output.kind === 'file' || output.kind === 'managed-block')) {
@@ -127,7 +127,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
     if (output.action === 'conflict') continue;
     if (output.action === 'removed') continue;
 
-    const manifestKey = resolveManifestKey(repoRoot, output.targetPath);
+    const manifestKey = toManifestKey(repoRoot, output.targetPath);
     const existingRecord = existingManifest?.targets[manifestKey];
     const existingHash = existingRecord?.hash ?? existingManifest?.targetHashes[manifestKey];
     if (!existingHash) {
@@ -196,7 +196,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
       const targets = warning.cleanupTargets;
       if (targets && targets.length > 0) {
         for (const targetPath of targets) {
-          const targetKey = resolveManifestKey(repoRoot, targetPath);
+          const targetKey = toManifestKey(repoRoot, targetPath);
           const isOwned = existingManifest?.targets?.[targetKey]?.owner === 'aco';
           if (!dryRun && (isOwned || forceClean)) {
             const allowedDirs = ['.agents/skills', '.codex/skills'];
@@ -237,12 +237,12 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
 
     // Remove cleaned paths from plan.manifest.targets
     for (const path of cleanedOwned) {
-      const key = resolveManifestKey(repoRoot, path);
+      const key = toManifestKey(repoRoot, path);
       delete plan.manifest.targetHashes[key];
       delete plan.manifest.targets[key];
     }
     for (const path of cleanedForced) {
-      const key = resolveManifestKey(repoRoot, path);
+      const key = toManifestKey(repoRoot, path);
       delete plan.manifest.targetHashes[key];
       delete plan.manifest.targets[key];
     }
@@ -361,7 +361,7 @@ async function computeTransformPlan(
       owner: 'aco',
       assetKind: 'config',
     });
-    const agentsMdKey = relative(repoRoot, agentsMdPath);
+    const agentsMdKey = toManifestKey(repoRoot, agentsMdPath);
     targetHashes[agentsMdKey] = agentsHash;
     targets[agentsMdKey] = { hash: agentsHash, owner: 'aco', kind: 'config' };
 
@@ -376,7 +376,7 @@ async function computeTransformPlan(
       owner: 'aco',
       assetKind: 'config',
     });
-    const geminiMdKey = relative(repoRoot, geminiMdPath);
+    const geminiMdKey = toManifestKey(repoRoot, geminiMdPath);
     targetHashes[geminiMdKey] = geminiHash;
     targets[geminiMdKey] = { hash: geminiHash, owner: 'aco', kind: 'config' };
   }
@@ -388,7 +388,7 @@ async function computeTransformPlan(
   skipped.push(...skillResult.skipped);
   for (const o of skillResult.outputs) {
     if (o.hash) {
-      const key = relative(repoRoot, o.targetPath);
+      const key = toManifestKey(repoRoot, o.targetPath);
       targetHashes[key] = o.hash;
       targets[key] = {
         hash: o.hash,
@@ -406,7 +406,7 @@ async function computeTransformPlan(
   warnings.push(...codexAgentResult.warnings);
   for (const o of codexAgentResult.outputs) {
     if (o.hash) {
-      const key = relative(repoRoot, o.targetPath);
+      const key = toManifestKey(repoRoot, o.targetPath);
       targetHashes[key] = o.hash;
       targets[key] = {
         hash: o.hash,
@@ -422,7 +422,7 @@ async function computeTransformPlan(
   warnings.push(...geminiAgentResult.warnings);
   for (const o of geminiAgentResult.outputs) {
     if (o.hash) {
-      const key = relative(repoRoot, o.targetPath);
+      const key = toManifestKey(repoRoot, o.targetPath);
       targetHashes[key] = o.hash;
       targets[key] = {
         hash: o.hash,
@@ -438,7 +438,7 @@ async function computeTransformPlan(
   warnings.push(...codexHookResult.warnings);
   for (const o of codexHookResult.outputs) {
     if (o.hash) {
-      const key = relative(repoRoot, o.targetPath);
+      const key = toManifestKey(repoRoot, o.targetPath);
       targetHashes[key] = o.hash;
       targets[key] = {
         hash: o.hash,
@@ -454,7 +454,7 @@ async function computeTransformPlan(
   warnings.push(...geminiHookResult.warnings);
   for (const o of geminiHookResult.outputs) {
     if (o.hash) {
-      const key = relative(repoRoot, o.targetPath);
+      const key = toManifestKey(repoRoot, o.targetPath);
       targetHashes[key] = o.hash;
       targets[key] = {
         hash: o.hash,

--- a/packages/wrapper/tests/sync-conflict.test.ts
+++ b/packages/wrapper/tests/sync-conflict.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdtemp, mkdir, writeFile, readFile, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative } from 'node:path';
 import { runSync } from '../src/sync/sync-engine.js';
 import { computeHash } from '../src/sync/hash.js';
 import type { SyncManifest } from '../src/sync/transform-interface.js';
@@ -96,11 +96,12 @@ describe('runSync Conflict Detection & Resolution', () => {
       assert.notEqual(finalContent, editedContent);
       assert.ok(finalContent.includes('name = "test-agent"'));
 
-      // Verify manifest was updated with new hash
+      // Verify manifest was updated with new hash (keys are now repo-relative)
       const manifestPath = join(tmpDir, '.aco', 'sync-manifest.json');
       const manifestRaw = await readFile(manifestPath, 'utf-8');
       const manifest = JSON.parse(manifestRaw) as SyncManifest;
-      assert.equal(manifest.targetHashes[targetPath], computeHash(finalContent));
+      const relKey = relative(tmpDir, targetPath);
+      assert.equal(manifest.targetHashes[relKey], computeHash(finalContent));
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }

--- a/packages/wrapper/tests/sync-manifest-portability.test.ts
+++ b/packages/wrapper/tests/sync-manifest-portability.test.ts
@@ -1,10 +1,11 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdtemp, mkdir, writeFile, readFile, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { discoverSources } from '../src/sync/source-discovery.js';
 import { readManifest, writeManifest, calculateDrift } from '../src/sync/manifest.js';
+import { runSync } from '../src/sync/sync-engine.js';
 import type { SyncManifest } from '../src/sync/transform-interface.js';
 
 // ---------------------------------------------------------------------------
@@ -92,7 +93,7 @@ describe('manifest migration: v2 absolute → v3 relative', () => {
 
       const manifest = await readManifest(rootPath);
       assert.ok(manifest, 'Expected manifest to be read');
-      assert.equal(manifest.version, '3', 'Expected version "3" after migration');
+      assert.equal(manifest.version, '4', 'Expected version "4" after migration');
 
       const keys = Object.keys(manifest.sourceHashes);
       for (const key of keys) {
@@ -135,7 +136,7 @@ describe('manifest migration: v2 absolute → v3 relative', () => {
 
       const manifest = await readManifest(rootPath);
       assert.ok(manifest);
-      assert.equal(manifest.version, '3');
+      assert.equal(manifest.version, '4');
       assert.equal(manifest.sourceHashes['CLAUDE.md'], 'abc123');
     } finally {
       await rm(rootPath, { recursive: true, force: true });
@@ -174,7 +175,7 @@ describe('manifest migration: outside-root path handling', () => {
 
       const manifest = await readManifest(rootPath);
       assert.ok(manifest);
-      assert.equal(manifest.version, '3');
+      assert.equal(manifest.version, '4');
 
       const keys = Object.keys(manifest.sourceHashes);
       assert.ok(
@@ -266,6 +267,160 @@ describe('calculateDrift: portable across relocated checkouts', () => {
       assert.equal(drift, true, 'Different content hashes should trigger drift');
     } finally {
       await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4.5  manifest: targetHashes/targets key migration — absolute → relative
+// ---------------------------------------------------------------------------
+
+describe('manifest migration: targetHashes/targets absolute → relative', () => {
+  it('migrates absolute targetHashes keys to relative on read', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'aco-tgt-mig-'));
+    try {
+      await mkdir(join(rootPath, '.aco'), { recursive: true });
+
+      const absoluteAgentsMd = `${rootPath}/AGENTS.md`;
+      const absoluteGeminiMd = `${rootPath}/GEMINI.md`;
+
+      const legacyManifest = {
+        version: '3',
+        generatedAt: '2025-01-01T00:00:00.000Z',
+        sourceHashes: { 'CLAUDE.md': 'abc123' },
+        targetHashes: {
+          [absoluteAgentsMd]: 'hash-agents',
+          [absoluteGeminiMd]: 'hash-gemini',
+        },
+        targets: {
+          [absoluteAgentsMd]: { hash: 'hash-agents', owner: 'aco', kind: 'config' },
+          [absoluteGeminiMd]: { hash: 'hash-gemini', owner: 'aco', kind: 'config' },
+        },
+        skipped: [],
+        warnings: [],
+      };
+
+      await writeFile(
+        join(rootPath, '.aco', 'sync-manifest.json'),
+        JSON.stringify(legacyManifest)
+      );
+
+      const manifest = await readManifest(rootPath);
+      assert.ok(manifest, 'Expected manifest to be read');
+
+      // All targetHashes keys must be relative (no leading /)
+      for (const key of Object.keys(manifest.targetHashes)) {
+        assert.ok(!key.startsWith('/'), `targetHashes key must be relative, got: "${key}"`);
+      }
+      // All targets keys must be relative
+      for (const key of Object.keys(manifest.targets)) {
+        assert.ok(!key.startsWith('/'), `targets key must be relative, got: "${key}"`);
+      }
+
+      assert.equal(
+        manifest.targetHashes['AGENTS.md'],
+        'hash-agents',
+        'Expected AGENTS.md relative key in targetHashes'
+      );
+      assert.equal(
+        manifest.targetHashes['GEMINI.md'],
+        'hash-gemini',
+        'Expected GEMINI.md relative key in targetHashes'
+      );
+      assert.ok(manifest.targets['AGENTS.md'], 'Expected AGENTS.md relative key in targets');
+      assert.ok(manifest.targets['GEMINI.md'], 'Expected GEMINI.md relative key in targets');
+      assert.equal(manifest.targets['AGENTS.md'].hash, 'hash-agents');
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+
+  it('already-relative targetHashes/targets keys pass through unchanged', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'aco-tgt-rel-'));
+    try {
+      await mkdir(join(rootPath, '.aco'), { recursive: true });
+
+      const legacyManifest = {
+        version: '3',
+        generatedAt: '2025-01-01T00:00:00.000Z',
+        sourceHashes: { 'CLAUDE.md': 'abc123' },
+        targetHashes: {
+          'AGENTS.md': 'hash-agents',
+        },
+        targets: {
+          'AGENTS.md': { hash: 'hash-agents', owner: 'aco', kind: 'config' },
+        },
+        skipped: [],
+        warnings: [],
+      };
+
+      await writeFile(
+        join(rootPath, '.aco', 'sync-manifest.json'),
+        JSON.stringify(legacyManifest)
+      );
+
+      const manifest = await readManifest(rootPath);
+      assert.ok(manifest);
+      assert.equal(manifest.targetHashes['AGENTS.md'], 'hash-agents');
+      assert.ok(manifest.targets['AGENTS.md']);
+    } finally {
+      await rm(rootPath, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4.6  sync-engine: cross-checkout -- no false drift in aco sync --check
+// ---------------------------------------------------------------------------
+
+describe('runSync: portable target keys across checkout locations', () => {
+  it('aco sync --check returns no drift when run from a different repoRoot with same content', async () => {
+    // rootA: run full sync, producing a manifest with relative target keys
+    const rootA = await realpath(await mkdtemp(join(tmpdir(), 'aco-xchk-a-')));
+    // rootB: same structure/content in a different directory
+    const rootB = await realpath(await mkdtemp(join(tmpdir(), 'aco-xchk-b-')));
+    try {
+      const claudeContent = '# shared context\n\nSome shared rules.';
+      for (const root of [rootA, rootB]) {
+        await writeFile(join(root, 'CLAUDE.md'), claudeContent);
+      }
+
+      // Run full sync on rootA to produce manifest
+      await runSync(rootA, { dryRun: false });
+
+      // Read the manifest produced by rootA
+      const manifestRaw = await readFile(join(rootA, '.aco', 'sync-manifest.json'), 'utf-8');
+      const manifestObj = JSON.parse(manifestRaw) as SyncManifest;
+
+      // Verify that manifest already has relative target keys (spec scenario 1)
+      for (const key of Object.keys(manifestObj.targetHashes)) {
+        assert.ok(!key.startsWith('/'), `targetHashes key must be relative after sync, got: "${key}"`);
+      }
+      for (const key of Object.keys(manifestObj.targets)) {
+        assert.ok(!key.startsWith('/'), `targets key must be relative after sync, got: "${key}"`);
+      }
+
+      // Copy the manifest to rootB (simulating a different checkout with the same manifest)
+      await mkdir(join(rootB, '.aco'), { recursive: true });
+
+      // For the cross-checkout test, we also need to create the same output files in rootB
+      // that the manifest references (AGENTS.md, GEMINI.md), with the same content/hashes
+      // We do this by running full sync on rootB too, then overwriting its manifest with rootA's
+      // (to simulate writing on one machine, checking on another)
+      await runSync(rootB, { dryRun: false });
+
+      // Now overwrite rootB's manifest with rootA's manifest.
+      // Both manifests should have identical relative-path keys and hashes
+      // since the source content is the same.
+      // Verify aco sync --check on rootB passes (exit 0 = no error)
+      // If target keys were absolute, rootB's check would find different keys than its disk paths.
+      await assert.doesNotReject(
+        runSync(rootB, { check: true }),
+        'aco sync --check should not detect drift when manifest has relative target keys'
+      );
+    } finally {
+      await rm(rootA, { recursive: true, force: true });
+      await rm(rootB, { recursive: true, force: true });
     }
   });
 });

--- a/packages/wrapper/tests/sync-manifest-portability.test.ts
+++ b/packages/wrapper/tests/sync-manifest-portability.test.ts
@@ -374,25 +374,25 @@ describe('manifest migration: targetHashes/targets absolute → relative', () =>
 // ---------------------------------------------------------------------------
 
 describe('runSync: portable target keys across checkout locations', () => {
-  it('aco sync --check returns no drift when run from a different repoRoot with same content', async () => {
-    // rootA: run full sync, producing a manifest with relative target keys
+  it('aco sync --check returns no drift when the manifest is written in one checkout and checked in another', async () => {
+    // Two independent checkout locations with identical source content.
     const rootA = await realpath(await mkdtemp(join(tmpdir(), 'aco-xchk-a-')));
-    // rootB: same structure/content in a different directory
     const rootB = await realpath(await mkdtemp(join(tmpdir(), 'aco-xchk-b-')));
     try {
+      // 1. Set up the same source tree in both checkouts.
       const claudeContent = '# shared context\n\nSome shared rules.';
       for (const root of [rootA, rootB]) {
         await writeFile(join(root, 'CLAUDE.md'), claudeContent);
       }
 
-      // Run full sync on rootA to produce manifest
+      // 2. Run a full sync in rootA: produces sync outputs (AGENTS.md/GEMINI.md)
+      //    and a manifest with repo-relative target keys.
       await runSync(rootA, { dryRun: false });
 
-      // Read the manifest produced by rootA
       const manifestRaw = await readFile(join(rootA, '.aco', 'sync-manifest.json'), 'utf-8');
       const manifestObj = JSON.parse(manifestRaw) as SyncManifest;
 
-      // Verify that manifest already has relative target keys (spec scenario 1)
+      // Sanity check: the manifest rootA wrote uses relative target keys (spec scenario 1).
       for (const key of Object.keys(manifestObj.targetHashes)) {
         assert.ok(!key.startsWith('/'), `targetHashes key must be relative after sync, got: "${key}"`);
       }
@@ -400,23 +400,21 @@ describe('runSync: portable target keys across checkout locations', () => {
         assert.ok(!key.startsWith('/'), `targets key must be relative after sync, got: "${key}"`);
       }
 
-      // Copy the manifest to rootB (simulating a different checkout with the same manifest)
-      await mkdir(join(rootB, '.aco'), { recursive: true });
-
-      // For the cross-checkout test, we also need to create the same output files in rootB
-      // that the manifest references (AGENTS.md, GEMINI.md), with the same content/hashes
-      // We do this by running full sync on rootB too, then overwriting its manifest with rootA's
-      // (to simulate writing on one machine, checking on another)
+      // 3. Run a full sync in rootB too, so rootB has the same generated output
+      //    files (AGENTS.md/GEMINI.md) on disk, then replace rootB's manifest with
+      //    the one rootA wrote. This is the actual cross-checkout scenario: a
+      //    manifest produced at one absolute path is consumed at a different one.
       await runSync(rootB, { dryRun: false });
+      await writeFile(join(rootB, '.aco', 'sync-manifest.json'), manifestRaw);
 
-      // Now overwrite rootB's manifest with rootA's manifest.
-      // Both manifests should have identical relative-path keys and hashes
-      // since the source content is the same.
-      // Verify aco sync --check on rootB passes (exit 0 = no error)
-      // If target keys were absolute, rootB's check would find different keys than its disk paths.
+      // 4. aco sync --check in rootB against rootA's manifest.
+      //    runSync throws on drift/conflict in check mode and resolves otherwise,
+      //    so a non-rejecting call means "no drift" (exit 0 equivalent).
+      //    With absolute target keys this would mismatch rootB's disk paths and
+      //    report false-positive drift.
       await assert.doesNotReject(
         runSync(rootB, { check: true }),
-        'aco sync --check should not detect drift when manifest has relative target keys'
+        'aco sync --check must not detect drift for a manifest written in a different checkout'
       );
     } finally {
       await rm(rootA, { recursive: true, force: true });

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -737,9 +737,9 @@ describe('Skill Sync', () => {
         await readFile(join(tmpDir, '.aco', 'sync-manifest.json'), 'utf-8')
       );
 
-      assert.equal(manifest.version, '3');
-      const targetPath = join(tmpDir, '.agents', 'skills', 'github-kanban-ops');
-      const record = manifest.targets[targetPath];
+      assert.equal(manifest.version, '4');
+      const targetKey = join('.agents', 'skills', 'github-kanban-ops');
+      const record = manifest.targets[targetKey];
       assert.ok(record, 'Manifest should record the target');
       assert.equal(record.owner, 'aco');
       assert.equal(record.kind, 'shared-skill');
@@ -769,7 +769,7 @@ describe('Skill Sync', () => {
       await runSync(tmpDir, { dryRun: false });
       const manifest = JSON.parse(await readFile(join(acoDir, 'sync-manifest.json'), 'utf-8'));
 
-      assert.equal(manifest.version, '3');
+      assert.equal(manifest.version, '4');
       assert.ok(manifest.targets, 'Migrated manifest should have targets');
       assert.ok(manifest.skipped, 'Migrated manifest should have skipped');
     } finally {


### PR DESCRIPTION
Closes #119

## What

`.aco/sync-manifest.json`의 `targetHashes`/`targets` 키를 절대 경로에서 repo-relative 경로로 전환했다.

## Why

PR #117에서 `sourceHashes`는 repo-relative 경로로 전환됐으나 `targetHashes`/`targets` 키는 절대 경로(`output.targetPath`)로 남아 있었다. 그 결과 체크아웃 위치가 달라지면(CI 에이전트, clone 경로 변경 등) 동일한 파일도 변경된 것으로 잘못 감지되어 `aco sync --check`가 drift 오탐을 냈다.

## Changes

- `sync-engine.ts`: `computeTransformPlan`의 manifest 빌드 경로(AGENTS.md/GEMINI.md + skills/Codex agents/Gemini agents/Codex hooks/Gemini hooks 총 6개 섹션)가 `relative(repoRoot, targetPath)` 키를 사용. 읽기 경로(conflict 탐지, action 결정, cleanup)는 `resolveManifestKey` 헬퍼로 절대 경로를 상대 키로 변환. manifest version `4`.
- `manifest.ts`: `migrateManifest`에 v3→v4 마이그레이션 추가 — 기존 절대 경로 키를 `relative(repoRoot, key)`로 자동 전환. 버전 게이트를 숫자 비교로 리팩터링하여 `targets:{}`가 명시된 v1 manifest가 마이그레이션을 건너뛰던 기존 버그도 수정. `rootPath` 파라미터를 required로 격상해 마이그레이션 없이 버전만 올리는 silent bump 경로를 제거.
- `skill-transform.ts`: stale skill target 탐지 루프가 manifest 키를 절대 경로로 가정하던 부분을 `toAbsoluteTarget`로 복원하도록 수정.
- 테스트: 절대 경로 legacy manifest 마이그레이션 단위 테스트, 다른 체크아웃 경로 간 cross-checkout drift 없음 통합 테스트 추가. 기존 테스트는 version `4`/상대 키에 맞춰 갱신.
- `openspec/changes/sync-manifest-targets-relative-paths/`: OpenSpec 변경 제안 아티팩트(proposal/design/spec/tasks).

## Checklist

- [x] `npm run typecheck` 통과
- [x] `npm test` 통과 (sync 관련 92/92, 전체 277/277 — `provider-session-reliability` timing flake는 격리 시 3/3 통과, 본 변경과 무관)
- [x] `npm run test:fixtures` 통과 (5/5)
- [x] 기존 절대 경로 manifest 자동 마이그레이션 검증
- [x] cross-checkout `aco sync --check` false positive 없음 검증 (변이 테스트로 회귀 탐지 능력 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)