### PR TITLE
feat(wrapper): add --model flag to aco run and aco ask

### DIFF
--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -155,7 +155,7 @@ async function cmdProvider(args: string[]): Promise<void> {
 async function cmdRun(args: string[]): Promise<void> {
   if (args.includes('--help') || args.includes('-h')) {
     console.error(
-      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>]'
+      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>] [--model <model>]'
     );
     process.exit(0);
   }
@@ -165,7 +165,7 @@ async function cmdRun(args: string[]): Promise<void> {
 
   if (!providerKey || !command) {
     console.error(
-      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>]'
+      'Usage: aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>] [--model <model>]'
     );
     process.exit(EXIT_ERROR);
   }
@@ -191,6 +191,7 @@ async function cmdRun(args: string[]): Promise<void> {
     process.exit(EXIT_ERROR);
   }
   const inputFlag = parseFlag(args, '--input') ?? '';
+  const model = parseFlag(args, '--model');
 
   let content = inputFlag;
   if (!content && !process.stdin.isTTY) {
@@ -242,6 +243,7 @@ async function cmdRun(args: string[]): Promise<void> {
     outputBuffer: resolveRunOutputBuffering(),
     timeoutMs: executionControl.timeoutMs,
     killGraceMs: executionControl.killGraceMs,
+    ...(model ? { model } : {}),
     onPid: (pid) => {
       activePid = pid;
     },

--- a/packages/wrapper/src/cli.ts
+++ b/packages/wrapper/src/cli.ts
@@ -192,6 +192,10 @@ async function cmdRun(args: string[]): Promise<void> {
   }
   const inputFlag = parseFlag(args, '--input') ?? '';
   const model = parseFlag(args, '--model');
+  if (args.includes('--model') && (!model || model.startsWith('-'))) {
+    console.error('Error: --model requires a valid value');
+    process.exit(EXIT_ERROR);
+  }
 
   let content = inputFlag;
   if (!content && !process.stdin.isTTY) {
@@ -486,9 +490,9 @@ function printUsage(): void {
   aco --version
   aco --help
   aco sync [--check] [--dry-run] [--force]
-  aco ask --task <text> [--providers codex,gemini,mock] [--input <text>] [--input-file <path>] [--preset <name>] [--permission-profile restricted|default|unrestricted] [--output-mode brief|save-only|full] [--dry-run|--yes]
+  aco ask --task <text> [--providers codex,gemini,mock] [--input <text>] [--input-file <path>] [--preset <name>] [--permission-profile restricted|default|unrestricted] [--output-mode brief|save-only|full] [--model <model>] [--dry-run|--yes]
   aco doctor
-  aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>]
+  aco run <provider> <command> [--input <text>] [--permission-profile default|restricted|unrestricted] [--timeout <seconds>] [--model <model>]
   aco result [--session <id>]
   aco status [--session <id>]
   aco cancel [--session <id>]

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -68,6 +68,11 @@ export async function cmdAsk(args: string[]): Promise<void> {
     return;
   }
 
+  const rawModel = parseFlag(args, '--model');
+  if (args.includes('--model') && (!rawModel || rawModel.startsWith('-'))) {
+    fail('Error: --model requires a valid value');
+  }
+
   let options: AskOptions;
   try {
     options = parseAskOptions(args);
@@ -464,6 +469,7 @@ Options:
   --output-mode <mode>            brief|save-only|full (default: brief)
                                     brief summary bound: ${SUMMARY_CHAR_LIMIT} chars
   --timeout <seconds>             Provider execution timeout (default: 300, env: ACO_TIMEOUT_SECONDS)
+  --model <model>                 Model identifier passed to the provider binary via -m flag
   --dry-run                       Print execution plan without invoking providers
   --yes                           Explicitly consent to provider execution`);
 }

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -49,6 +49,7 @@ interface AskOptions {
   dryRun: boolean;
   timeoutSeconds: number;
   executionControl: ProviderExecutionControl;
+  model?: string;
 }
 
 interface AskSessionLedger {
@@ -140,6 +141,7 @@ export async function cmdAsk(args: string[]): Promise<void> {
       maxOutputBuffer: SUMMARY_SOURCE_CHAR_LIMIT,
       timeoutMs: options.executionControl.timeoutMs,
       killGraceMs: options.executionControl.killGraceMs,
+      ...(options.model ? { model: options.model } : {}),
       onChunk:
         options.outputMode === 'full'
           ? (chunk) => {
@@ -247,6 +249,7 @@ function parseAskOptions(args: string[]): AskOptions {
     dryRun: args.includes('--dry-run'),
     timeoutSeconds: resolveProviderTimeoutSeconds(timeoutFlag),
     executionControl: resolveProviderExecutionControl(timeoutFlag),
+    model: parseFlag(args, '--model'),
   };
 }
 

--- a/packages/wrapper/src/providers/codex.ts
+++ b/packages/wrapper/src/providers/codex.ts
@@ -86,6 +86,9 @@ export class CodexProvider implements IProvider {
     if (profile !== 'restricted') {
       args.push('--full-auto');
     }
+    if (options?.model) {
+      args.push('-m', options.model);
+    }
     return args;
   }
 

--- a/packages/wrapper/src/providers/gemini.ts
+++ b/packages/wrapper/src/providers/gemini.ts
@@ -74,6 +74,9 @@ export class GeminiProvider implements IProvider {
     if (profile !== 'restricted') {
       base.unshift('--yolo');
     }
+    if (options?.model) {
+      base.unshift('-m', options.model);
+    }
     return base;
   }
 

--- a/packages/wrapper/src/providers/interface.ts
+++ b/packages/wrapper/src/providers/interface.ts
@@ -41,6 +41,8 @@ export interface InvokeOptions {
   timeoutMs?: number;
   /** Grace period after SIGTERM before SIGKILL. */
   killGraceMs?: number;
+  /** Model identifier passed to the provider binary via -m flag. */
+  model?: string;
 }
 
 export interface IProvider {

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -27,6 +27,8 @@ export interface ProviderSessionRunOptions {
   killGraceMs?: number;
   /** Called once with the provider's OS PID when available. */
   onPid?: (pid: number) => void;
+  /** Model identifier passed to the provider binary via -m flag. */
+  model?: string;
 }
 
 export interface ProviderSessionRunResult {
@@ -65,6 +67,7 @@ export async function invokeProviderForSession(
         outputBuffer,
         timeoutMs: options.timeoutMs,
         killGraceMs: options.killGraceMs,
+        model: options.model,
         onPid: (pid) => {
           options.onPid?.(pid);
           sessionStore.update(options.sessionId, { pid }).catch((err: unknown) => {


### PR DESCRIPTION
## What

`aco run`과 `aco ask` 양쪽에 `--model <model>` 플래그를 추가했다.

## Why

Codex(`-m <MODEL>`)와 Gemini(`-m <model>`) CLI 모두 런타임 모델 지정을 지원하지만, `aco`에는 이를 전달할 수단이 없었다. 실험적 모델(예: `gemini-2.5-pro-exp-03-25`)이나 특정 Codex 모델을 명시적으로 선택하려면 provider binary를 직접 실행해야 했다.

## Changes

- `InvokeOptions`에 `model?: string` 추가 ([interface.ts](packages/wrapper/src/providers/interface.ts))
- `CodexProvider.buildArgs()`에서 `-m <model>` push ([codex.ts](packages/wrapper/src/providers/codex.ts))
- `GeminiProvider.buildArgs()`에서 `-m <model>`을 `-p` 앞에 unshift ([gemini.ts](packages/wrapper/src/providers/gemini.ts))
- `ProviderSessionRunOptions`에 `model?` 추가 후 `invoke()` 호출까지 전파 ([provider-session-runner.ts](packages/wrapper/src/runtime/provider-session-runner.ts))
- `cmdRun`: `--model` 파싱 및 help 텍스트 갱신 ([cli.ts](packages/wrapper/src/cli.ts))
- `AskOptions`에 `model?` 추가, `parseAskOptions` 파싱, `invokeProviderForSession` 전달 ([ask.ts](packages/wrapper/src/commands/ask.ts))

모델명은 provider binary가 지원하는 값을 그대로 `-m`에 넘기므로 experimental 계열 포함 어떤 모델이든 동작한다.

## Checklist

- [x] `aco run <provider> <command> --model <model>` 동작 확인
- [x] `aco ask --providers <list> --task "..." --model <model>` 동작 확인
- [x] typecheck 통과
- [x] 전체 테스트 274개 통과