### PR TITLE
docs(readme): SVG 다이어그램 갱신 및 저장소 구조 섹션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <a href="https://www.npmjs.com/package/@pureliture/ai-cli-orch-wrapper">
   <img src="https://img.shields.io/npm/v/@pureliture/ai-cli-orch-wrapper?style=for-the-badge&logo=npm&logoColor=white&color=CB3837&label=npm" alt="npm" />
 </a>
-<img src="https://img.shields.io/badge/license-ISC-3b82f6?style=for-the-badge" alt="license" />
+<img src="https://img.shields.io/badge/license-MIT-3b82f6?style=for-the-badge" alt="license" />
 <img src="https://img.shields.io/badge/node-%E2%89%A518-339933?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="node" />
 <img src="https://img.shields.io/badge/PRs-welcome-10b981?style=for-the-badge" alt="prs" />
 <img src="https://img.shields.io/badge/OpenSpec-driven-8b5cf6?style=for-the-badge" alt="openspec" />
@@ -41,6 +41,7 @@
   <a href="#-아키텍처-개요"><img src="https://img.shields.io/badge/🏛️_Architecture-1e293b?style=for-the-badge" alt="Architecture" /></a>
   <a href="#-사용자-가이드"><img src="https://img.shields.io/badge/📖_User_Guide-1e293b?style=for-the-badge" alt="User Guide" /></a>
   <a href="#-사용-시나리오"><img src="https://img.shields.io/badge/🎯_Use_Cases-1e293b?style=for-the-badge" alt="Use Cases" /></a>
+  <a href="#-저장소-구조"><img src="https://img.shields.io/badge/🗂️_Repo_Layout-1e293b?style=for-the-badge" alt="Repo Layout" /></a>
   <a href="#%EF%B8%8F-하네스-구성"><img src="https://img.shields.io/badge/🛠️_Harness-1e293b?style=for-the-badge" alt="Harness" /></a>
 </p>
 
@@ -328,6 +329,13 @@ sync drift 상태를 확인하지만 real provider execution이나 remote auth v
 `aco ask`는 Claude Code 세션 안에서 외부 AI CLI에 advisory 작업을 맡기기 위한 high-level
 wrapper입니다. provider 실행은 명시적 동의 없이는 시작되지 않습니다.
 
+<p align="center">
+  <img src="docs/images/session-lifecycle.svg" alt="Delegation Lifecycle" width="100%" />
+</p>
+
+> 💡 `--dry-run`은 실행 계획만 표시하고 provider를 호출하지 않습니다. 실제 위임은 `--yes`로
+> 명시 동의했을 때만 시작되며, 그 시점에 session이 생성되고 ledger·brief·output이 기록됩니다.
+
 ```bash
 # 실행 계획만 확인하고 provider는 호출하지 않음
 aco ask --providers mock --task "review this demo input" --input "demo" --dry-run
@@ -480,6 +488,60 @@ PR 머지 전 Gemini와 Codex **양쪽 리뷰**를 받고 싶을 때
 </tr>
 </tbody>
 </table>
+
+<br/>
+
+<!-- ────────────── SECTION DIVIDER ────────────── -->
+<img src="https://capsule-render.vercel.app/api?type=rect&color=gradient&customColorList=12&height=3" width="100%" />
+
+<br/>
+
+## 🗂️ 저장소 구조
+
+이 저장소는 npm workspace이며, Node wrapper와 Go runtime이 한 트리에 공존합니다.
+
+<p align="center">
+  <img src="docs/images/repository-structure.svg" alt="Repository Structure" width="100%" />
+</p>
+
+<table>
+<thead>
+<tr><th>경로</th><th>역할</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>packages/wrapper/</code></td>
+<td><code>@pureliture/ai-cli-orch-wrapper</code> 런타임 — <code>aco</code> CLI, provider interface·구현·registry, sync engine, session/task/output lifecycle</td>
+</tr>
+<tr>
+<td><code>packages/installer/</code></td>
+<td>install-time entrypoint와 setup flow</td>
+</tr>
+<tr>
+<td><code>cmd/aco/</code> · <code>internal/</code></td>
+<td>Go runtime — blocking provider 실행 실험(<code>delegate</code> · <code>run</code>)과 provider·runner 내부 구현</td>
+</tr>
+<tr>
+<td><code>templates/commands/</code> · <code>templates/prompts/</code> · <code>templates/tasks/</code></td>
+<td>command pack에 포함되어 배포되는 slash command·prompt·task preset 소스</td>
+</tr>
+<tr>
+<td><code>docs/</code></td>
+<td>architecture, contract, guides, reference, phase plan, archive 문서</td>
+</tr>
+<tr>
+<td><code>openspec/</code></td>
+<td>OpenSpec proposal·spec·design·task 목록</td>
+</tr>
+<tr>
+<td><code>.github/workflows/</code></td>
+<td><code>ci.yml</code> · <code>release.yml</code> 등 CI/릴리스 워크플로우</td>
+</tr>
+</tbody>
+</table>
+
+> 💡 `Go runtime`은 별도 디렉터리가 아니라 root의 <code>cmd/aco/</code>와 <code>internal/</code>을 묶은
+> 개념적 그룹입니다. Node/Go 책임 경계는 [docs/contract/go-node-boundary.md](docs/contract/go-node-boundary.md)에 정의되어 있습니다.
 
 <br/>
 

--- a/docs/images/architecture-overview.svg
+++ b/docs/images/architecture-overview.svg
@@ -22,7 +22,7 @@
   <text x="103" y="96" font-size="9" font-weight="700" letter-spacing="1.5" fill="#9ca3af">AI CLI — ENTRY POINT (ORCHESTRATOR)</text>
 
   
-  <image x="103" y="107" width="22" height="22" preserveAspectRatio="xMidYMid meet"></image>
+  <svg x="103" y="107" width="22" height="22" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-3.654 0H6.57L0 20h3.603l6.57-16.48z" fill="#CC785C"/></svg>
   <text x="131" y="124" font-size="14" font-weight="700" fill="#111827">Claude Code</text>
   <rect x="240" y="111" width="42" height="18" rx="9" fill="#f3e8ff" stroke="#a855f7" stroke-width="1"></rect>
   <text x="261" y="120" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#7e22ce">ORCH</text>
@@ -116,7 +116,7 @@
   
   
   <rect x="85" y="662" width="168" height="105" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1.5" filter="url(#sh-sm)"></rect>
-  <image x="152" y="669" width="34" height="34" preserveAspectRatio="xMidYMid meet"></image>
+  <svg x="152" y="669" width="34" height="34" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C12 2 10.2 10.2 2 12C10.2 13.8 12 22 12 22C12 22 13.8 13.8 22 12C13.8 10.2 12 2 12 2Z" fill="#4285F4"/></svg>
   <text x="169" y="716" text-anchor="middle" font-size="13" font-weight="700" fill="#111827">Gemini CLI</text>
   <text x="169" y="731" text-anchor="middle" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@google/gemini-cli</text>
   <text x="169" y="745" text-anchor="middle" font-size="8.5" fill="#94a3b8">GEMINI_API_KEY · OAuth</text>
@@ -144,7 +144,7 @@
   <line x1="686" y1="118" x2="930" y2="118" stroke="#f1f5f9" stroke-width="1"></line>
 
   
-  <image x="686" y="126" width="18" height="18" preserveAspectRatio="xMidYMid meet"></image>
+  <svg x="686" y="126" width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M13.827 3.52h3.603L24 20h-3.603l-6.57-16.48zm-3.654 0H6.57L0 20h3.603l6.57-16.48z" fill="#CC785C"/></svg>
   <text x="710" y="140" font-size="13" font-weight="700" fill="#111827">Claude Code</text>
   <text x="686" y="154" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@anthropic/claude-code</text>
   <text x="686" y="172" font-size="9.5" fill="#6b7280">Orchestrator</text>
@@ -168,7 +168,7 @@
   <line x1="686" y1="294" x2="930" y2="294" stroke="#f1f5f9" stroke-width="1"></line>
 
   
-  <image x="686" y="301" width="18" height="18" preserveAspectRatio="xMidYMid meet"></image>
+  <svg x="686" y="301" width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M12 2C12 2 10.2 10.2 2 12C10.2 13.8 12 22 12 22C12 22 13.8 13.8 22 12C13.8 10.2 12 2 12 2Z" fill="#4285F4"/></svg>
   <text x="710" y="316" font-size="13" font-weight="700" fill="#111827">Gemini CLI</text>
   <text x="686" y="330" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@google/gemini-cli</text>
   <text x="686" y="348" font-size="9.5" fill="#6b7280">Orchestrator</text>

--- a/docs/images/architecture-overview.svg
+++ b/docs/images/architecture-overview.svg
@@ -1,193 +1,191 @@
-<svg viewBox="0 0 720 600" xmlns="http://www.w3.org/2000/svg"
-     font-family="'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,sans-serif">
+<svg viewBox="0 0 975 800" xmlns="http://www.w3.org/2000/svg" font-family="&#39;Helvetica Neue&#39;,Helvetica,Arial,sans-serif">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fdf4ff"/>
-      <stop offset="35%" stop-color="#eef2ff"/>
-      <stop offset="70%" stop-color="#ecfeff"/>
-      <stop offset="100%" stop-color="#f0fdfa"/>
-    </linearGradient>
-
-    <!-- Component gradients -->
-    <linearGradient id="purple-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
-    </linearGradient>
-    <linearGradient id="blue-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#2563eb"/>
-    </linearGradient>
-    <linearGradient id="green-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#34d399"/>
-      <stop offset="100%" stop-color="#059669"/>
-    </linearGradient>
-    <linearGradient id="orange-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fbbf24"/>
-      <stop offset="100%" stop-color="#d97706"/>
-    </linearGradient>
-    <linearGradient id="teal-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#2dd4bf"/>
-      <stop offset="100%" stop-color="#0d9488"/>
-    </linearGradient>
-
-    <!-- Drop shadow filter -->
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
-      <feOffset dx="0" dy="3" result="offset-blur"/>
-      <feFlood flood-color="#1e1b4b" flood-opacity="0.18"/>
-      <feComposite in2="offset-blur" operator="in"/>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-
-    <!-- Arrow marker -->
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
-    </marker>
+    <filter id="sh" x="-8%" y="-8%" width="116%" height="122%"><feDropShadow dx="0" dy="1" stdDeviation="3" flood-color="#1e293b" flood-opacity="0.07"></feDropShadow></filter>
+    <filter id="sh-sm" x="-5%" y="-5%" width="110%" height="116%"><feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#1e293b" flood-opacity="0.05"></feDropShadow></filter>
+    <linearGradient id="aco-grad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0f172a"></stop><stop offset="100%" stop-color="#1e293b"></stop></linearGradient>
+    <marker id="arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0.5 L9 4 L0 7.5 z" fill="#94a3b8"></path></marker>
+    <marker id="arr-dash" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0.5 L9 4 L0 7.5 z" fill="#d1d5db"></path></marker>
+    <clipPath id="aco-clip"><rect x="85" y="510" width="555" height="112" rx="10"></rect></clipPath>
   </defs>
 
-  <!-- Background -->
-  <rect width="720" height="600" rx="18" fill="url(#bg-grad)"/>
+  <rect width="975" height="800" fill="#f1f5f9"></rect>
+  <text x="362" y="42" text-anchor="middle" font-size="15" font-weight="700" fill="#0f172a" letter-spacing="0.3">AI CLI Orchestration Wrapper — Architecture</text>
 
-  <!-- Decorative dots in corners -->
-  <circle cx="30" cy="30" r="3" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="690" cy="30" r="3" fill="#3b82f6" opacity="0.4"/>
-  <circle cx="30" cy="570" r="3" fill="#10b981" opacity="0.4"/>
-  <circle cx="690" cy="570" r="3" fill="#f59e0b" opacity="0.4"/>
+  
+  <circle cx="42" cy="118" r="18" fill="none" stroke="#94a3b8" stroke-width="1.5"></circle>
+  <path d="M17,148 Q42,134 67,148" fill="none" stroke="#94a3b8" stroke-width="1.5" stroke-linecap="round"></path>
+  <text x="42" y="168" text-anchor="middle" font-size="11" fill="#94a3b8">User</text>
+  <line x1="62" y1="118" x2="83" y2="118" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"></line>
 
-  <!-- Title -->
-  <text x="360" y="36" text-anchor="middle" dominant-baseline="middle"
-        font-size="18" font-weight="700" fill="#1e293b" letter-spacing="0.5">
-    Consent-Gated Delegation Architecture
-  </text>
-  <line x1="240" y1="55" x2="320" y2="55" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/>
-  <line x1="400" y1="55" x2="480" y2="55" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="360" cy="55" r="4" fill="#8b5cf6"/>
+  
+  <rect x="85" y="76" width="555" height="92" rx="10" fill="white" stroke="#d1d5db" stroke-width="1.5" stroke-dasharray="6,3" filter="url(#sh)"></rect>
+  <text x="103" y="96" font-size="9" font-weight="700" letter-spacing="1.5" fill="#9ca3af">AI CLI — ENTRY POINT (ORCHESTRATOR)</text>
 
-  <!-- ─── CLAUDE CODE HARNESS ─── -->
-  <g filter="url(#shadow)">
-    <rect x="135" y="75" width="450" height="108" rx="12" fill="white" stroke="#a78bfa" stroke-width="1.5"/>
-    <rect x="135" y="75" width="450" height="40" rx="12" fill="url(#purple-grad)"/>
-    <rect x="135" y="95" width="450" height="20" fill="url(#purple-grad)"/>
-  </g>
-  <text x="360" y="95" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white" letter-spacing="0.3">
-    📁  Claude Code Harness
-  </text>
-  <text x="360" y="135" text-anchor="middle" dominant-baseline="middle"
-        font-size="11.5" fill="#475569">.claude/commands/aco.md  ·  aco-delegation skill  ·  .claude/aco/tasks</text>
-  <text x="360" y="153" text-anchor="middle" dominant-baseline="middle"
-        font-size="11.5" fill="#475569">CLAUDE.md  ·  settings.json  ·  rules/*.md  ·  legacy commands</text>
-  <text x="360" y="172" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#94a3b8" font-style="italic">✎ Source of Truth — hand-maintained</text>
+  
+  <image x="103" y="107" width="22" height="22" preserveAspectRatio="xMidYMid meet"></image>
+  <text x="131" y="124" font-size="14" font-weight="700" fill="#111827">Claude Code</text>
+  <rect x="240" y="111" width="42" height="18" rx="9" fill="#f3e8ff" stroke="#a855f7" stroke-width="1"></rect>
+  <text x="261" y="120" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#7e22ce">ORCH</text>
+  <rect x="288" y="111" width="76" height="18" rx="9" fill="#dcfce7" stroke="#16a34a" stroke-width="1"></rect>
+  <text x="326" y="120" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#15803d">● SUPPORTED</text>
 
-  <!-- Arrow: Harness → aco CLI -->
-  <line x1="360" y1="183" x2="360" y2="222" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <rect x="265" y="192" width="190" height="20" rx="10" fill="white" stroke="#cbd5e1" stroke-width="1"/>
-  <text x="360" y="202" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#475569">/aco  ·  aco pack  ·  aco sync</text>
+  
+  <svg x="103" y="135" width="22" height="22" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient gradientUnits="userSpaceOnUse" id="cx-entry" x1="12" x2="12" y1="3" y2="21"><stop stop-color="#B1A7FF"></stop><stop offset=".5" stop-color="#7A9DFF"></stop><stop offset="1" stop-color="#3941FF"></stop></linearGradient></defs><path d="M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z" fill="#fff"></path><path d="M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z" fill="url(#cx-entry)"></path></svg>
+  <text x="131" y="152" font-size="14" font-weight="700" fill="#111827">Codex CLI</text>
+  <rect x="225" y="139" width="42" height="18" rx="9" fill="#f3e8ff" stroke="#a855f7" stroke-width="1"></rect>
+  <text x="246" y="148" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#7e22ce">ORCH</text>
+  <rect x="273" y="139" width="70" height="18" rx="9" fill="#fef3c7" stroke="#d97706" stroke-width="1"></rect>
+  <text x="308" y="148" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#92400e">○ ROADMAP</text>
 
-  <!-- ─── ACO CLI ─── -->
-  <g filter="url(#shadow)">
-    <rect x="105" y="225" width="510" height="100" rx="12" fill="white" stroke="#60a5fa" stroke-width="1.5"/>
-    <rect x="105" y="225" width="510" height="38" rx="12" fill="url(#blue-grad)"/>
-    <rect x="105" y="244" width="510" height="19" fill="url(#blue-grad)"/>
-  </g>
-  <text x="360" y="244" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white" letter-spacing="0.3">
-    ⚙️  aco CLI — @pureliture/ai-cli-orch-wrapper
-  </text>
-  <text x="360" y="279" text-anchor="middle" dominant-baseline="middle"
-        font-size="11.5" font-weight="500" fill="#1e293b">ask  ·  doctor  ·  run  ·  result  ·  status  ·  cancel  ·  sync  ·  pack</text>
-  <text x="360" y="298" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#64748b">ask defaults: --providers mock  ·  --permission-profile restricted  ·  --output-mode brief</text>
-  <text x="360" y="314" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#64748b">--dry-run shows plan  ·  --yes required to invoke external providers</text>
+  <line x1="362" y1="168" x2="362" y2="198" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"></line>
 
-  <!-- Fork arrow: aco CLI → Mock / Gemini / Codex -->
-  <line x1="360" y1="325" x2="360" y2="350" stroke="#94a3b8" stroke-width="1.5"/>
-  <line x1="160" y1="350" x2="560" y2="350" stroke="#94a3b8" stroke-width="1.5"/>
-  <line x1="160" y1="350" x2="160" y2="378" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <line x1="360" y1="350" x2="360" y2="378" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <line x1="560" y1="350" x2="560" y2="378" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arrow)"/>
-  <rect x="170" y="338" width="120" height="20" rx="10" fill="white" stroke="#10b981" stroke-width="1"/>
-  <text x="230" y="348" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#059669">aco ask gemini</text>
-  <rect x="300" y="338" width="120" height="20" rx="10" fill="white" stroke="#3b82f6" stroke-width="1"/>
-  <text x="360" y="348" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#2563eb">aco ask mock</text>
-  <rect x="430" y="338" width="120" height="20" rx="10" fill="white" stroke="#f59e0b" stroke-width="1"/>
-  <text x="490" y="348" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#b45309">aco ask codex</text>
+  
+  <rect x="85" y="200" width="555" height="122" rx="10" fill="white" stroke="#d1d5db" stroke-width="1.5" filter="url(#sh)"></rect>
+  <text x="103" y="220" font-size="9" font-weight="700" letter-spacing="1.5" fill="#9ca3af">CLAUDE CODE HARNESS</text>
+  
+  <rect x="385" y="208" width="50" height="18" rx="9" fill="#fef9c3" stroke="#ca8a04" stroke-width="1"></rect>
+  <text x="410" y="217" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#854d0e">Agents</text>
+  <rect x="441" y="208" width="44" height="18" rx="9" fill="#dbeafe" stroke="#2563eb" stroke-width="1"></rect>
+  <text x="463" y="217" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#1d4ed8">Skills</text>
 
-  <!-- ─── GEMINI CLI ─── -->
-  <g filter="url(#shadow)">
-    <rect x="55" y="380" width="210" height="92" rx="12" fill="white" stroke="#34d399" stroke-width="1.5"/>
-    <rect x="55" y="380" width="210" height="36" rx="12" fill="url(#green-grad)"/>
-    <rect x="55" y="398" width="210" height="18" fill="url(#green-grad)"/>
-  </g>
-  <text x="160" y="398" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white" letter-spacing="0.3">
-    🟢  Gemini CLI
-  </text>
-  <text x="160" y="435" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" fill="#475569">@google/gemini-cli</text>
-  <text x="160" y="455" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#94a3b8">GEMINI_API_KEY  ·  OAuth</text>
+  <rect x="103" y="228" width="519" height="80" rx="5" fill="#1e1e2e"></rect>
+  <text x="117" y="249" font-family="&#39;Courier New&#39;,Courier,monospace" font-size="11"><tspan fill="#64748b">$ </tspan><tspan fill="#cbd5e1">claude --agents planning,code,bug,security</tspan></text>
+  <text x="117" y="267" font-family="&#39;Courier New&#39;,Courier,monospace" font-size="11"><tspan fill="#374151">› </tspan><tspan fill="#6b7280">Spawning </tspan><tspan fill="#7dd3fc">planning</tspan><tspan fill="#6b7280"> agent............</tspan><tspan fill="#4ade80">✓</tspan></text>
+  <text x="117" y="285" font-family="&#39;Courier New&#39;,Courier,monospace" font-size="11"><tspan fill="#374151">› </tspan><tspan fill="#6b7280">Spawning </tspan><tspan fill="#7dd3fc">code builder</tspan><tspan fill="#6b7280">...........</tspan><tspan fill="#4ade80">✓</tspan></text>
+  <text x="117" y="303" font-family="&#39;Courier New&#39;,Courier,monospace" font-size="11"><tspan fill="#374151">› </tspan><tspan fill="#6b7280">Spawning </tspan><tspan fill="#7dd3fc">bug finder</tspan><tspan fill="#6b7280"> + </tspan><tspan fill="#7dd3fc">security auditor</tspan><tspan fill="#6b7280">......</tspan><tspan fill="#4ade80">✓</tspan></text>
 
-  <!-- ─── MOCK PROVIDER ─── -->
-  <g filter="url(#shadow)">
-    <rect x="285" y="380" width="150" height="92" rx="12" fill="white" stroke="#60a5fa" stroke-width="1.5"/>
-    <rect x="285" y="380" width="150" height="36" rx="12" fill="url(#blue-grad)"/>
-    <rect x="285" y="398" width="150" height="18" fill="url(#blue-grad)"/>
-  </g>
-  <text x="360" y="398" text-anchor="middle" dominant-baseline="middle"
-        font-size="13" font-weight="700" fill="white" letter-spacing="0.3">
-    🔵  Mock Provider
-  </text>
-  <text x="360" y="435" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" fill="#475569">deterministic demo</text>
-  <text x="360" y="455" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#94a3b8">no external credentials</text>
+  <line x1="362" y1="322" x2="362" y2="350" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"></line>
 
-  <!-- ─── CODEX CLI ─── -->
-  <g filter="url(#shadow)">
-    <rect x="455" y="380" width="210" height="92" rx="12" fill="white" stroke="#fbbf24" stroke-width="1.5"/>
-    <rect x="455" y="380" width="210" height="36" rx="12" fill="url(#orange-grad)"/>
-    <rect x="455" y="398" width="210" height="18" fill="url(#orange-grad)"/>
-  </g>
-  <text x="560" y="398" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white" letter-spacing="0.3">
-    🟠  Codex CLI
-  </text>
-  <text x="560" y="435" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" fill="#475569">@openai/codex</text>
-  <text x="560" y="455" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#94a3b8">OPENAI_API_KEY  ·  OAuth</text>
+  
+  <rect x="85" y="353" width="555" height="115" rx="10" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="7,4"></rect>
+  <text x="103" y="372" font-size="9" font-weight="700" letter-spacing="1.5" fill="#3b82f6">SUBAGENT CONTEXT</text>
+  <rect x="103" y="380" width="120" height="68" rx="7" fill="white" stroke="#93c5fd" stroke-width="1.2"></rect>
+  <rect x="103" y="380" width="120" height="9" rx="7" fill="#3b82f6"></rect><rect x="103" y="384" width="120" height="5" fill="#3b82f6"></rect>
+  <text x="163" y="411" text-anchor="middle" font-size="12" font-weight="600" fill="#1d4ed8">planning</text>
+  <text x="163" y="427" text-anchor="middle" font-size="10" fill="#6b7280">agent</text>
+  <text x="163" y="441" text-anchor="middle" font-size="9" fill="#94a3b8">discussion</text>
+  <rect x="233" y="380" width="120" height="68" rx="7" fill="white" stroke="#93c5fd" stroke-width="1.2"></rect>
+  <rect x="233" y="380" width="120" height="9" rx="7" fill="#3b82f6"></rect><rect x="233" y="384" width="120" height="5" fill="#3b82f6"></rect>
+  <text x="293" y="411" text-anchor="middle" font-size="12" font-weight="600" fill="#1d4ed8">code</text>
+  <text x="293" y="427" text-anchor="middle" font-size="10" fill="#6b7280">builder</text>
+  <text x="293" y="441" text-anchor="middle" font-size="9" fill="#94a3b8">implement</text>
+  <rect x="363" y="380" width="120" height="68" rx="7" fill="white" stroke="#93c5fd" stroke-width="1.2"></rect>
+  <rect x="363" y="380" width="120" height="9" rx="7" fill="#3b82f6"></rect><rect x="363" y="384" width="120" height="5" fill="#3b82f6"></rect>
+  <text x="423" y="411" text-anchor="middle" font-size="12" font-weight="600" fill="#1d4ed8">bug</text>
+  <text x="423" y="427" text-anchor="middle" font-size="10" fill="#6b7280">finder</text>
+  <text x="423" y="441" text-anchor="middle" font-size="9" fill="#94a3b8">debug</text>
+  <rect x="493" y="380" width="138" height="68" rx="7" fill="white" stroke="#93c5fd" stroke-width="1.2"></rect>
+  <rect x="493" y="380" width="138" height="9" rx="7" fill="#3b82f6"></rect><rect x="493" y="384" width="138" height="5" fill="#3b82f6"></rect>
+  <text x="562" y="411" text-anchor="middle" font-size="12" font-weight="600" fill="#1d4ed8">security</text>
+  <text x="562" y="427" text-anchor="middle" font-size="10" fill="#6b7280">auditor</text>
+  <text x="562" y="441" text-anchor="middle" font-size="9" fill="#94a3b8">review</text>
 
-  <!-- Arrows: providers → Session Store -->
-  <path d="M 160 472 Q 200 495 270 510" stroke="#94a3b8" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
-  <path d="M 360 472 L 360 508" stroke="#94a3b8" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
-  <path d="M 560 472 Q 520 495 450 510" stroke="#94a3b8" stroke-width="1.5" fill="none" marker-end="url(#arrow)"/>
-  <text x="360" y="495" text-anchor="middle" dominant-baseline="middle"
-        font-size="9.5" fill="#94a3b8" font-style="italic">advisory output saved as artifacts</text>
+  <line x1="362" y1="468" x2="362" y2="476" stroke="#94a3b8" stroke-width="1.5"></line>
+  <text x="362" y="488" text-anchor="middle" font-size="9" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#94a3b8">/aco · aco pack · aco sync</text>
+  <line x1="362" y1="495" x2="362" y2="508" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"></line>
 
-  <!-- ─── SESSION STORE ─── -->
-  <g filter="url(#shadow)">
-    <rect x="195" y="510" width="330" height="78" rx="12" fill="white" stroke="#2dd4bf" stroke-width="1.5"/>
-    <rect x="195" y="510" width="330" height="34" rx="12" fill="url(#teal-grad)"/>
-    <rect x="195" y="527" width="330" height="17" fill="url(#teal-grad)"/>
-  </g>
-  <text x="360" y="527" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white" letter-spacing="0.3">
-    💾  Session Store
-  </text>
-  <text x="360" y="562" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="500" fill="#1e293b">~/.aco/runs/&lt;run-id&gt;/  ·  ~/.aco/sessions/&lt;uuid&gt;/</text>
-  <text x="360" y="580" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#64748b">ledger.json  ·  bounded brief.md  ·  task.json  ·  output.log  ·  aco result</text>
+  
+  <rect x="85" y="510" width="555" height="112" rx="10" fill="white" stroke="#1e293b" stroke-width="2" filter="url(#sh)"></rect>
+  <rect x="85" y="510" width="555" height="40" fill="url(#aco-grad)" clip-path="url(#aco-clip)"></rect>
+  <text x="103" y="536" font-size="14" fill="#475569">⚙</text>
+  <text x="122" y="536" font-size="14" font-weight="700" fill="white">aco CLI</text>
+  <text x="195" y="536" font-size="10" fill="#64748b">— @pureliture/ai-cli-orch-wrapper</text>
+  <rect x="512" y="521" width="112" height="18" rx="9" fill="#0f766e"></rect>
+  <text x="568" y="530" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#ccfbf1" letter-spacing="0.5">CONSENT-GATED</text>
+  <rect x="103" y="562" width="32" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="119" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">ask</text>
+  <rect x="141" y="562" width="52" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="167" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">doctor</text>
+  <rect x="199" y="562" width="32" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="215" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">run</text>
+  <rect x="237" y="562" width="44" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="259" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">result</text>
+  <rect x="287" y="562" width="44" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="309" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">status</text>
+  <rect x="337" y="562" width="46" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="360" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">cancel</text>
+  <rect x="389" y="562" width="36" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="407" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">sync</text>
+  <rect x="431" y="562" width="36" height="20" rx="10" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"></rect><text x="449" y="572" text-anchor="middle" dominant-baseline="middle" font-size="9" font-weight="600" fill="#374151">pack</text>
+  <text x="103" y="597" font-size="9" fill="#6b7280"><tspan font-weight="600">Defaults:</tspan>  --providers mock · --permission-profile restricted · --output-mode brief · --yes required</text>
+
+  
+  <line x1="362" y1="622" x2="362" y2="632" stroke="#94a3b8" stroke-width="1.5"></line>
+  <line x1="169" y1="632" x2="499" y2="632" stroke="#94a3b8" stroke-width="1.5"></line>
+  <line x1="169" y1="632" x2="169" y2="660" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"></line>
+  <line x1="339" y1="632" x2="339" y2="660" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#arr)"></line>
+  <line x1="499" y1="632" x2="499" y2="660" stroke="#d1d5db" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arr-dash)"></line>
+  
+  <text x="169" y="626" text-anchor="middle" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#94a3b8">aco ask gemini</text>
+  <text x="339" y="626" text-anchor="middle" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#94a3b8">aco ask codex</text>
+  <text x="499" y="626" text-anchor="middle" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#d1d5db">aco ask ···</text>
+
+  
+  
+  <rect x="85" y="662" width="168" height="105" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1.5" filter="url(#sh-sm)"></rect>
+  <image x="152" y="669" width="34" height="34" preserveAspectRatio="xMidYMid meet"></image>
+  <text x="169" y="716" text-anchor="middle" font-size="13" font-weight="700" fill="#111827">Gemini CLI</text>
+  <text x="169" y="731" text-anchor="middle" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@google/gemini-cli</text>
+  <text x="169" y="745" text-anchor="middle" font-size="8.5" fill="#94a3b8">GEMINI_API_KEY · OAuth</text>
+
+  
+  <rect x="263" y="662" width="152" height="105" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1.5" filter="url(#sh-sm)"></rect>
+  <svg x="315" y="669" width="34" height="34" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient gradientUnits="userSpaceOnUse" id="cx-bottom" x1="12" x2="12" y1="3" y2="21"><stop stop-color="#B1A7FF"></stop><stop offset=".5" stop-color="#7A9DFF"></stop><stop offset="1" stop-color="#3941FF"></stop></linearGradient></defs><path d="M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z" fill="#fff"></path><path d="M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z" fill="url(#cx-bottom)"></path></svg>
+  <text x="339" y="716" text-anchor="middle" font-size="13" font-weight="700" fill="#111827">Codex CLI</text>
+  <text x="339" y="731" text-anchor="middle" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@openai/codex</text>
+  <text x="339" y="745" text-anchor="middle" font-size="8.5" fill="#94a3b8">OPENAI_API_KEY · OAuth</text>
+
+  
+  <rect x="425" y="662" width="148" height="105" rx="10" fill="#f9fafb" stroke="#d1d5db" stroke-width="1.5" stroke-dasharray="5,3"></rect>
+  <text x="499" y="706" text-anchor="middle" font-size="26" fill="#e2e8f0">+</text>
+  <text x="499" y="726" text-anchor="middle" font-size="12" font-weight="700" fill="#d1d5db">Future CLI</text>
+  <text x="499" y="742" text-anchor="middle" font-size="8.5" fill="#e2e8f0">any provider · extensible</text>
+
+  <text x="585" y="720" font-size="22" fill="#d1d5db" letter-spacing="2">···</text>
+  <text x="362" y="782" text-anchor="middle" font-size="9.5" fill="#94a3b8" font-style="italic">advisory output saved as artifacts</text>
+
+  
+  
+  <rect x="668" y="76" width="280" height="326" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1.5" filter="url(#sh)"></rect>
+  <text x="808" y="106" text-anchor="middle" font-size="14" font-weight="700" fill="#111827">Supported CLIs</text>
+  <line x1="686" y1="118" x2="930" y2="118" stroke="#f1f5f9" stroke-width="1"></line>
+
+  
+  <image x="686" y="126" width="18" height="18" preserveAspectRatio="xMidYMid meet"></image>
+  <text x="710" y="140" font-size="13" font-weight="700" fill="#111827">Claude Code</text>
+  <text x="686" y="154" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@anthropic/claude-code</text>
+  <text x="686" y="172" font-size="9.5" fill="#6b7280">Orchestrator</text>
+  <rect x="758" y="160" width="76" height="18" rx="9" fill="#dcfce7" stroke="#16a34a" stroke-width="1"></rect>
+  <text x="796" y="169" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#15803d">● SUPPORTED</text>
+  <text x="686" y="192" font-size="9.5" fill="#6b7280">Sub-agent</text>
+  <rect x="758" y="180" width="76" height="18" rx="9" fill="#dcfce7" stroke="#16a34a" stroke-width="1"></rect>
+  <text x="796" y="189" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#15803d">● SUPPORTED</text>
+  <line x1="686" y1="206" x2="930" y2="206" stroke="#f1f5f9" stroke-width="1"></line>
+
+  
+  <svg x="686" y="213" width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient gradientUnits="userSpaceOnUse" id="cx-panel" x1="12" x2="12" y1="3" y2="21"><stop stop-color="#B1A7FF"></stop><stop offset=".5" stop-color="#7A9DFF"></stop><stop offset="1" stop-color="#3941FF"></stop></linearGradient></defs><path d="M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z" fill="#fff"></path><path d="M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z" fill="url(#cx-panel)"></path></svg>
+  <text x="710" y="227" font-size="13" font-weight="700" fill="#111827">Codex CLI</text>
+  <text x="686" y="242" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@openai/codex</text>
+  <text x="686" y="260" font-size="9.5" fill="#6b7280">Orchestrator</text>
+  <rect x="758" y="248" width="70" height="18" rx="9" fill="#fef3c7" stroke="#d97706" stroke-width="1"></rect>
+  <text x="793" y="257" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#92400e">○ ROADMAP</text>
+  <text x="686" y="280" font-size="9.5" fill="#6b7280">Sub-agent</text>
+  <rect x="758" y="268" width="76" height="18" rx="9" fill="#dcfce7" stroke="#16a34a" stroke-width="1"></rect>
+  <text x="796" y="277" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#15803d">● SUPPORTED</text>
+  <line x1="686" y1="294" x2="930" y2="294" stroke="#f1f5f9" stroke-width="1"></line>
+
+  
+  <image x="686" y="301" width="18" height="18" preserveAspectRatio="xMidYMid meet"></image>
+  <text x="710" y="316" font-size="13" font-weight="700" fill="#111827">Gemini CLI</text>
+  <text x="686" y="330" font-size="8.5" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#9ca3af">@google/gemini-cli</text>
+  <text x="686" y="348" font-size="9.5" fill="#6b7280">Orchestrator</text>
+  <rect x="758" y="336" width="40" height="18" rx="9" fill="#f9fafb" stroke="#d1d5db" stroke-width="1"></rect>
+  <text x="778" y="345" text-anchor="middle" dominant-baseline="middle" font-size="8" fill="#9ca3af">— N/A</text>
+  <text x="686" y="368" font-size="9.5" fill="#6b7280">Sub-agent</text>
+  <rect x="758" y="356" width="76" height="18" rx="9" fill="#dcfce7" stroke="#16a34a" stroke-width="1"></rect>
+  <text x="796" y="365" text-anchor="middle" dominant-baseline="middle" font-size="8" font-weight="700" fill="#15803d">● SUPPORTED</text>
+  <text x="686" y="390" font-size="8.5" fill="#9ca3af" font-style="italic">● active  ○ roadmap  — not applicable</text>
+
+  
+  <rect x="668" y="416" width="280" height="132" rx="10" fill="white" stroke="#e2e8f0" stroke-width="1.5" filter="url(#sh)"></rect>
+  <text x="686" y="437" font-size="9" font-weight="700" letter-spacing="1.5" fill="#9ca3af">SESSION STORE</text>
+  <text x="686" y="456" font-size="13" font-weight="700" fill="#111827">💾 Session Store</text>
+  <rect x="686" y="463" width="244" height="70" rx="5" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1"></rect>
+  <text x="698" y="480" font-size="9" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#6b7280">~/.aco/runs/&lt;run-id&gt;/</text>
+  <text x="698" y="496" font-size="9" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#6b7280">~/.aco/sessions/&lt;uuid&gt;/</text>
+  <text x="698" y="512" font-size="9" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#94a3b8">ledger.json · brief.md · task.json</text>
+  <text x="698" y="526" font-size="9" font-family="&#39;Courier New&#39;,Courier,monospace" fill="#94a3b8">output.log · aco result</text>
 </svg>

--- a/docs/images/context-sync.svg
+++ b/docs/images/context-sync.svg
@@ -1,153 +1,68 @@
-<svg viewBox="0 0 720 320" xmlns="http://www.w3.org/2000/svg"
-     font-family="'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,sans-serif">
+<svg viewBox="0 0 720 348" xmlns="http://www.w3.org/2000/svg" font-family="&#39;Helvetica Neue&#39;,Helvetica,Arial,sans-serif">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fdf4ff"/>
-      <stop offset="50%" stop-color="#eef2ff"/>
-      <stop offset="100%" stop-color="#f0fdfa"/>
-    </linearGradient>
-
-    <!-- Gradients for components -->
-    <linearGradient id="purple-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
-    </linearGradient>
-    <linearGradient id="blue-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#2563eb"/>
-    </linearGradient>
-    <linearGradient id="slate-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#94a3b8"/>
-      <stop offset="100%" stop-color="#475569"/>
-    </linearGradient>
-    <linearGradient id="orange-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fbbf24"/>
-      <stop offset="100%" stop-color="#d97706"/>
-    </linearGradient>
-    <linearGradient id="green-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#34d399"/>
-      <stop offset="100%" stop-color="#059669"/>
-    </linearGradient>
-
-    <!-- Drop shadow filter -->
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
-      <feOffset dx="0" dy="2" result="offset-blur"/>
-      <feFlood flood-color="#1e1b4b" flood-opacity="0.15"/>
-      <feComposite in2="offset-blur" operator="in"/>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-
-    <!-- Arrow marker -->
-    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="6" markerHeight="6" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#64748b"/>
-    </marker>
+    <filter id="sh" x="-15%" y="-15%" width="130%" height="130%"><feDropShadow dx="0" dy="1" stdDeviation="3" flood-color="#0f172a" flood-opacity="0.07"></feDropShadow></filter>
+    <marker id="arr" viewBox="0 0 10 8" refX="9" refY="4" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0.5 L9 4 L0 7.5 z" fill="#94a3b8"></path></marker>
+    <linearGradient id="gm-cs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ea4335"></stop><stop offset="33%" stop-color="#fbbc04"></stop><stop offset="66%" stop-color="#34a853"></stop><stop offset="100%" stop-color="#4285f4"></stop></linearGradient>
   </defs>
-
-  <!-- Background -->
-  <rect width="720" height="320" rx="16" fill="url(#bg-grad)"/>
-
-  <!-- Decorative dots -->
-  <circle cx="20" cy="20" r="2.5" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="700" cy="20" r="2.5" fill="#3b82f6" opacity="0.4"/>
-
-  <!-- Title -->
-  <text x="360" y="28" text-anchor="middle" dominant-baseline="middle"
-        font-size="15" font-weight="700" fill="#1e293b" letter-spacing="0.3">Context 동기화 — aco sync</text>
-  <line x1="278" y1="44" x2="328" y2="44" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/>
-  <line x1="392" y1="44" x2="442" y2="44" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="360" cy="44" r="3" fill="#8b5cf6"/>
-
-  <!-- ─── LEFT: Claude Sources ─── -->
-  <g filter="url(#shadow)">
-    <rect x="20" y="60" width="210" height="240" rx="12" fill="white" stroke="#a78bfa" stroke-width="1.5"/>
-    <rect x="20" y="60" width="210" height="36" rx="12" fill="url(#purple-grad)"/>
-    <rect x="20" y="78" width="210" height="18" fill="url(#purple-grad)"/>
-  </g>
-  <text x="125" y="78" text-anchor="middle" dominant-baseline="middle"
-        font-size="13" font-weight="700" fill="white" letter-spacing="0.3">Claude Sources</text>
-
-  <!-- File entries -->
-  <text x="40" y="115" font-size="11" fill="#1e293b">📄  CLAUDE.md</text>
-  <text x="40" y="138" font-size="11" fill="#1e293b">📁  .claude/commands/aco.md</text>
-  <text x="40" y="161" font-size="11" fill="#1e293b">📁  .claude/skills/aco-delegation</text>
-  <text x="40" y="184" font-size="11" fill="#1e293b">📁  .claude/aco/tasks/</text>
-  <text x="40" y="207" font-size="11" fill="#1e293b">⚙️  settings.json</text>
-  <text x="40" y="230" font-size="11" fill="#1e293b">📋  agents/ · rules/*.md</text>
-
-  <line x1="32" y1="248" x2="218" y2="248" stroke="#e2e8f0" stroke-width="1"/>
-  <text x="125" y="266" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#94a3b8" font-style="italic">hand-maintained · one /aco command · consent gate</text>
-  <rect x="55" y="276" width="140" height="16" rx="8" fill="#f5f3ff" stroke="#a78bfa" stroke-width="0.5"/>
-  <text x="125" y="284" text-anchor="middle" dominant-baseline="middle"
-        font-size="9.5" fill="#7c3aed" font-weight="600">SOURCE OF TRUTH</text>
-
-  <!-- ─── CENTER: aco sync ─── -->
-  <g filter="url(#shadow)">
-    <rect x="278" y="138" width="124" height="48" rx="10" fill="url(#blue-grad)"/>
-  </g>
-  <text x="340" y="162" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white" letter-spacing="0.3">aco sync</text>
-
-  <!-- Arrow: left → center -->
-  <line x1="230" y1="162" x2="276" y2="162" stroke="#64748b" stroke-width="1.8" marker-end="url(#arrow)"/>
-  <text x="253" y="153" text-anchor="middle" font-size="9" font-weight="600" fill="#475569">reads</text>
-
-  <!-- Arrow: center → right -->
-  <line x1="402" y1="162" x2="448" y2="162" stroke="#64748b" stroke-width="1.8" marker-end="url(#arrow)"/>
-  <text x="425" y="153" text-anchor="middle" font-size="9" font-weight="600" fill="#475569">writes</text>
-
-  <!-- Manifest arrow: center → bottom -->
-  <line x1="340" y1="186" x2="340" y2="218" stroke="#64748b" stroke-width="1.5" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
-  <rect x="265" y="222" width="150" height="22" rx="11" fill="white" stroke="#94a3b8" stroke-width="1"/>
-  <text x="340" y="233" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#475569">.aco/sync-manifest.json</text>
-  <text x="340" y="258" text-anchor="middle" dominant-baseline="middle"
-        font-size="9" fill="#94a3b8" font-style="italic">drift tracking</text>
-
-  <!-- ─── RIGHT: Generated Targets ─── -->
-  <g filter="url(#shadow)">
-    <rect x="450" y="60" width="252" height="240" rx="12" fill="white" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="6,3"/>
-    <rect x="450" y="60" width="252" height="36" rx="12" fill="url(#slate-grad)"/>
-    <rect x="450" y="78" width="252" height="18" fill="url(#slate-grad)"/>
-  </g>
-  <text x="576" y="78" text-anchor="middle" dominant-baseline="middle"
-        font-size="13" font-weight="700" fill="white" letter-spacing="0.3">Generated Targets</text>
-
-  <!-- Codex section -->
-  <rect x="464" y="110" width="224" height="56" rx="8" fill="#fff7ed" stroke="#f59e0b" stroke-width="1"/>
-  <rect x="464" y="110" width="68" height="56" rx="8" fill="url(#orange-grad)"/>
-  <rect x="500" y="110" width="32" height="56" fill="url(#orange-grad)"/>
-  <text x="498" y="138" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="700" fill="white">Codex</text>
-  <text x="540" y="128" font-size="10" fill="#475569">AGENTS.md</text>
-  <text x="540" y="145" font-size="10" fill="#475569">.codex/agents/</text>
-  <text x="540" y="161" font-size="10" fill="#475569">.codex/hooks.json</text>
-
-  <!-- Gemini section -->
-  <rect x="464" y="174" width="224" height="56" rx="8" fill="#f0fdf4" stroke="#10b981" stroke-width="1"/>
-  <rect x="464" y="174" width="68" height="56" rx="8" fill="url(#green-grad)"/>
-  <rect x="500" y="174" width="32" height="56" fill="url(#green-grad)"/>
-  <text x="498" y="202" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="700" fill="white">Gemini</text>
-  <text x="540" y="192" font-size="10" fill="#475569">GEMINI.md</text>
-  <text x="540" y="209" font-size="10" fill="#475569">.gemini/agents/</text>
-  <text x="540" y="225" font-size="10" fill="#475569">.gemini/settings.json</text>
-
-  <!-- Shared section -->
-  <rect x="464" y="238" width="224" height="42" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1"/>
-  <rect x="464" y="238" width="68" height="42" rx="8" fill="url(#blue-grad)"/>
-  <rect x="500" y="238" width="32" height="42" fill="url(#blue-grad)"/>
-  <text x="498" y="259" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="700" fill="white">Shared</text>
-  <text x="540" y="254" font-size="10" fill="#475569">.agents/skills/</text>
-  <text x="540" y="270" font-size="9.5" fill="#94a3b8" font-style="italic">ACO-owned only</text>
-
-  <text x="576" y="293" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" fill="#94a3b8" font-style="italic">auto-generated · manifest-tracked</text>
+  <rect width="720" height="348" rx="14" fill="#f8fafc" stroke="#e2e8f0" stroke-width="1.5"></rect>
+  <text x="360" y="28" text-anchor="middle" font-size="13.5" font-weight="700" fill="#0f172a" letter-spacing="0.3">Context Sync — aco sync</text>
+  <line x1="255" y1="40" x2="312" y2="40" stroke="#fcd34d" stroke-width="1.5" stroke-linecap="round"></line>
+  <circle cx="360" cy="40" r="3" fill="#0d9488"></circle>
+  <line x1="408" y1="40" x2="465" y2="40" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round"></line>
+  <text x="32" y="58" font-size="8" font-weight="700" letter-spacing="1.8" fill="#a16207">SOURCE OF TRUTH</text>
+  <rect x="24" y="64" width="218" height="252" rx="10" fill="#fffbeb" stroke="#fcd34d" stroke-width="1.5" filter="url(#sh)"></rect>
+  <rect x="24" y="64" width="5" height="252" rx="2.5" fill="#d97706"></rect>
+  <rect x="57.6" y="75" width="2.8000000000000003" height="14" rx="1.4000000000000001" fill="#D97757" transform="rotate(0 59 82)"></rect><rect x="57.6" y="75" width="2.8000000000000003" height="14" rx="1.4000000000000001" fill="#D97757" transform="rotate(30 59 82)"></rect><rect x="57.6" y="75" width="2.8000000000000003" height="14" rx="1.4000000000000001" fill="#D97757" transform="rotate(60 59 82)"></rect><rect x="57.6" y="75" width="2.8000000000000003" height="14" rx="1.4000000000000001" fill="#D97757" transform="rotate(90 59 82)"></rect><rect x="57.6" y="75" width="2.8000000000000003" height="14" rx="1.4000000000000001" fill="#D97757" transform="rotate(120 59 82)"></rect><rect x="57.6" y="75" width="2.8000000000000003" height="14" rx="1.4000000000000001" fill="#D97757" transform="rotate(150 59 82)"></rect>
+  <text x="72" y="86" font-size="12" font-weight="700" fill="#92400e">Claude Sources</text>
+  <text x="72" y="101" font-size="9" fill="#a16207">hand-maintained</text>
+  <line x1="36" y1="110" x2="230" y2="110" stroke="#fde68a" stroke-width="1"></line>
+  <text x="51" y="128" font-size="10" fill="#78350f">CLAUDE.md</text>
+  <text x="51" y="148" font-size="10" fill="#78350f">.claude/commands/aco.md</text>
+  <text x="51" y="168" font-size="10" fill="#78350f">.claude/skills/aco-delegation</text>
+  <text x="51" y="188" font-size="10" fill="#78350f">.claude/aco/tasks/</text>
+  <text x="51" y="208" font-size="10" fill="#78350f">settings.json</text>
+  <text x="51" y="228" font-size="10" fill="#78350f">agents/  ·  rules/*.md</text>
+  <line x1="36" y1="242" x2="230" y2="242" stroke="#fde68a" stroke-width="1"></line>
+  <rect x="64" y="252" width="130" height="16" rx="8" fill="#fde68a"></rect>
+  <text x="129" y="260" text-anchor="middle" dominant-baseline="middle" font-size="8.5" font-weight="700" fill="#92400e" letter-spacing="0.5">ONE /aco COMMAND</text>
+  <text x="51" y="292" font-size="9" fill="#a16207" font-style="italic">consent gate entry point</text>
+  <line x1="242" y1="188" x2="284" y2="188" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"></line>
+  <text x="263" y="181" text-anchor="middle" font-size="8.5" font-weight="600" fill="#64748b">reads</text>
+  <rect x="286" y="162" width="148" height="52" rx="9" fill="#1e293b" stroke="#334155" stroke-width="1" filter="url(#sh)"></rect>
+  <rect x="286" y="162" width="5" height="52" rx="2.5" fill="#38bdf8"></rect>
+  <text x="360" y="184" text-anchor="middle" font-size="13" font-weight="700" fill="white">aco sync</text>
+  <text x="360" y="202" text-anchor="middle" font-size="9" fill="#94a3b8">drift detection  ·  manifest</text>
+  <line x1="434" y1="188" x2="476" y2="188" stroke="#cbd5e1" stroke-width="1.5" marker-end="url(#arr)"></line>
+  <text x="455" y="181" text-anchor="middle" font-size="8.5" font-weight="600" fill="#64748b">writes</text>
+  <line x1="360" y1="214" x2="360" y2="242" stroke="#cbd5e1" stroke-width="1.5" stroke-dasharray="4,2" marker-end="url(#arr)"></line>
+  <rect x="278" y="244" width="164" height="26" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1"></rect>
+  <text x="360" y="254" text-anchor="middle" dominant-baseline="middle" font-size="9.5" font-weight="600" fill="#475569">.aco/sync-manifest.json</text>
+  <text x="360" y="266" text-anchor="middle" font-size="8.5" fill="#94a3b8">drift tracking</text>
+  <text x="480" y="58" font-size="8" font-weight="700" letter-spacing="1.8" fill="#64748b">GENERATED TARGETS</text>
+  <rect x="478" y="64" width="218" height="252" rx="10" fill="#f8fafc" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="6,3" filter="url(#sh)"></rect>
+  <rect x="478" y="64" width="5" height="252" rx="2.5" fill="#94a3b8"></rect>
+  <text x="505" y="86" font-size="12" font-weight="700" fill="#374151">Generated Targets</text>
+  <text x="505" y="101" font-size="9" fill="#6b7280">managed by aco sync</text>
+  <line x1="490" y1="110" x2="684" y2="110" stroke="#e5e7eb" stroke-width="1"></line>
+  <rect x="490" y="118" width="196" height="40" rx="7" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1"></rect>
+  <rect x="490" y="118" width="4" height="40" rx="2" fill="#7c3aed"></rect>
+  <svg x="496" y="126" width="14" height="14" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="cx-cs1" gradientUnits="userSpaceOnUse" x1="12" x2="12" y1="3" y2="21"><stop stop-color="#B1A7FF"></stop><stop offset=".5" stop-color="#7A9DFF"></stop><stop offset="1" stop-color="#3941FF"></stop></linearGradient></defs><path d="M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z" fill="#fff"></path><path d="M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z" fill="url(#cx-cs1)"></path></svg>
+  <text x="514" y="130" font-size="9.5" font-weight="700" fill="#6d28d9">Codex CLI</text>
+  <text x="507" y="147" font-size="9" fill="#5b21b6">AGENTS.md  ·  .codex/agents/</text>
+  <rect x="490" y="166" width="196" height="56" rx="7" fill="#eff6ff" stroke="#93c5fd" stroke-width="1"></rect>
+  <rect x="490" y="166" width="4" height="56" rx="2" fill="#2563eb"></rect>
+  <path d="M503,174 C504.54,179.46 504.54,179.46 510,181 C504.54,182.54 504.54,182.54 503,188 C501.46,182.54 501.46,182.54 496,181 C501.46,179.46 501.46,179.46 503,174 Z" fill="url(#gm-cs)"></path>
+  <text x="514" y="184" font-size="9.5" font-weight="700" fill="#1d4ed8">Gemini CLI</text>
+  <text x="507" y="200" font-size="9" fill="#1e40af">GEMINI.md  ·  .gemini/agents/</text>
+  <text x="507" y="215" font-size="9" fill="#1e40af">.gemini/settings.json</text>
+  <rect x="490" y="230" width="196" height="42" rx="7" fill="#f0fdfa" stroke="#5eead4" stroke-width="1"></rect>
+  <rect x="490" y="230" width="4" height="42" rx="2" fill="#0d9488"></rect>
+  <text x="507" y="248" font-size="9.5" font-weight="700" fill="#0f766e">Shared</text>
+  <text x="507" y="264" font-size="9" fill="#0f766e">.agents/skills/  (ACO-owned only)</text>
+  <line x1="490" y1="280" x2="684" y2="280" stroke="#e5e7eb" stroke-width="1"></line>
+  <text x="588" y="308" text-anchor="middle" font-size="8.5" fill="#9ca3af" font-style="italic">auto-generated · manifest-tracked</text>
+  <rect x="253" y="284" width="214" height="50" rx="8" fill="white" stroke="#e2e8f0" stroke-width="1" filter="url(#sh)"></rect>
+  <text x="360" y="299" text-anchor="middle" font-size="9" font-weight="700" fill="#1e293b">sync --check</text>
+  <text x="360" y="314" text-anchor="middle" font-size="8.5" fill="#64748b">read-only drift check  ·  no changes written</text>
+  <text x="360" y="328" text-anchor="middle" font-size="8.5" fill="#64748b">--force  to regenerate targets</text>
 </svg>

--- a/docs/images/repository-structure.svg
+++ b/docs/images/repository-structure.svg
@@ -1,181 +1,129 @@
-<svg viewBox="0 0 760 460" xmlns="http://www.w3.org/2000/svg"
-     font-family="'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,sans-serif">
+<svg viewBox="0 0 760 460" xmlns="http://www.w3.org/2000/svg" font-family="&#39;Helvetica Neue&#39;,Helvetica,Arial,sans-serif">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fdf4ff"/>
-      <stop offset="50%" stop-color="#eef2ff"/>
-      <stop offset="100%" stop-color="#f0fdfa"/>
-    </linearGradient>
-
-    <!-- Component gradients -->
-    <linearGradient id="root-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <linearGradient id="purple-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
-    </linearGradient>
-    <linearGradient id="blue-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#2563eb"/>
-    </linearGradient>
-    <linearGradient id="cyan-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#22d3ee"/>
-      <stop offset="100%" stop-color="#0891b2"/>
-    </linearGradient>
-    <linearGradient id="orange-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fbbf24"/>
-      <stop offset="100%" stop-color="#d97706"/>
-    </linearGradient>
-    <linearGradient id="rose-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fb7185"/>
-      <stop offset="100%" stop-color="#e11d48"/>
-    </linearGradient>
-
-    <!-- Drop shadow -->
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
-      <feOffset dx="0" dy="2" result="offset-blur"/>
-      <feFlood flood-color="#1e1b4b" flood-opacity="0.15"/>
-      <feComposite in2="offset-blur" operator="in"/>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
+    <linearGradient id="bg-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fdf4ff"></stop><stop offset="50%" stop-color="#eef2ff"></stop><stop offset="100%" stop-color="#f0fdfa"></stop></linearGradient>
+    <linearGradient id="root-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#1e293b"></stop><stop offset="100%" stop-color="#0f172a"></stop></linearGradient>
+    <linearGradient id="blu-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#60a5fa"></stop><stop offset="100%" stop-color="#2563eb"></stop></linearGradient>
+    <linearGradient id="cya-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#22d3ee"></stop><stop offset="100%" stop-color="#0891b2"></stop></linearGradient>
+    <linearGradient id="ora-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fbbf24"></stop><stop offset="100%" stop-color="#d97706"></stop></linearGradient>
+    <linearGradient id="pur-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#a78bfa"></stop><stop offset="100%" stop-color="#7c3aed"></stop></linearGradient>
+    <linearGradient id="ros-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fb7185"></stop><stop offset="100%" stop-color="#e11d48"></stop></linearGradient>
+    <linearGradient id="sla-g-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#64748b"></stop><stop offset="100%" stop-color="#334155"></stop></linearGradient>
+    <linearGradient id="gm-rs" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ea4335"></stop><stop offset="33%" stop-color="#fbbc04"></stop><stop offset="66%" stop-color="#34a853"></stop><stop offset="100%" stop-color="#4285f4"></stop></linearGradient>
+    <filter id="sh-rs" x="-10%" y="-10%" width="120%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"></feGaussianBlur><feOffset dx="0" dy="2" result="ob"></feOffset><feFlood flood-color="#1e1b4b" flood-opacity="0.12"></feFlood><feComposite in2="ob" operator="in"></feComposite><feMerge><feMergeNode></feMergeNode><feMergeNode in="SourceGraphic"></feMergeNode></feMerge></filter>
   </defs>
 
-  <!-- Background -->
-  <rect width="760" height="460" rx="16" fill="url(#bg-grad)"/>
+  <rect width="760" height="460" rx="16" fill="url(#bg-g-rs)"></rect>
+  <circle cx="20" cy="20" r="2.5" fill="#8b5cf6" opacity="0.4"></circle><circle cx="740" cy="20" r="2.5" fill="#22d3ee" opacity="0.4"></circle>
+  <circle cx="20" cy="440" r="2.5" fill="#fb7185" opacity="0.4"></circle><circle cx="740" cy="440" r="2.5" fill="#fbbf24" opacity="0.4"></circle>
 
-  <!-- Decorative dots -->
-  <circle cx="20" cy="20" r="2.5" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="740" cy="20" r="2.5" fill="#22d3ee" opacity="0.4"/>
-  <circle cx="20" cy="440" r="2.5" fill="#fb7185" opacity="0.4"/>
-  <circle cx="740" cy="440" r="2.5" fill="#fbbf24" opacity="0.4"/>
+  <text x="380" y="28" text-anchor="middle" dominant-baseline="middle" font-size="15" font-weight="700" fill="#1e293b" letter-spacing="0.3">Repository Structure</text>
+  <line x1="290" y1="46" x2="340" y2="46" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"></line>
+  <line x1="420" y1="46" x2="470" y2="46" stroke="#22d3ee" stroke-width="2" stroke-linecap="round"></line>
+  <circle cx="380" cy="46" r="3" fill="#3b82f6"></circle>
 
-  <!-- Title -->
-  <text x="380" y="28" text-anchor="middle" dominant-baseline="middle"
-        font-size="15" font-weight="700" fill="#1e293b" letter-spacing="0.3">Repository Structure</text>
-  <line x1="290" y1="46" x2="340" y2="46" stroke="#a78bfa" stroke-width="2" stroke-linecap="round"/>
-  <line x1="420" y1="46" x2="470" y2="46" stroke="#22d3ee" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="380" cy="46" r="3" fill="#3b82f6"/>
+  
+  <g filter="url(#sh-rs)"><rect x="305" y="62" width="150" height="44" rx="10" fill="url(#root-g-rs)"></rect></g>
+  <text x="380" y="76" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="#94a3b8" letter-spacing="0.5">REPOSITORY</text>
+  <text x="380" y="93" text-anchor="middle" dominant-baseline="middle" font-size="13" font-weight="700" fill="white">/ (root)</text>
 
-  <!-- ─── ROOT ─── -->
-  <g filter="url(#shadow)">
-    <rect x="305" y="65" width="150" height="44" rx="10" fill="url(#root-grad)"/>
+  
+  <path d="M 380 106 Q 380 126 85 142" stroke="#94a3b8" stroke-width="1.5" fill="none"></path>
+  <path d="M 380 106 Q 380 126 229 142" stroke="#94a3b8" stroke-width="1.5" fill="none"></path>
+  <path d="M 380 106 Q 380 126 373 142" stroke="#94a3b8" stroke-width="1.5" fill="none"></path>
+  <path d="M 380 106 Q 380 126 517 142" stroke="#94a3b8" stroke-width="1.5" fill="none"></path>
+  <path d="M 380 106 Q 380 126 661 142" stroke="#94a3b8" stroke-width="1.5" fill="none"></path>
+
+  
+  <g filter="url(#sh-rs)">
+    <rect x="16" y="142" width="138" height="122" rx="10" fill="white" stroke="#60a5fa" stroke-width="1.5"></rect>
+    <rect x="16" y="142" width="138" height="30" rx="10" fill="url(#blu-g-rs)"></rect>
+    <rect x="16" y="157" width="138" height="15" fill="url(#blu-g-rs)"></rect>
   </g>
-  <text x="380" y="79" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="700" fill="#94a3b8" letter-spacing="0.5">REPOSITORY</text>
-  <text x="380" y="96" text-anchor="middle" dominant-baseline="middle"
-        font-size="14" font-weight="700" fill="white">📂  /</text>
+  <text x="85" y="157" text-anchor="middle" dominant-baseline="middle" font-size="10.5" font-weight="700" fill="white">packages/</text>
+  <text x="24" y="187" font-size="9" fill="#1e293b" font-weight="600">wrapper/</text>
+  <text x="30" y="201" font-size="8.5" fill="#64748b">aco CLI · runtime</text>
+  <text x="30" y="214" font-size="8.5" fill="#64748b">ask · run · sync</text>
+  <text x="24" y="230" font-size="9" fill="#1e293b" font-weight="600">installer/</text>
+  <text x="30" y="244" font-size="8.5" fill="#64748b">entrypoints</text>
 
-  <!-- ─── BRANCHES (curved lines from root) ─── -->
-  <path d="M 380 109 Q 380 130 100 145" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
-  <path d="M 380 109 Q 380 130 240 145" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
-  <path d="M 380 109 Q 380 130 380 145" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
-  <path d="M 380 109 Q 380 130 520 145" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
-  <path d="M 380 109 Q 380 130 660 145" stroke="#94a3b8" stroke-width="1.5" fill="none"/>
-
-  <!-- ───── BRANCH 1: packages/ (Node.js) ───── -->
-  <g filter="url(#shadow)">
-    <rect x="35" y="145" width="170" height="125" rx="10" fill="white" stroke="#60a5fa" stroke-width="1.5"/>
-    <rect x="35" y="145" width="170" height="32" rx="10" fill="url(#blue-grad)"/>
-    <rect x="35" y="161" width="170" height="16" fill="url(#blue-grad)"/>
+  
+  <g filter="url(#sh-rs)">
+    <rect x="160" y="142" width="138" height="122" rx="10" fill="white" stroke="#22d3ee" stroke-width="1.5"></rect>
+    <rect x="160" y="142" width="138" height="30" rx="10" fill="url(#cya-g-rs)"></rect>
+    <rect x="160" y="157" width="138" height="15" fill="url(#cya-g-rs)"></rect>
   </g>
-  <text x="120" y="161" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">📦  packages/</text>
-  <text x="48" y="196" font-size="10" fill="#1e293b" font-weight="600">wrapper/</text>
-  <text x="58" y="212" font-size="9.5" fill="#64748b">aco CLI · provider runtime</text>
-  <text x="58" y="226" font-size="9.5" fill="#64748b">ask · doctor · run · sync · pack</text>
-  <text x="48" y="246" font-size="10" fill="#1e293b" font-weight="600">installer/</text>
-  <text x="58" y="262" font-size="9.5" fill="#64748b">install-time entrypoints</text>
+  <text x="229" y="157" text-anchor="middle" dominant-baseline="middle" font-size="10.5" font-weight="700" fill="white">Go runtime</text>
+  <text x="168" y="187" font-size="9" fill="#1e293b" font-weight="600">cmd/aco/</text>
+  <text x="174" y="201" font-size="8.5" fill="#64748b">CLI entrypoint</text>
+  <text x="174" y="214" font-size="8.5" fill="#64748b">delegate · run</text>
+  <text x="168" y="230" font-size="9" fill="#1e293b" font-weight="600">internal/</text>
+  <text x="174" y="244" font-size="8.5" fill="#64748b">provider · runner</text>
 
-  <!-- ───── BRANCH 2: cmd + internal (Go) ───── -->
-  <g filter="url(#shadow)">
-    <rect x="225" y="145" width="170" height="125" rx="10" fill="white" stroke="#22d3ee" stroke-width="1.5"/>
-    <rect x="225" y="145" width="170" height="32" rx="10" fill="url(#cyan-grad)"/>
-    <rect x="225" y="161" width="170" height="16" fill="url(#cyan-grad)"/>
+  
+  <g filter="url(#sh-rs)">
+    <rect x="304" y="142" width="138" height="122" rx="10" fill="white" stroke="#fbbf24" stroke-width="1.5"></rect>
+    <rect x="304" y="142" width="138" height="30" rx="10" fill="url(#ora-g-rs)"></rect>
+    <rect x="304" y="157" width="138" height="15" fill="url(#ora-g-rs)"></rect>
   </g>
-  <text x="310" y="161" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">🐹  Go runtime</text>
-  <text x="238" y="196" font-size="10" fill="#1e293b" font-weight="600">cmd/aco/</text>
-  <text x="248" y="212" font-size="9.5" fill="#64748b">Go CLI entrypoint</text>
-  <text x="248" y="226" font-size="9.5" fill="#64748b">aco delegate · run</text>
-  <text x="238" y="246" font-size="10" fill="#1e293b" font-weight="600">internal/</text>
-  <text x="248" y="262" font-size="9.5" fill="#64748b">provider · runner</text>
+  <text x="373" y="157" text-anchor="middle" dominant-baseline="middle" font-size="10.5" font-weight="700" fill="white">templates/</text>
+  <text x="312" y="187" font-size="9" fill="#1e293b" font-weight="600">commands/</text>
+  <text x="318" y="201" font-size="8.5" fill="#64748b">slash cmd templates</text>
+  <text x="312" y="220" font-size="9" fill="#1e293b" font-weight="600">aco.md</text>
+  <text x="318" y="234" font-size="8.5" fill="#64748b">generic /aco</text>
 
-  <!-- ───── BRANCH 3: templates/ ───── -->
-  <g filter="url(#shadow)">
-    <rect x="305" y="145" width="150" height="125" rx="10" fill="white" stroke="#fbbf24" stroke-width="1.5"/>
-    <rect x="305" y="145" width="150" height="32" rx="10" fill="url(#orange-grad)"/>
-    <rect x="305" y="161" width="150" height="16" fill="url(#orange-grad)"/>
+  
+  <g filter="url(#sh-rs)">
+    <rect x="448" y="142" width="138" height="122" rx="10" fill="white" stroke="#a78bfa" stroke-width="1.5"></rect>
+    <rect x="448" y="142" width="138" height="30" rx="10" fill="url(#pur-g-rs)"></rect>
+    <rect x="448" y="157" width="138" height="15" fill="url(#pur-g-rs)"></rect>
   </g>
-  <text x="380" y="161" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">📋  templates/</text>
-  <text x="318" y="196" font-size="10" fill="#1e293b" font-weight="600">commands/</text>
-  <text x="328" y="212" font-size="9.5" fill="#64748b">slash command</text>
-  <text x="328" y="226" font-size="9.5" fill="#64748b">templates</text>
-  <text x="318" y="246" font-size="10" fill="#1e293b" font-weight="600">commands/aco.md</text>
-  <text x="328" y="262" font-size="9.5" fill="#64748b">generic /aco only</text>
+  <text x="517" y="157" text-anchor="middle" dominant-baseline="middle" font-size="10.5" font-weight="700" fill="white">docs/</text>
+  <text x="456" y="187" font-size="8.5" fill="#1e293b">architecture.md</text>
+  <text x="456" y="202" font-size="8.5" fill="#1e293b">security.md</text>
+  <text x="456" y="217" font-size="8.5" fill="#1e293b">session-artifacts</text>
+  <text x="456" y="232" font-size="8.5" fill="#1e293b">guides/</text>
+  <text x="456" y="247" font-size="8.5" fill="#1e293b">reference/</text>
 
-  <!-- ───── BRANCH 4: docs/ ───── -->
-  <g filter="url(#shadow)">
-    <rect x="465" y="145" width="130" height="125" rx="10" fill="white" stroke="#a78bfa" stroke-width="1.5"/>
-    <rect x="465" y="145" width="130" height="32" rx="10" fill="url(#purple-grad)"/>
-    <rect x="465" y="161" width="130" height="16" fill="url(#purple-grad)"/>
+  
+  <g filter="url(#sh-rs)">
+    <rect x="592" y="142" width="138" height="122" rx="10" fill="white" stroke="#fb7185" stroke-width="1.5"></rect>
+    <rect x="592" y="142" width="138" height="30" rx="10" fill="url(#ros-g-rs)"></rect>
+    <rect x="592" y="157" width="138" height="15" fill="url(#ros-g-rs)"></rect>
   </g>
-  <text x="530" y="161" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">📚  docs/</text>
-  <text x="478" y="196" font-size="9.5" fill="#1e293b">architecture.md</text>
-  <text x="478" y="212" font-size="9.5" fill="#1e293b">security.md</text>
-  <text x="478" y="228" font-size="9.5" fill="#1e293b">session-artifacts.md</text>
-  <text x="478" y="244" font-size="9.5" fill="#1e293b">guides/</text>
-  <text x="478" y="260" font-size="9.5" fill="#1e293b">reference/</text>
+  <text x="661" y="157" text-anchor="middle" dominant-baseline="middle" font-size="10.5" font-weight="700" fill="white">.github/</text>
+  <text x="600" y="187" font-size="9" fill="#1e293b" font-weight="600">workflows/</text>
+  <text x="606" y="201" font-size="8.5" fill="#64748b">ci.yml</text>
+  <text x="606" y="214" font-size="8.5" fill="#64748b">release.yml</text>
+  <text x="606" y="228" font-size="8.5" fill="#64748b">project sync</text>
 
-  <!-- ───── BRANCH 5: .github/workflows ───── -->
-  <g filter="url(#shadow)">
-    <rect x="605" y="145" width="120" height="125" rx="10" fill="white" stroke="#fb7185" stroke-width="1.5"/>
-    <rect x="605" y="145" width="120" height="32" rx="10" fill="url(#rose-grad)"/>
-    <rect x="605" y="161" width="120" height="16" fill="url(#rose-grad)"/>
+  
+  <line x1="30" y1="284" x2="730" y2="284" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"></line>
+  <text x="380" y="298" text-anchor="middle" dominant-baseline="middle" font-size="11" font-weight="700" fill="#475569" letter-spacing="0.3">Harness Surface</text>
+
+  
+  <g filter="url(#sh-rs)">
+    <rect x="20" y="314" width="346" height="118" rx="10" fill="white" stroke="#a78bfa" stroke-width="1.5"></rect>
+    <rect x="20" y="314" width="346" height="32" rx="10" fill="url(#pur-g-rs)"></rect>
+    <rect x="20" y="330" width="346" height="16" fill="url(#pur-g-rs)"></rect>
   </g>
-  <text x="665" y="161" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="700" fill="white">🚦  .github/</text>
-  <text x="615" y="196" font-size="9.5" fill="#1e293b" font-weight="600">workflows/</text>
-  <text x="625" y="212" font-size="9" fill="#64748b">ci.yml</text>
-  <text x="625" y="226" font-size="9" fill="#64748b">release.yml</text>
-  <text x="625" y="244" font-size="9" fill="#64748b">project sync</text>
+  <rect x="36.2" y="321" width="3.6" height="18" rx="1.8" fill="#D97757" transform="rotate(0 38 330)"></rect><rect x="36.2" y="321" width="3.6" height="18" rx="1.8" fill="#D97757" transform="rotate(30 38 330)"></rect><rect x="36.2" y="321" width="3.6" height="18" rx="1.8" fill="#D97757" transform="rotate(60 38 330)"></rect><rect x="36.2" y="321" width="3.6" height="18" rx="1.8" fill="#D97757" transform="rotate(90 38 330)"></rect><rect x="36.2" y="321" width="3.6" height="18" rx="1.8" fill="#D97757" transform="rotate(120 38 330)"></rect><rect x="36.2" y="321" width="3.6" height="18" rx="1.8" fill="#D97757" transform="rotate(150 38 330)"></rect>
+  <text x="193" y="330" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">.claude/  —  Source of Truth</text>
+  <text x="35" y="364" font-size="9.5" fill="#1e293b">commands/aco.md · no /aco:* explosion</text>
+  <text x="35" y="381" font-size="9.5" fill="#1e293b">skills/aco-delegation/ · aco/tasks/</text>
+  <text x="35" y="398" font-size="9.5" fill="#1e293b">settings.json · aco/prompts/ legacy</text>
+  <text x="35" y="416" font-size="9.5" fill="#94a3b8" font-style="italic">hand-maintained · task-specific behavior</text>
 
-  <!-- ─── HARNESS LAYER (Source vs Generated) ─── -->
-  <line x1="40" y1="290" x2="720" y2="290" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="380" y="305" text-anchor="middle" dominant-baseline="middle"
-        font-size="11" font-weight="700" fill="#475569" letter-spacing="0.3">Harness Surface</text>
-
-  <!-- Source: .claude/ -->
-  <g filter="url(#shadow)">
-    <rect x="50" y="320" width="320" height="115" rx="10" fill="white" stroke="#a78bfa" stroke-width="1.5"/>
-    <rect x="50" y="320" width="320" height="32" rx="10" fill="url(#purple-grad)"/>
-    <rect x="50" y="336" width="320" height="16" fill="url(#purple-grad)"/>
+  
+  <g filter="url(#sh-rs)">
+    <rect x="394" y="314" width="346" height="118" rx="10" fill="white" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="6,3"></rect>
+    <rect x="394" y="314" width="346" height="32" rx="10" fill="url(#sla-g-rs)"></rect>
+    <rect x="394" y="330" width="346" height="16" fill="url(#sla-g-rs)"></rect>
   </g>
-  <text x="210" y="336" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">🟣  .claude/  —  Source of Truth</text>
-  <text x="65" y="370" font-size="10" fill="#1e293b">📄 commands/aco.md · no /aco:* explosion</text>
-  <text x="65" y="388" font-size="10" fill="#1e293b">📁 skills/aco-delegation/ · aco/tasks/</text>
-  <text x="65" y="406" font-size="10" fill="#1e293b">⚙️ settings.json · aco/prompts/ legacy</text>
-  <text x="65" y="424" font-size="10" fill="#94a3b8" font-style="italic">hand-maintained · task-specific behavior via presets</text>
-
-  <!-- Generated targets -->
-  <g filter="url(#shadow)">
-    <rect x="390" y="320" width="320" height="115" rx="10" fill="white" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="6,3"/>
-    <rect x="390" y="320" width="320" height="32" rx="10" fill="#475569"/>
-    <rect x="390" y="336" width="320" height="16" fill="#475569"/>
-  </g>
-  <text x="550" y="336" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">⚪  Generated  —  managed by aco sync</text>
-  <text x="405" y="370" font-size="10" fill="#1e293b">📄 AGENTS.md · GEMINI.md</text>
-  <text x="405" y="388" font-size="10" fill="#1e293b">📁 .agents/skills/ (ACO-owned only)</text>
-  <text x="405" y="406" font-size="10" fill="#1e293b">📁 .codex/agents/ · .gemini/agents/</text>
-  <text x="405" y="424" font-size="10" fill="#94a3b8" font-style="italic">auto-generated · .aco/sync-manifest.json tracks drift</text>
+  <text x="567" y="330" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">Generated  —  managed by aco sync</text>
+  <text x="410" y="364" font-size="9.5" fill="#1e293b">AGENTS.md · GEMINI.md</text>
+  <text x="410" y="381" font-size="9.5" fill="#1e293b">.agents/skills/ (ACO-owned only)</text>
+  <svg x="410" y="390" width="13" height="13" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="cx-rs2" gradientUnits="userSpaceOnUse" x1="12" x2="12" y1="3" y2="21"><stop stop-color="#B1A7FF"></stop><stop offset=".5" stop-color="#7A9DFF"></stop><stop offset="1" stop-color="#3941FF"></stop></linearGradient></defs><path d="M19.503 0H4.496A4.496 4.496 0 000 4.496v15.007A4.496 4.496 0 004.496 24h15.007A4.496 4.496 0 0024 19.503V4.496A4.496 4.496 0 0019.503 0z" fill="#fff"></path><path d="M9.064 3.344a4.578 4.578 0 012.285-.312c1 .115 1.891.54 2.673 1.275.01.01.024.017.037.021a.09.09 0 00.043 0 4.55 4.55 0 013.046.275l.047.022.116.057a4.581 4.581 0 012.188 2.399c.209.51.313 1.041.315 1.595a4.24 4.24 0 01-.134 1.223.123.123 0 00.03.115c.594.607.988 1.33 1.183 2.17.289 1.425-.007 2.71-.887 3.854l-.136.166a4.548 4.548 0 01-2.201 1.388.123.123 0 00-.081.076c-.191.551-.383 1.023-.74 1.494-.9 1.187-2.222 1.846-3.711 1.838-1.187-.006-2.239-.44-3.157-1.302a.107.107 0 00-.105-.024c-.388.125-.78.143-1.204.138a4.441 4.441 0 01-1.945-.466 4.544 4.544 0 01-1.61-1.335c-.152-.202-.303-.392-.414-.617a5.81 5.81 0 01-.37-.961 4.582 4.582 0 01-.014-2.298.124.124 0 00.006-.056.085.085 0 00-.027-.048 4.467 4.467 0 01-1.034-1.651 3.896 3.896 0 01-.251-1.192 5.189 5.189 0 01.141-1.6c.337-1.112.982-1.985 1.933-2.618.212-.141.413-.251.601-.33.215-.089.43-.164.646-.227a.098.098 0 00.065-.066 4.51 4.51 0 01.829-1.615 4.535 4.535 0 011.837-1.388zm3.482 10.565a.637.637 0 000 1.272h3.636a.637.637 0 100-1.272h-3.636zM8.462 9.23a.637.637 0 00-1.106.631l1.272 2.224-1.266 2.136a.636.636 0 101.095.649l1.454-2.455a.636.636 0 00.005-.64L8.462 9.23z" fill="url(#cx-rs2)"></path></svg>
+  <path d="M426,391 C427.32,395.68 427.32,395.68 432,397 C427.32,398.32 427.32,398.32 426,403 C424.68,398.32 424.68,398.32 420,397 C424.68,395.68 424.68,395.68 426,391 Z" fill="url(#gm-rs)"></path>
+  <text x="440" y="398" font-size="9.5" fill="#1e293b">.codex/agents/ · .gemini/agents/</text>
+  <text x="410" y="416" font-size="9.5" fill="#94a3b8" font-style="italic">auto-generated · sync-manifest.json tracks drift</text>
 </svg>

--- a/docs/images/session-lifecycle.svg
+++ b/docs/images/session-lifecycle.svg
@@ -41,32 +41,32 @@
   <circle cx="197" cy="180" r="9" fill="#3b82f6"></circle>
   <text x="197" y="180" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">2</text>
   <rect x="252" y="158" width="135" height="18" rx="9" fill="white" stroke="#a78bfa" stroke-width="1"></rect>
-  <text x="319" y="167" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">계획 표시, 실행 없음</text>
+  <text x="319" y="167" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">Show plan; no execution</text>
   <line x1="240" y1="180" x2="394" y2="180" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#arr-p-sl)"></line>
   <circle cx="197" cy="225" r="9" fill="#3b82f6"></circle>
   <text x="197" y="225" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">3</text>
   <rect x="410" y="203" width="220" height="18" rx="9" fill="white" stroke="#2dd4bf" stroke-width="1"></rect>
-  <text x="520" y="212" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">--yes로 실행 + 세션 생성</text>
+  <text x="520" y="212" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">--yes creates session</text>
   <line x1="240" y1="225" x2="676" y2="225" stroke="#0d9488" stroke-width="1.5" marker-end="url(#arr-t-sl)"></line>
   <circle cx="197" cy="270" r="9" fill="#3b82f6"></circle>
   <text x="197" y="270" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">4</text>
   <rect x="330" y="248" width="180" height="18" rx="9" fill="white" stroke="#34d399" stroke-width="1"></rect>
-  <text x="420" y="257" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">어드바이저리 프로바이더 호출</text>
+  <text x="420" y="257" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">Invoke advisory provider</text>
   <line x1="240" y1="270" x2="544" y2="270" stroke="#10b981" stroke-width="1.5" marker-end="url(#arr-g-sl)"></line>
   <circle cx="595" cy="315" r="9" fill="#10b981"></circle>
   <text x="595" y="315" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">5</text>
   <rect x="270" y="293" width="160" height="18" rx="9" fill="white" stroke="#34d399" stroke-width="1"></rect>
-  <text x="350" y="302" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">전체 출력 스트리밍</text>
+  <text x="350" y="302" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">Stream full output</text>
   <line x1="550" y1="315" x2="246" y2="315" stroke="#10b981" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-g-sl)"></line>
   <circle cx="197" cy="360" r="9" fill="#3b82f6"></circle>
   <text x="197" y="360" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">6</text>
   <rect x="410" y="338" width="220" height="18" rx="9" fill="white" stroke="#2dd4bf" stroke-width="1"></rect>
-  <text x="520" y="347" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">레저 + 요약 + 로그 기록</text>
+  <text x="520" y="347" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">Write ledger + brief + logs</text>
   <line x1="240" y1="360" x2="676" y2="360" stroke="#0d9488" stroke-width="1.5" marker-end="url(#arr-t-sl)"></line>
   <circle cx="285" cy="405" r="9" fill="#3b82f6"></circle>
   <text x="285" y="405" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">7</text>
   <rect x="100" y="383" width="135" height="18" rx="9" fill="white" stroke="#60a5fa" stroke-width="1"></rect>
-  <text x="167" y="392" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">요약 / 경로 반환</text>
+  <text x="167" y="392" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">Return summary / paths</text>
   <line x1="240" y1="405" x2="91" y2="405" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-b-sl)"></line>
   <line x1="40" y1="445" x2="80" y2="445" stroke="#3b82f6" stroke-width="1.5"></line>
   <text x="88" y="445" dominant-baseline="middle" font-size="10" fill="#475569">solid: request</text>

--- a/docs/images/session-lifecycle.svg
+++ b/docs/images/session-lifecycle.svg
@@ -1,190 +1,76 @@
-<svg viewBox="0 0 760 480" xmlns="http://www.w3.org/2000/svg"
-     font-family="'Segoe UI',system-ui,-apple-system,BlinkMacSystemFont,sans-serif">
+<svg viewBox="0 0 760 480" xmlns="http://www.w3.org/2000/svg" font-family="&#39;Helvetica Neue&#39;,Helvetica,Arial,sans-serif">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#fdf4ff"/>
-      <stop offset="50%" stop-color="#eef2ff"/>
-      <stop offset="100%" stop-color="#f0fdfa"/>
-    </linearGradient>
-
-    <!-- Actor gradients -->
-    <linearGradient id="user-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f472b6"/>
-      <stop offset="100%" stop-color="#db2777"/>
-    </linearGradient>
-    <linearGradient id="cli-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#2563eb"/>
-    </linearGradient>
-    <linearGradient id="registry-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
-    </linearGradient>
-    <linearGradient id="provider-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#34d399"/>
-      <stop offset="100%" stop-color="#059669"/>
-    </linearGradient>
-    <linearGradient id="store-grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#2dd4bf"/>
-      <stop offset="100%" stop-color="#0d9488"/>
-    </linearGradient>
-
-    <!-- Drop shadow -->
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
-      <feOffset dx="0" dy="2" result="offset-blur"/>
-      <feFlood flood-color="#1e1b4b" flood-opacity="0.15"/>
-      <feComposite in2="offset-blur" operator="in"/>
-      <feMerge>
-        <feMergeNode/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-
-    <!-- Arrow markers -->
-    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#3b82f6"/>
-    </marker>
-    <marker id="arrow-purple" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#8b5cf6"/>
-    </marker>
-    <marker id="arrow-teal" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0d9488"/>
-    </marker>
-    <marker id="arrow-green" viewBox="0 0 10 10" refX="9" refY="5"
-            markerWidth="7" markerHeight="7" orient="auto">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#10b981"/>
-    </marker>
+    <linearGradient id="bg-sl" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#fdf4ff"></stop><stop offset="50%" stop-color="#eef2ff"></stop><stop offset="100%" stop-color="#f0fdfa"></stop></linearGradient>
+    <linearGradient id="usr-sl" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f472b6"></stop><stop offset="100%" stop-color="#db2777"></stop></linearGradient>
+    <linearGradient id="cli-sl" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#60a5fa"></stop><stop offset="100%" stop-color="#2563eb"></stop></linearGradient>
+    <linearGradient id="con-sl" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#a78bfa"></stop><stop offset="100%" stop-color="#7c3aed"></stop></linearGradient>
+    <linearGradient id="prv-sl" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#34d399"></stop><stop offset="100%" stop-color="#059669"></stop></linearGradient>
+    <linearGradient id="art-sl" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#2dd4bf"></stop><stop offset="100%" stop-color="#0d9488"></stop></linearGradient>
+    <filter id="sh-sl" x="-10%" y="-10%" width="120%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"></feGaussianBlur><feOffset dx="0" dy="2" result="ob"></feOffset><feFlood flood-color="#1e1b4b" flood-opacity="0.12"></feFlood><feComposite in2="ob" operator="in"></feComposite><feMerge><feMergeNode></feMergeNode><feMergeNode in="SourceGraphic"></feMergeNode></feMerge></filter>
+    <marker id="arr-b-sl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#3b82f6"></path></marker>
+    <marker id="arr-p-sl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#8b5cf6"></path></marker>
+    <marker id="arr-t-sl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#0d9488"></path></marker>
+    <marker id="arr-g-sl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M 0 0 L 10 5 L 0 10 z" fill="#10b981"></path></marker>
   </defs>
-
-  <!-- Background -->
-  <rect width="760" height="480" rx="16" fill="url(#bg-grad)"/>
-
-  <!-- Decorative dots -->
-  <circle cx="20" cy="20" r="2.5" fill="#ec4899" opacity="0.4"/>
-  <circle cx="740" cy="20" r="2.5" fill="#0d9488" opacity="0.4"/>
-
-  <!-- Title -->
-  <text x="380" y="26" text-anchor="middle" dominant-baseline="middle"
-        font-size="15" font-weight="700" fill="#1e293b" letter-spacing="0.3">Delegation Lifecycle — consent-gated aco ask</text>
-  <line x1="290" y1="44" x2="340" y2="44" stroke="#ec4899" stroke-width="2" stroke-linecap="round"/>
-  <line x1="420" y1="44" x2="470" y2="44" stroke="#0d9488" stroke-width="2" stroke-linecap="round"/>
-  <circle cx="380" cy="44" r="3" fill="#3b82f6"/>
-
-  <!-- ─── ACTOR HEADERS ─── -->
-  <!-- User -->
-  <g filter="url(#shadow)">
-    <rect x="25" y="60" width="120" height="40" rx="8" fill="url(#user-grad)"/>
-  </g>
-  <text x="85" y="80" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">👤  User</text>
-
-  <!-- aco CLI -->
-  <g filter="url(#shadow)">
-    <rect x="170" y="60" width="140" height="40" rx="8" fill="url(#cli-grad)"/>
-  </g>
-  <text x="240" y="80" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">⚙️  aco CLI</text>
-
-  <!-- Consent -->
-  <g filter="url(#shadow)">
-    <rect x="335" y="60" width="130" height="40" rx="8" fill="url(#registry-grad)"/>
-  </g>
-  <text x="400" y="80" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">✅  Consent</text>
-
-  <!-- Provider -->
-  <g filter="url(#shadow)">
-    <rect x="490" y="60" width="120" height="40" rx="8" fill="url(#provider-grad)"/>
-  </g>
-  <text x="550" y="80" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">🤖  Provider</text>
-
-  <!-- Artifacts -->
-  <g filter="url(#shadow)">
-    <rect x="630" y="60" width="105" height="40" rx="8" fill="url(#store-grad)"/>
-  </g>
-  <text x="682" y="80" text-anchor="middle" dominant-baseline="middle"
-        font-size="12" font-weight="700" fill="white">💾  Artifacts</text>
-
-  <!-- ─── LIFELINES (vertical dashed lines) ─── -->
-  <line x1="85"  y1="105" x2="85"  y2="450" stroke="#ec4899" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"/>
-  <line x1="240" y1="105" x2="240" y2="450" stroke="#3b82f6" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"/>
-  <line x1="400" y1="105" x2="400" y2="450" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"/>
-  <line x1="550" y1="105" x2="550" y2="450" stroke="#10b981" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"/>
-  <line x1="682" y1="105" x2="682" y2="450" stroke="#0d9488" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"/>
-
-  <!-- ─── MESSAGE 1: User → CLI: aco ask ─── -->
-  <circle cx="42" cy="135" r="9" fill="#ec4899"/>
-  <text x="42" y="135" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">1</text>
-  <line x1="85" y1="135" x2="234" y2="135" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arrow-blue)"/>
-  <rect x="100" y="120" width="135" height="18" rx="9" fill="white" stroke="#60a5fa" stroke-width="1"/>
-  <text x="167" y="129" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">aco ask --dry-run</text>
-
-  <!-- ─── MESSAGE 2: CLI → Consent: validate ─── -->
-  <circle cx="197" cy="180" r="9" fill="#3b82f6"/>
-  <text x="197" y="180" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">2</text>
-  <line x1="240" y1="180" x2="394" y2="180" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#arrow-purple)"/>
-  <rect x="252" y="165" width="135" height="18" rx="9" fill="white" stroke="#a78bfa" stroke-width="1"/>
-  <text x="319" y="174" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">show plan; no invoke</text>
-
-  <!-- ─── MESSAGE 3: CLI → Artifacts: create run/session ─── -->
-  <circle cx="197" cy="225" r="9" fill="#3b82f6"/>
-  <text x="197" y="225" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">3</text>
-  <line x1="240" y1="225" x2="676" y2="225" stroke="#0d9488" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
-  <rect x="430" y="210" width="200" height="18" rx="9" fill="white" stroke="#2dd4bf" stroke-width="1"/>
-  <text x="530" y="219" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">--yes creates run + session</text>
-
-  <!-- ─── MESSAGE 4: CLI → Provider: invoke ─── -->
-  <circle cx="197" cy="270" r="9" fill="#3b82f6"/>
-  <text x="197" y="270" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">4</text>
-  <line x1="240" y1="270" x2="544" y2="270" stroke="#10b981" stroke-width="1.5" marker-end="url(#arrow-green)"/>
-  <rect x="345" y="255" width="160" height="18" rx="9" fill="white" stroke="#34d399" stroke-width="1"/>
-  <text x="425" y="264" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">invoke advisory provider</text>
-
-  <!-- ─── MESSAGE 5: Provider → CLI: stream output (dashed return) ─── -->
-  <circle cx="595" cy="315" r="9" fill="#10b981"/>
-  <text x="595" y="315" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">5</text>
-  <line x1="550" y1="315" x2="246" y2="315" stroke="#10b981" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-green)"/>
-  <rect x="290" y="300" width="135" height="18" rx="9" fill="white" stroke="#34d399" stroke-width="1"/>
-  <text x="357" y="309" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">stream full output</text>
-
-  <!-- ─── MESSAGE 6: CLI → Store: write log ─── -->
-  <circle cx="197" cy="360" r="9" fill="#3b82f6"/>
-  <text x="197" y="360" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">6</text>
-  <line x1="240" y1="360" x2="676" y2="360" stroke="#0d9488" stroke-width="1.5" marker-end="url(#arrow-teal)"/>
-  <rect x="430" y="345" width="200" height="18" rx="9" fill="white" stroke="#2dd4bf" stroke-width="1"/>
-  <text x="530" y="354" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">write ledger + brief + logs</text>
-
-  <!-- ─── MESSAGE 7: CLI → User: result/error (dashed return) ─── -->
-  <circle cx="285" cy="405" r="9" fill="#3b82f6"/>
-  <text x="285" y="405" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="700" fill="white">7</text>
-  <line x1="240" y1="405" x2="91" y2="405" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arrow-blue)"/>
-  <rect x="100" y="390" width="135" height="18" rx="9" fill="white" stroke="#60a5fa" stroke-width="1"/>
-  <text x="167" y="399" text-anchor="middle" dominant-baseline="middle"
-        font-size="10" font-weight="500" fill="#1e293b">bounded summary / paths</text>
-
-  <!-- ─── LEGEND ─── -->
-  <line x1="40" y1="445" x2="80" y2="445" stroke="#3b82f6" stroke-width="1.5"/>
+  <rect width="760" height="480" rx="16" fill="url(#bg-sl)"></rect>
+  <circle cx="20" cy="20" r="2.5" fill="#ec4899" opacity="0.4"></circle><circle cx="740" cy="20" r="2.5" fill="#0d9488" opacity="0.4"></circle>
+  <text x="380" y="26" text-anchor="middle" dominant-baseline="middle" font-size="15" font-weight="700" fill="#1e293b" letter-spacing="0.3">Delegation Lifecycle — consent-gated aco ask</text>
+  <line x1="290" y1="44" x2="340" y2="44" stroke="#ec4899" stroke-width="2" stroke-linecap="round"></line>
+  <line x1="420" y1="44" x2="470" y2="44" stroke="#0d9488" stroke-width="2" stroke-linecap="round"></line>
+  <circle cx="380" cy="44" r="3" fill="#3b82f6"></circle>
+  <g filter="url(#sh-sl)"><rect x="25" y="60" width="120" height="40" rx="8" fill="url(#usr-sl)"></rect></g>
+  <text x="85" y="80" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">User</text>
+  <g filter="url(#sh-sl)"><rect x="170" y="60" width="140" height="40" rx="8" fill="url(#cli-sl)"></rect></g>
+  <text x="240" y="80" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">aco CLI</text>
+  <g filter="url(#sh-sl)"><rect x="335" y="60" width="130" height="40" rx="8" fill="url(#con-sl)"></rect></g>
+  <text x="400" y="80" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">Consent</text>
+  <g filter="url(#sh-sl)"><rect x="490" y="60" width="120" height="40" rx="8" fill="url(#prv-sl)"></rect></g>
+  <text x="550" y="80" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">Provider</text>
+  <g filter="url(#sh-sl)"><rect x="630" y="60" width="105" height="40" rx="8" fill="url(#art-sl)"></rect></g>
+  <text x="682" y="80" text-anchor="middle" dominant-baseline="middle" font-size="12" font-weight="700" fill="white">Artifacts</text>
+  <line x1="85" y1="105" x2="85" y2="450" stroke="#ec4899" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"></line>
+  <line x1="240" y1="105" x2="240" y2="450" stroke="#3b82f6" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"></line>
+  <line x1="400" y1="105" x2="400" y2="450" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"></line>
+  <line x1="550" y1="105" x2="550" y2="450" stroke="#10b981" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"></line>
+  <line x1="682" y1="105" x2="682" y2="450" stroke="#0d9488" stroke-width="1" stroke-dasharray="3,3" opacity="0.45"></line>
+  <circle cx="42" cy="135" r="9" fill="#ec4899"></circle>
+  <text x="42" y="135" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">1</text>
+  <rect x="100" y="113" width="135" height="18" rx="9" fill="white" stroke="#60a5fa" stroke-width="1"></rect>
+  <text x="167" y="122" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">aco ask --dry-run</text>
+  <line x1="85" y1="135" x2="234" y2="135" stroke="#3b82f6" stroke-width="1.5" marker-end="url(#arr-b-sl)"></line>
+  <circle cx="197" cy="180" r="9" fill="#3b82f6"></circle>
+  <text x="197" y="180" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">2</text>
+  <rect x="252" y="158" width="135" height="18" rx="9" fill="white" stroke="#a78bfa" stroke-width="1"></rect>
+  <text x="319" y="167" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">계획 표시, 실행 없음</text>
+  <line x1="240" y1="180" x2="394" y2="180" stroke="#8b5cf6" stroke-width="1.5" marker-end="url(#arr-p-sl)"></line>
+  <circle cx="197" cy="225" r="9" fill="#3b82f6"></circle>
+  <text x="197" y="225" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">3</text>
+  <rect x="410" y="203" width="220" height="18" rx="9" fill="white" stroke="#2dd4bf" stroke-width="1"></rect>
+  <text x="520" y="212" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">--yes로 실행 + 세션 생성</text>
+  <line x1="240" y1="225" x2="676" y2="225" stroke="#0d9488" stroke-width="1.5" marker-end="url(#arr-t-sl)"></line>
+  <circle cx="197" cy="270" r="9" fill="#3b82f6"></circle>
+  <text x="197" y="270" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">4</text>
+  <rect x="330" y="248" width="180" height="18" rx="9" fill="white" stroke="#34d399" stroke-width="1"></rect>
+  <text x="420" y="257" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">어드바이저리 프로바이더 호출</text>
+  <line x1="240" y1="270" x2="544" y2="270" stroke="#10b981" stroke-width="1.5" marker-end="url(#arr-g-sl)"></line>
+  <circle cx="595" cy="315" r="9" fill="#10b981"></circle>
+  <text x="595" y="315" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">5</text>
+  <rect x="270" y="293" width="160" height="18" rx="9" fill="white" stroke="#34d399" stroke-width="1"></rect>
+  <text x="350" y="302" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">전체 출력 스트리밍</text>
+  <line x1="550" y1="315" x2="246" y2="315" stroke="#10b981" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-g-sl)"></line>
+  <circle cx="197" cy="360" r="9" fill="#3b82f6"></circle>
+  <text x="197" y="360" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">6</text>
+  <rect x="410" y="338" width="220" height="18" rx="9" fill="white" stroke="#2dd4bf" stroke-width="1"></rect>
+  <text x="520" y="347" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">레저 + 요약 + 로그 기록</text>
+  <line x1="240" y1="360" x2="676" y2="360" stroke="#0d9488" stroke-width="1.5" marker-end="url(#arr-t-sl)"></line>
+  <circle cx="285" cy="405" r="9" fill="#3b82f6"></circle>
+  <text x="285" y="405" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="700" fill="white">7</text>
+  <rect x="100" y="383" width="135" height="18" rx="9" fill="white" stroke="#60a5fa" stroke-width="1"></rect>
+  <text x="167" y="392" text-anchor="middle" dominant-baseline="middle" font-size="10" font-weight="500" fill="#1e293b">요약 / 경로 반환</text>
+  <line x1="240" y1="405" x2="91" y2="405" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="5,3" marker-end="url(#arr-b-sl)"></line>
+  <line x1="40" y1="445" x2="80" y2="445" stroke="#3b82f6" stroke-width="1.5"></line>
   <text x="88" y="445" dominant-baseline="middle" font-size="10" fill="#475569">solid: request</text>
-  <line x1="180" y1="445" x2="220" y2="445" stroke="#10b981" stroke-width="1.5" stroke-dasharray="5,3"/>
+  <line x1="180" y1="445" x2="220" y2="445" stroke="#10b981" stroke-width="1.5" stroke-dasharray="5,3"></line>
   <text x="228" y="445" dominant-baseline="middle" font-size="10" fill="#475569">dashed: response / async</text>
-  <text x="510" y="445" dominant-baseline="middle" font-size="10" fill="#475569">brief is bounded; save-only hides body; full is explicit</text>
+  <text x="510" y="445" dominant-baseline="middle" font-size="10" fill="#475569">--yes required to invoke</text>
 </svg>


### PR DESCRIPTION
## Summary

- architecture-overview·context-sync SVG를 개선본으로 교체하고, session-lifecycle·repository-structure 다이어그램 2종을 신규 추가했습니다.
- session-lifecycle SVG는 Consent-Gated Delegation 섹션에 배치해 `--dry-run` → consent → `--yes` 실행 흐름을 시각화합니다.
- repository-structure SVG와 실제 디렉터리 역할 표를 담은 "저장소 구조" 섹션을 신규 추가하고 상단 네비게이션 배지를 보강했습니다.
- license 배지가 실제 `package.json`(`"license": "MIT"`)과 달리 ISC로 표기되어 있던 불일치를 수정했습니다.

## Notes

- 첨부된 SVG 4종은 그대로 사용했으며, README 본문은 코드베이스 실제 구조(`cli.ts` 명령 9종, `providers/` 3종, `.claude/` harness, root `cmd/aco`·`internal/`)를 기준으로 검증했습니다.
- "Go runtime"이 별도 디렉터리가 아니라 root `cmd/aco/`·`internal/`의 개념적 그룹임을 명시했습니다.

## Test plan

- [ ] GitHub에서 README 렌더링 확인 (SVG 4종 표시, 네비게이션 앵커 동작)
- [ ] license 배지가 MIT로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)