### PR TITLE
docs(aco): ACO.md 사용 가이드 추가 및 README에 각 CLI 참조 안내

### DIFF
--- a/ACO.md
+++ b/ACO.md
@@ -1,0 +1,135 @@
+# ACO — AI CLI Orchestration Wrapper
+
+`aco`는 외부 AI CLI에 자문 작업을 위임하는 consent-gated wrapper입니다.
+실제 provider를 호출하기 전에 반드시 실행 계획을 미리 확인해야 합니다.
+
+---
+
+## 빠른 시작 — 동의 흐름 (consent-gated flow)
+
+```bash
+# 1단계: 실행 계획 미리보기 (provider 호출 없음)
+aco ask --task "TypeScript 타입 에러 분석" --providers antigravity --dry-run
+
+# 2단계: 계획 확인 후 실제 실행
+aco ask --task "TypeScript 타입 에러 분석" --providers antigravity --yes
+```
+
+> ※ 주의: 위 예시의 provider를 `codex`로 바꿔 **Codex CLI 세션 안에서** 실행하면 self-delegation(재귀)이 됩니다. Codex 세션에서는 `--providers antigravity`(또는 다른 peer)를 쓰세요. [주의 사항](#주의-사항-caution) 참고.
+
+`--yes` 없이 실행하면 `Consent required` 안내만 출력하고 종료합니다(인터랙티브 동의 프롬프트는 없습니다).
+실행 계획은 `--dry-run`으로 확인하고, 실제 위임은 계획 확인 후 `--yes`로 실행하세요.
+
+---
+
+## 서브커맨드 목록
+
+| 커맨드 | 설명 |
+|---|---|
+| `aco ask` | 작업을 AI provider에 위임 |
+| `aco sync` | Claude 구조적 소스(skills, agents)를 Codex 표면(`.agents/skills/`, `.codex/agents/`)으로 동기화 — 가이드라인 markdown(`AGENTS.md`/`GEMINI.md`)은 생성하지 않음 |
+| `aco delegate <agent-id>` | `.claude/agents/<agent-id>.md`로 로컬 프롬프트 구성 (외부 호출 없음) |
+| `aco doctor` | 환경 및 provider 설정 진단 |
+| `aco run <provider> <command>` | provider에 원시 커맨드 직접 전달 |
+| `aco result` | 마지막 위임 결과 조회 |
+| `aco status` | 진행 중인 위임 작업 상태 확인 |
+| `aco cancel` | 진행 중인 작업 취소 |
+| `aco pack {install\|uninstall\|status\|setup}` | pack 관리 |
+| `aco provider setup <name>` | provider 초기 설정 |
+
+---
+
+## aco ask — 상세 옵션
+
+```
+aco ask --task <text>
+        [--providers codex,antigravity,mock]
+        [--input <text>]
+        [--input-file <path>]
+        [--preset <name>]
+        [--permission-profile restricted|default|unrestricted]
+        [--output-mode brief|save-only|full]
+        [--model <model>]
+        [--dry-run | --yes]
+```
+
+### 옵션 설명
+
+- `--task` — 위임할 작업 설명 (`--preset` 미사용 시 필수)
+- `--providers` — 사용할 provider 목록, 쉼표로 구분
+- `--input` / `--input-file` — 추가 컨텍스트 텍스트 또는 파일
+- `--preset` — 사전 정의된 설정 프로파일 적용
+- `--permission-profile` — `restricted`(기본값) | `default` | `unrestricted`
+- `--output-mode` — `brief`(기본값, 전체 출력은 아티팩트로 저장) | `save-only` | `full`
+- `--model` — provider가 지원하는 경우 모델 지정
+- `--dry-run` — 실행 계획만 출력, provider 호출 없음
+- `--yes` — 동의 프롬프트 없이 즉시 실행
+
+---
+
+## Provider 목록
+
+`aco ask`의 `--providers` 플래그에 사용할 수 있는 provider:
+
+| Provider | 설명 |
+|---|---|
+| `codex` | OpenAI Codex CLI |
+| `antigravity` | Antigravity (agy) CLI |
+| `mock` | 테스트용 mock provider |
+
+**기본(default) provider는 `mock`입니다.** `--providers`를 생략하면 mock이 사용됩니다.
+실제 작업을 위임할 때는 반드시 `--providers codex` 또는 `--providers antigravity`를 명시하세요.
+
+---
+
+## aco sync — 구조적 표면 동기화
+
+`aco sync`는 Claude 구조적 소스(`.claude/skills/`, `.claude/agents/`)를 Codex 표면(`.agents/skills/`, `.codex/agents/`)으로 변환합니다.
+**가이드라인 markdown(`AGENTS.md`/`GEMINI.md`)은 생성·동기화하지 않습니다** — `AGENTS.md`는 hand-maintained peer 문서이고 `GEMINI.md`는 제거되었습니다.
+
+```bash
+aco sync            # Claude skills/agents → Codex 구조적 표면 동기화
+aco sync --check    # 스테일 대상 감지 (변경 없음)
+aco sync --dry-run  # 변경 사항 미리보기
+aco sync --force    # 관리 drift 덮어쓰기 (의도적 강제 동기화)
+```
+
+---
+
+## aco delegate — 로컬 에이전트 프롬프트 구성
+
+```bash
+aco delegate <agent-id>
+```
+
+`.claude/agents/<agent-id>.md`를 읽어 로컬 프롬프트를 구성합니다.
+**외부 AI CLI 호출이 없습니다.** 에이전트 정의 파일 기반의 로컬 작업에만 사용됩니다.
+
+---
+
+## 주의 사항 (caution)
+
+### 재귀(self-delegation) 위험
+
+Codex 세션 내부에서 `aco ask --providers codex`를 호출하면 **재귀(self-delegation)** 가 됩니다.
+동일 provider를 중첩 호출하는 구조라 컨텍스트 혼선이나 예기치 않은 동작이 생길 수 있습니다.
+
+**권장**: repo 정책상 Codex 세션의 peer는 `antigravity`/`mock`입니다. `--providers antigravity`(또는 다른 peer)로 위임하세요.
+
+```bash
+# Codex 세션 내부에서 — 이렇게 하지 마세요
+aco ask --task "..." --providers codex   # 재귀 위험
+
+# 대신 peer provider로 위임
+aco ask --task "..." --providers antigravity
+```
+
+### permission-profile 주의
+
+`--permission-profile unrestricted`는 provider에 광범위한 파일시스템·네트워크 권한을 허용합니다.
+신뢰할 수 없는 작업에는 기본값인 `restricted`를 사용하세요.
+
+### --yes 플래그 주의
+
+`--yes`는 동의 절차를 건너뜁니다. 자동화 스크립트에서만 사용하고,
+새 작업을 처음 위임할 때는 `--dry-run`으로 계획을 먼저 확인하세요.

--- a/README.md
+++ b/README.md
@@ -790,6 +790,120 @@ node packages/wrapper/dist/cli.js sync --check
 
 <br/>
 
+## 📋 각 CLI 가이드라인 파일에 ACO.md 참조 추가하기
+
+`ACO.md`는 이 저장소의 `aco` 사용법을 요약한 레퍼런스 문서입니다.
+각 AI CLI의 가이드라인 파일에 `ACO.md`를 참조해 두면, 해당 CLI가 세션을 시작할 때마다
+`aco` 사용 방법을 자동으로 컨텍스트에 포함할 수 있습니다.
+
+> **참고:** Claude Code의 `@ACO.md` 인라인 import 구문은 Claude Code 고유 기능입니다.
+> **Codex**는 이 구문을 지원하지 않으므로 `AGENTS.md`에 일반 텍스트 *포인터*(파일을 가리키는 지시문)를 둡니다 — 내용이 자동 인라인되지 않고 에이전트가 필요 시 `ACO.md`를 읽습니다.
+> **Antigravity(agy)**는 Rules 파일에서 자체 `@filename` 참조를 지원합니다(공식 docs 기준). 따라서 텍스트 포인터 또는 `@` 참조 둘 다 가능합니다.
+
+---
+
+### Claude Code
+
+Claude Code는 `CLAUDE.md`에서 `@파일명` 구문으로 다른 파일을 인라인 임포트할 수 있습니다.
+
+**경로 안전성 주의사항:** `@ACO.md`는 참조된 파일이 실제로 존재하는 위치에서만 해석됩니다.
+사용자 레벨 `~/.claude/CLAUDE.md`에 `@ACO.md`를 추가하면, `ACO.md`가 없는 프로젝트에서는
+**해석 오류**가 발생할 수 있습니다. 전역 참조 시 두 가지 방법 중 하나를 선택합니다.
+
+**방법 A — 글로벌 설치 (사본 방식):**
+
+```bash
+# ACO.md를 ~/.claude/에 사본으로 복사 (저장소 루트에서 실행)
+cp ACO.md ~/.claude/ACO.md
+
+# ~/.claude/CLAUDE.md에 추가
+echo "" >> ~/.claude/CLAUDE.md
+echo "@ACO.md" >> ~/.claude/CLAUDE.md
+```
+
+**방법 B — 절대경로 사용:**
+
+```
+# ~/.claude/CLAUDE.md 또는 프로젝트 CLAUDE.md
+@/absolute/path/to/repo/ACO.md
+```
+
+**프로젝트 한정 참조 (저장소 내부에서만 사용하는 경우):**
+
+```
+# 저장소 루트 CLAUDE.md — ACO.md가 이 repo에 존재하므로 안전
+@ACO.md
+```
+
+---
+
+### Codex
+
+Codex는 `@`-import를 지원하지 않습니다. 프로젝트 루트의 `AGENTS.md`에 일반 텍스트로
+`ACO.md`를 참조하는 지시문을 추가합니다. `AGENTS.md`는 `aco sync`가 생성하지 않으므로
+직접 편집합니다.
+
+이 참조는 *포인터*입니다 — `AGENTS.md`가 `ACO.md` 내용을 자동으로 인라인하지 않고,
+에이전트가 지시에 따라 `ACO.md`를 읽도록 안내하는 역할입니다. `AGENTS.md`에 아래 줄을 추가합니다:
+
+```markdown
+> aco 사용법은 저장소 루트의 ACO.md를 참고한다. 위임 작업 전 ACO.md를 읽을 것.
+```
+
+사용자 레벨 설정으로 관리하려면 `~/.codex/AGENTS.md`를 사용하는 방법도 있으나,
+이 파일의 지원 여부는 Codex CLI 버전에 따라 다를 수 있으므로 공식 문서를 확인합니다.
+
+---
+
+### Antigravity (agy)
+
+Antigravity는 `~/.gemini/GEMINI.md`를 사용자 레벨 글로벌 룰 파일로 지원합니다.
+이 파일에 `ACO.md` 참조를 추가하면 모든 워크스페이스에 적용됩니다.
+
+```bash
+# ~/.gemini/GEMINI.md에 참조 추가
+cat >> ~/.gemini/GEMINI.md << 'EOF'
+
+## ACO 사용법
+
+aco 사용법은 저장소 루트의 ACO.md를 참고한다.
+EOF
+```
+
+**`@` 참조 사용 (선택):** Antigravity Rules 파일은 `@filename` 참조를 지원합니다. 상대경로는
+Rules 파일 위치 기준, 절대경로(`@/abs/path/ACO.md`)는 그대로 해석되며, 그 외에는 워크스페이스
+기준으로 resolve됩니다. 따라서 텍스트 포인터 대신 `~/.gemini/GEMINI.md`에 `@/절대경로/ACO.md`를
+넣어 내용을 끌어올 수도 있습니다.
+
+> **경로 안전 주의(Claude와 동일):** 전역 `~/.gemini/GEMINI.md`에 단순 상대경로 `@ACO.md`를 쓰면
+> `~/.gemini/ACO.md` → 현재 워크스페이스 순으로 resolve를 시도하므로, `ACO.md`가 없는 다른
+> 프로젝트에서 `agy`를 띄우면 탐색 오류/룰 누락이 납니다. 전역 룰에서는 **절대경로(`@/절대경로/ACO.md`)**
+> 또는 사본을 사용하세요. 단순 텍스트 포인터(파일 참조)는 이 문제에서 자유롭습니다.
+
+> **참고:** 이 저장소는 프로젝트 루트 `GEMINI.md`를 `aco sync` 생성 대상에서 제거했습니다.
+> 이미 워크스페이스 정책용으로 프로젝트 루트 `GEMINI.md`를 유지하고 있는 사용자는
+> 해당 파일에 직접 추가할 수 있으나, 글로벌 적용에는 `~/.gemini/GEMINI.md`를 우선합니다.
+> 워크스페이스 룰 표면으로는 `.agents/rules/`도 사용할 수 있습니다(Rules 전용 디렉터리).
+
+---
+
+### 요약
+
+| CLI | 파일 | 방법 |
+|-----|------|------|
+| Claude Code | `~/.claude/CLAUDE.md` 또는 프로젝트 `CLAUDE.md` | `@ACO.md` 또는 절대경로 (`@`-import는 Claude Code 고유 기능) |
+| Codex | `AGENTS.md` (프로젝트 루트, 직접 유지보수) | 일반 텍스트 참조 |
+| Antigravity (agy) | `~/.gemini/GEMINI.md` (사용자 레벨 글로벌 룰) | 일반 텍스트 참조 |
+
+> 이 설정은 수동 작업입니다. `aco sync`는 사용자 홈 디렉터리의 파일을 자동으로 편집하지 않습니다.
+
+<br/>
+
+<!-- ────────────── SECTION DIVIDER ────────────── -->
+<img src="https://capsule-render.vercel.app/api?type=rect&color=gradient&customColorList=12&height=3" width="100%" />
+
+<br/>
+
 ## 📚 문서
 
 <table>

--- a/docs/reference/context-sync.md
+++ b/docs/reference/context-sync.md
@@ -42,7 +42,7 @@ Do not add `/aco:review`, `/aco:spec-review`, `/aco:plan-review`, or similar tas
 
 | 표면                      | Codex CLI 0.122.0                                | Antigravity (`agy`)               |
 | ------------------------- | ------------------------------------------------ | --------------------------------- |
-| 프로젝트 지침             | `AGENTS.md`                                      | (없음 — `agy`는 AGENTS.md 미지원) |
+| 프로젝트 지침             | `AGENTS.md`                                      | (`aco sync` 생성 없음 — 아래 주의 참조) |
 | Skills                    | `.agents/skills/<skill>/SKILL.md`                | `.agents/skills/<skill>/SKILL.md` |
 | Custom agents             | `.codex/agents/*.toml`                           | (없음 — agent 표면 미지원)        |
 | 비대화형 prompt           | `codex exec [PROMPT]`                            | `agy --prompt <prompt>`           |
@@ -51,6 +51,8 @@ Do not add `/aco:review`, `/aco:spec-review`, `/aco:plan-review`, or similar tas
 Codex는 공유 skill을 `.agents/skills/<skill>/`에서 읽는다. `.codex/skills/`는 `aco sync`가 관리하는 공유 표면이 아니다. 단, `.codex/skills/aco/`처럼 hand-maintained Codex-local 일급 진입점(`$aco`)은 존재한다.
 
 > **AGENTS.md 주의**: 위 표의 `AGENTS.md`는 Codex CLI 런타임이 읽는 경로를 나타낼 뿐이다. `AGENTS.md`는 `aco sync`가 생성하거나 관리하지 않는다. 사람이 직접 유지보수하는 peer 문서이다.
+>
+> **agy capability vs sync 구분**: 표의 "프로젝트 지침" agy 칸이 "생성 없음"인 것은 **`aco sync`가 agy용 project-instruction target을 생성하지 않는다**는 sync-파이프라인 사실이지, agy CLI가 해당 파일을 못 읽는다는 뜻이 아니다. Antigravity CLI는 워크스페이스 루트의 로컬 `AGENTS.md`/`GEMINI.md`를 startup에 파싱하지만, `aco sync`의 자동 생성·동기화 대상에서만 제외된다(hand-maintained). 전역 가이드라인은 `~/.gemini/GEMINI.md`(global rules, 전 workspace 적용)로 로드된다.
 >
 > **Gemini 제거 주의**: Phases 1-3 마이그레이션으로 Gemini CLI provider가 제거되었다. `GEMINI.md`는 더 이상 `aco sync` 생성 대상이 아니다. `.gemini/agents/*`도 sync 대상에서 제외된다.
 

--- a/openspec/changes/aco-md-readme-reference/.openspec.yaml
+++ b/openspec/changes/aco-md-readme-reference/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/aco-md-readme-reference/design.md
+++ b/openspec/changes/aco-md-readme-reference/design.md
@@ -1,0 +1,89 @@
+## Context
+
+aco는 provider-neutral wrapper로 Claude / Codex / Antigravity(agy)를 묶지만, "각 CLI에서 aco를 어떻게 쓰는가"를 담은 단일 사용 가이드가 없다. 사용자 전역 `CLAUDE.md`의 `@RTK.md` 패턴(rtk 사용법을 user-level guideline이 import)을 aco에도 적용하려 한다.
+
+현재 surface 사실(머지된 main 기준, `docs/reference/context-sync.md` + routine-harness Antigravity knowledge):
+- `AGENTS.md`는 #150 이후 `aco sync`가 생성/관리하지 않는 hand-maintained peer 문서다.
+- Antigravity(agy)는 GEMINI.md/AGENTS.md를 실제로 읽는다: user-level `~/.gemini/GEMINI.md`(global rules, 전 workspace), workspace root `GEMINI.md`/`AGENTS.md`(startup 파싱), `.agents/rules/`. 저장소 문서의 "agy AGENTS.md 미지원"은 `aco sync`가 agy용 target을 생성하지 않는다는 sync-파이프라인 진술이지 CLI capability가 아니다.
+- `@`-import는 Claude Code 고유 기능이다.
+
+제약: 사용자 요청상 (1) 명령어를 추가하지 않는다, (2) `aco sync` 자동화를 추가하지 않는다(README 안내 전용), (3) repo가 사용자 홈을 자동 수정하지 않는다.
+
+## Goals / Non-Goals
+
+**Goals:**
+- root `ACO.md` 단일 사용 가이드 신설.
+- README에 provider별 ACO.md 참조 설정 방법 문서화(Claude/Codex/Antigravity).
+- 참조 모델이 실제 CLI 동작과 일치하고 `aco sync`에 회귀를 주지 않음을 보장.
+
+**Non-Goals:**
+- 새 slash/CLI 명령어, `aco sync` managed block/생성 target.
+- repo가 사용자 user-level 파일(`~/.claude/CLAUDE.md`, `~/.gemini/GEMINI.md` 등)을 자동 편집/설치하는 기능.
+- aco runtime/provider/delegation 동작 변경.
+
+## Decisions
+
+### ADR-1: ACO.md 참조를 sync managed block이 아니라 README 수동 안내로 제공
+
+**Context**: 각 CLI guideline이 ACO.md를 참조하게 하는 방법은 (A) `aco sync`가 managed block을 생성·주입, (B) README가 사람이 직접 편집하도록 안내, 두 갈래다.
+
+| 차원 | A: sync managed block | B: README 수동 안내 |
+|------|----------------------|---------------------|
+| 복잡도 | High (sync 엔진·manifest·target 확장) | Low (문서만) |
+| 사용자 요청 부합 | 위반(자동화 추가) | 부합 |
+| user-level surface 도달 | 불가(sync는 project-scoped) | 가능(`~/.claude`, `~/.gemini`) |
+| 회귀 위험 | sync contract 변경 위험 | 코드 무변경 |
+
+**Decision**: B. `@RTK.md`가 user-level `~/.claude/CLAUDE.md`에서 동작하듯, ACO.md 참조는 본질적으로 user-level 설정이고 sync(project-scoped)로는 도달할 수 없다. 사용자도 명령어·sync 추가를 명시적으로 배제했다.
+
+**Alternatives 기각**: A는 sync가 닿지 못하는 user-level surface가 핵심이라 부적합하고, AGENTS.md는 애초에 sync 비대상(hand-maintained)이라 managed block을 둘 수 없다.
+
+### ADR-2: provider별 참조 위치를 capability에 맞춰 분기
+
+**Decision**:
+- Claude → `~/.claude/CLAUDE.md` `@ACO.md`. 단 ACO.md가 참조 경로에 실제 존재해야 하므로 `~/.claude/ACO.md` 사본 또는 절대경로를 안내(ADR-4 참조).
+- Codex → project root `AGENTS.md`(hand-maintained) 명시 텍스트 참조 1순위 + 복사용 표준 문구. user `~/.codex/AGENTS.md` 전역 로딩은 미검증이라 선택 대안.
+- Antigravity → user-level `~/.gemini/GEMINI.md`(global rules) 명시 참조 1순위. project root `GEMINI.md`는 이 repo가 sync 제거했으므로 권장하지 않고 caveat 대안으로 강등. `.agents/rules/`도 대안.
+
+**Rationale**: `@`-import는 Claude 전용이라 Codex/agy엔 적용 불가 → 명시 텍스트 참조. agy의 global rules 위치가 `~/.gemini/GEMINI.md`(knowledge 검증: routine-harness rules-workflows.md, gcli-migration.md)라 전 workspace 적용 가능. 지원 provider registry는 `codex`/`antigravity`/`mock`(기본 `mock`)이므로 ACO.md는 셋 모두를 표기하고, Codex 세션이 codex를 호출하는 self-delegation 재귀는 caveat로 분리한다.
+
+**Alternative 기각**: "모든 provider에 `@import` 통일"은 Codex/agy가 그 문법을 지원하지 않아 무효. "project root `GEMINI.md` 권장"은 repo가 GEMINI.md를 sync 비대상으로 제거한 현 상태와 충돌해 사용자를 오도하므로 기각.
+
+### ADR-4: Claude 전역 참조는 경로 명시(사본/절대경로)로 안전화
+
+**Context**: `~/.claude/CLAUDE.md`의 `@ACO.md`는 활성 workspace root 기준 상대 resolve라, repo root ACO.md를 가리키리라는 보장이 없고 ACO.md 없는 다른 프로젝트에서 로드 실패할 수 있다(두 리뷰어 공통 P1).
+
+**Decision**: README는 전역 참조 시 (a) `~/.claude/ACO.md` 사본 + `@ACO.md`, 또는 (b) 절대경로 `@/abs/path/ACO.md`를 안내하고, project `CLAUDE.md`의 `@ACO.md`는 해당 repo 내에서만 안전하다는 한계를 경고한다.
+
+**Trade-off**: 사본/절대경로는 ACO.md 갱신 시 동기화 부담이 있으나, 깨진 참조보다 안전. RTK.md(`~/RTK.md`)와 동일한 user-level 사본 관례.
+
+### ADR-3: ACO.md를 user-level 가이드 문서로 취급하고 배치 경로를 README에 안내
+
+**Decision**: ACO.md는 repo에 작성하되, `@ACO.md`/명시 참조가 user-level guideline에서 해석되려면 경로가 필요하므로 README가 배치/경로(예: repo 참조 또는 `~/ACO.md` 사본) 안내를 포함한다. repo는 자동 복사하지 않는다.
+
+**Trade-off**: 자동 설치가 없어 사용자가 한 번 수동 설정해야 한다(= RTK.md와 동일 UX). 단순성·범위 최소화를 위해 수용.
+
+## Risks / Trade-offs
+
+- [문서-실제 동작 드리프트] ACO.md가 aco 실제 서브커맨드와 어긋날 수 있음 → 검증 단계에서 현재 브랜치 aco와 대조(spec scenario), 향후 변경 시 ACO.md 동기 갱신을 maintenance note로 남김.
+- [저장소 문서 모순] `context-sync.md`의 "agy AGENTS.md 미지원" 문구가 manual-reference 맥락과 충돌해 독자 혼동 → 해당 문구를 "sync 비생성 vs CLI capability" 구분으로 보강.
+- [user-level 경로 의존] user-level guideline에서 repo의 ACO.md를 참조할 때 경로 깨짐 가능 → README가 권장 배치(사본/절대경로)와 한계를 명시.
+- [범위 누수] 편의상 명령어/sync 자동화를 추가하려는 유혹 → Non-Goals와 spec의 "미추가" requirement로 차단. 추가로 allowlist diff gate(코드/명령/sync source 경로 무변경)와 ACO.md/README의 sync target 미등록 정적 대조로 적극 증명.
+- [provider 목록 오기] 문서가 `antigravity`/`mock`만 적으면 실제 registry(`codex` 포함)와 어긋남 → ACO.md에 `codex`/`antigravity`/`mock`(기본 `mock`) 전체 표기 + Codex self-delegation 재귀 caveat.
+- [전역 경로 미검증] Codex `~/.codex/AGENTS.md`, agy global path의 런타임 인식은 독립 재검증 전까지 불확실 → Codex는 project root `AGENTS.md`를 1순위로, agy는 knowledge 검증된 `~/.gemini/GEMINI.md`만 1순위로 두고 1회 spot check 권장.
+
+## Testing Strategy
+
+docs-only 변경이라 testing pyramid의 무게중심은 정적 검증(문서 계약)과 회귀 가드에 둔다.
+
+- **정적/구조 검증(many, fast)**: `ACO.md` 존재 및 필수 섹션(서브커맨드·위임 흐름·peers·주의사항) 포함 확인. `README.md`의 참조 안내 섹션이 세 provider 경로/메커니즘을 모두 포함하는지 확인. grep 기반 체크로 충분.
+- **회귀 가드(integration)**: `aco sync --check`(필요 시 `--strict`) 통과. 추가로 **allowlist diff gate** — `packages/wrapper/src/cli.ts`, `.../commands/`, `.../sync/`, `.claude/commands/`, `templates/commands/`, `.agents/skills/`, `.codex/agents/`에 변경이 없음을 `git diff`로 증명(소극적 통과를 넘어 적극적 무변경 증명). **적극적 제외 검증** — `.aco/sync.yaml`/sync 대상에 `ACO.md`/`README.md`가 미등록임을 정적 대조.
+- **artifact schema gate**: `openspec validate aco-md-readme-reference --type change --strict` 통과 — docs-only라도 OpenSpec artifact 정합 유지.
+- **정확성 대조(high-confidence)**: ACO.md에 적힌 서브커맨드/플래그를 현재 브랜치 `aco --help`/CLI usage와 대조해 폐기/오타 명령이 없는지 확인. agy 참조 경로가 knowledge(`~/.gemini/GEMINI.md` global rules)와 일치하는지 확인.
+- **수동 동작 확인(few, e2e, 선택)**: 문서대로 설정 시 Claude `@ACO.md`가 로드되고 agy가 GEMINI.md를 파싱하는지 1회 스폿 체크. 자동화 비대상이라 회귀 스위트에는 넣지 않는다.
+- **커버리지 타깃**: spec의 모든 scenario가 정적 체크 또는 회귀 명령으로 1:1 매핑. skip 대상: 산문 표현 스타일, 문서 포맷팅.
+
+## Open Questions
+
+- ACO.md 배치 권장안을 "repo 파일 직접 참조"로 할지 "`~/`로 사본 안내"로 할지 — README 작성 시 RTK.md 관례에 맞춰 확정(기본: 사용자가 자기 user-level guideline에서 참조 가능한 형태로 안내).
+- `context-sync.md` 문구 보강을 본 change에 포함할지 별도 doc chore로 뺄지 — 현 범위에선 포함(혼동 제거가 본 기능의 정확성과 직결).

--- a/openspec/changes/aco-md-readme-reference/proposal.md
+++ b/openspec/changes/aco-md-readme-reference/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+aco는 Claude / Codex / Antigravity(agy)를 한 wrapper로 묶지만, 각 CLI가 `aco`를 어떻게 호출·위임하는지에 대한 단일 사용 가이드가 없다. 사용자는 provider별로 호출 방식을 따로 익혀야 한다. 사용자 전역 `CLAUDE.md`가 `@RTK.md`로 rtk 사용법을 끌어오듯, aco 사용법을 담은 단일 `ACO.md`를 만들고 각 CLI guideline이 이를 참조하게 하면 학습 비용이 사라진다.
+
+## What Changes
+
+- repo root에 aco 사용 가이드 `ACO.md`를 신설한다. aco 주요 서브커맨드, consent-gated 위임 흐름(`aco ask --dry-run` → `--yes`), 지원 provider 전체(`codex`/`antigravity`/`mock`, 기본값 `mock`), Codex 세션이 codex provider를 호출하는 self-delegation 재귀 caveat, 주의사항을 담는다.
+- README에 "각 CLI guideline에서 ACO.md를 참조하는 방법"을 안내하는 섹션을 추가한다. provider별 참조 위치와 메커니즘을 문서화한다:
+  - Claude: user `~/.claude/CLAUDE.md`에서 `@ACO.md`를 쓰려면 ACO.md가 해당 참조 경로에 실제 존재해야 한다. repo root ACO.md는 임의 프로젝트에서 자동 resolve되지 않으므로, (a) `~/.claude/ACO.md`로 사본을 두고 `@ACO.md`, 또는 (b) 절대경로 `@/abs/path/ACO.md`를 안내한다. project root `CLAUDE.md`에서 `@ACO.md`는 그 repo 안에서만 안전하다는 한계를 경고한다.
+  - Codex: project root `AGENTS.md`(hand-maintained)에 ACO.md 명시 텍스트 참조를 1순위로 안내하고, 복사-붙여넣기용 표준 문구 예시를 제공한다. user `~/.codex/AGENTS.md` 전역 로딩은 검증 전까지 선택 대안으로 둔다.
+  - Antigravity(agy): user-level `~/.gemini/GEMINI.md`(global rules, 전 workspace 적용, knowledge 검증됨)에 ACO.md 참조를 1순위로 고정한다. 이 repo는 `GEMINI.md`를 sync 생성 대상에서 제거했으므로 project root `GEMINI.md`는 권장하지 않고, 기존 workspace 정책이 있을 때만 쓰는 caveat 대안으로 강등한다. `.agents/rules/`도 대안으로 명시한다.
+- 새 slash/CLI 명령어를 추가하지 **않는다**. `aco sync` 자동화/managed block을 추가하지 **않는다**(README 안내 전용).
+- 참조 추가가 sync 비대상 surface(AGENTS.md 등)에만 닿으므로 `aco sync --check`에 회귀가 없음을 보장한다.
+
+## Capabilities
+
+### New Capabilities
+- `aco-usage-guide`: aco 사용법을 담은 `ACO.md` 문서와, 각 CLI guideline(Claude/Codex/Antigravity)에서 그 문서를 참조하도록 설정하는 README 안내. 명령어·sync 자동화 없이 문서와 수동 참조 설정만 정의한다.
+
+### Modified Capabilities
+<!-- 없음 — 기존 spec의 요구사항 변경 없음. aco-v2-spec은 runtime/delegation 계약이라 본 문서-surface 추가와 무관. -->
+
+## Impact
+
+- 신규 파일: root `ACO.md`.
+- 수정 파일: `README.md`(참조 안내 섹션 추가). 정합 확인용으로 `docs/reference/context-sync.md`의 "agy AGENTS.md 미지원" 문구가 manual-reference 맥락과 혼동되지 않게 보강(sync 비생성 vs CLI capability 구분).
+- 코드 변경 없음: wrapper runtime, provider 구현, `aco sync` 엔진, 명령어 surface는 그대로다.
+- 외부 영향: 사용자가 자기 환경의 user-level guideline 파일을 수동 편집하도록 안내(README). repo가 사용자 홈을 자동 수정하지 않는다.

--- a/openspec/changes/aco-md-readme-reference/specs/aco-usage-guide/spec.md
+++ b/openspec/changes/aco-md-readme-reference/specs/aco-usage-guide/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: ACO.md 사용 가이드 문서
+
+repo root에 `ACO.md`가 존재해야 하며(SHALL), aco CLI의 주요 서브커맨드, consent-gated 위임 흐름(`aco ask --dry-run` 후 `--yes`), 지원 provider 전체(`codex`/`antigravity`/`mock`, 기본값 `mock`), 그리고 사용 시 주의사항을 담아야 한다(SHALL). 가이드 내용은 현재 브랜치의 실제 aco 동작과 일치해야 한다(MUST).
+
+#### Scenario: ACO.md가 핵심 사용법을 담는다
+- **WHEN** repo root의 `ACO.md`를 연다
+- **THEN** aco 주요 서브커맨드, consent-gated 위임 흐름, 지원 provider 전체(`codex`/`antigravity`/`mock`)와 기본값(`mock`), 주의사항 섹션이 모두 존재한다
+
+#### Scenario: 가이드가 실제 CLI 동작과 일치한다
+- **WHEN** `ACO.md`에 기술된 서브커맨드·위임 플래그·provider 목록을 현재 브랜치 aco(`aco ask --help`, registry)와 대조한다
+- **THEN** 문서에 존재하지 않거나 폐기된 명령/플래그/provider가 없다
+
+#### Scenario: Codex self-delegation caveat가 명시된다
+- **WHEN** Codex 세션에서 `aco ask --providers codex`로 codex를 호출하는 경우의 안내를 읽는다
+- **THEN** self-delegation(재귀) 위험과 권장 회피(다른 peer로 위임)가 caveat로 기술되어 있다
+
+### Requirement: README 참조 설정 안내
+
+`README.md`는 각 CLI guideline 문서에서 `ACO.md`를 참조하도록 설정하는 방법을 안내해야 한다(SHALL). 안내는 Claude, Codex, Antigravity 세 provider 각각의 참조 위치와 메커니즘을 명시해야 한다(MUST).
+
+#### Scenario: README가 provider별 참조 방법을 안내한다
+- **WHEN** `README.md`의 ACO.md 참조 안내 섹션을 읽는다
+- **THEN** Claude는 `~/.claude` 경로의 `@ACO.md` import, Codex는 project root `AGENTS.md` 명시 참조, Antigravity는 user-level `~/.gemini/GEMINI.md` 참조로 각각 기술되어 있다
+
+#### Scenario: @-import 한계가 명시된다
+- **WHEN** Codex/Antigravity 참조 안내를 읽는다
+- **THEN** `@`-import는 Claude Code 고유 기능이며 Codex/agy는 명시 텍스트 참조를 사용한다는 점이 안내되고, Codex 참조에는 복사-붙여넣기용 표준 문구 예시가 포함된다
+
+### Requirement: Claude 참조 경로 안전성 안내
+
+README의 Claude 안내는 `@ACO.md`가 참조 파일이 실제 존재하는 경로에서만 해석된다는 점을 명시해야 한다(SHALL). repo root `ACO.md`가 임의 프로젝트에서 자동 resolve되지 않으므로, user-level 전역 참조를 원할 경우 `~/.claude/ACO.md` 사본 또는 절대경로(`@/abs/path/ACO.md`) 사용을 안내해야 한다(SHALL).
+
+#### Scenario: 전역 참조 경로 안전 안내
+- **WHEN** Claude 참조 안내를 읽는다
+- **THEN** `~/.claude/CLAUDE.md`의 `@ACO.md`가 ACO.md 미존재 프로젝트에서 깨질 수 있다는 경고와, `~/.claude/ACO.md` 사본 또는 절대경로 대안이 함께 제시된다
+
+### Requirement: Antigravity 참조는 user-level GEMINI.md 우선
+
+README의 Antigravity 안내는 `~/.gemini/GEMINI.md`(global rules, 전 workspace 적용)를 1순위 참조 위치로 제시해야 한다(SHALL). 이 repo가 `GEMINI.md`를 `aco sync` 생성 대상에서 제거했으므로 project root `GEMINI.md`는 권장하지 않으며(SHALL NOT 권장), 기존 workspace 정책이 있을 때만 쓰는 caveat 대안으로만 명시해야 한다(SHALL). `.agents/rules/`도 대안으로 명시할 수 있다.
+
+#### Scenario: agy 안내가 user-level을 1순위로 둔다
+- **WHEN** Antigravity 참조 안내를 읽는다
+- **THEN** `~/.gemini/GEMINI.md`가 1순위로 제시되고, project root `GEMINI.md`는 권장이 아닌 caveat 대안으로만 표기된다
+
+### Requirement: context-sync 문서 정합은 sync target 미추가
+
+`docs/reference/context-sync.md`의 "agy AGENTS.md 미지원" 문구는 "agy가 로컬 `AGENTS.md`/`GEMINI.md`를 파싱하나 `aco sync` 자동 생성 대상에서만 제외된다(hand-maintained)"는 의미로 보강해야 한다(SHALL). 이 보강은 새 `aco sync` 생성 target을 추가하지 않으며 manual/runtime reference caveat 문구에 한정해야 한다(SHALL NOT 새 target 추가).
+
+#### Scenario: 문서 정합이 sync target을 늘리지 않는다
+- **WHEN** `context-sync.md` 보강 후 sync 대상 목록을 확인한다
+- **THEN** "sync 비생성 vs CLI capability" 구분 문구만 추가되고 새 sync 생성 target은 없다
+
+### Requirement: 명령어·sync 자동화 미추가
+
+이 변경은 새 slash/CLI 명령어를 추가하지 않아야 하며(SHALL NOT), `ACO.md` 참조를 위한 `aco sync` managed block이나 생성 target을 추가하지 않아야 한다(SHALL NOT). 참조는 사람이 직접 편집하는 surface에만 적용된다.
+
+#### Scenario: command/sync source 무변경 (allowlist diff gate)
+- **WHEN** 변경 후 `packages/wrapper/src/cli.ts`, `packages/wrapper/src/commands/`, `packages/wrapper/src/sync/`, `.claude/commands/`, `templates/commands/`, `.agents/skills/`, `.codex/agents/`의 diff를 확인한다
+- **THEN** 위 경로에 변경이 없다(문서 외 surface 무변경)
+
+#### Scenario: ACO.md/README가 sync target에 미등록
+- **WHEN** `.aco/sync.yaml`과 `aco sync` 대상 목록을 정적으로 대조한다
+- **THEN** `ACO.md`와 `README.md`가 sync 생성/관리 target에 포함되어 있지 않다
+
+#### Scenario: sync 무회귀
+- **WHEN** 변경 적용 후 `aco sync --check`(가능하면 `--strict`)를 실행한다
+- **THEN** stale/conflict 없이 통과한다(exit 0)

--- a/openspec/changes/aco-md-readme-reference/tasks.md
+++ b/openspec/changes/aco-md-readme-reference/tasks.md
@@ -1,0 +1,28 @@
+## 1. ACO.md 작성
+
+- [x] 1.1 현재 브랜치 aco 서브커맨드/위임 플래그/provider registry 수집 (`aco ask --help`, `aco --help`, registry: `codex`/`antigravity`/`mock`)
+- [x] 1.2 root `ACO.md` 작성: 목적, 주요 서브커맨드, consent-gated 위임 흐름(`aco ask --dry-run` → `--yes`), 지원 provider 전체(`codex`/`antigravity`/`mock`, 기본값 `mock`), 주의사항
+- [x] 1.3 Codex self-delegation(재귀) caveat 추가: Codex 세션에서 `--providers codex` 호출 위험과 다른 peer 위임 권장
+- [x] 1.4 ACO.md 내용을 1.1 수집 결과와 대조해 폐기/오타 명령·플래그·provider 제거 (spec: 가이드-실제 동작 일치)
+
+## 2. README 참조 안내 추가
+
+- [x] 2.1 README에 "ACO.md 참조 설정" 섹션 신설 (RTK.md user-level 패턴 설명 포함)
+- [x] 2.2 Claude 안내: `~/.claude/CLAUDE.md`의 `@ACO.md`. 경로 안전 안내 — `~/.claude/ACO.md` 사본 또는 절대경로 `@/abs/path/ACO.md` 사용, ACO.md 미존재 프로젝트에서 깨질 수 있음 경고, project `CLAUDE.md` `@ACO.md`는 그 repo 내에서만 안전
+- [x] 2.3 Codex 안내: project root `AGENTS.md` 명시 텍스트 참조 1순위 + 복사-붙여넣기용 표준 문구 예시 제공, `@`-import 비지원 명시, user `~/.codex/AGENTS.md` 전역은 미검증 선택 대안으로 표기
+- [x] 2.4 Antigravity 안내: user-level `~/.gemini/GEMINI.md`(global rules) 1순위 고정. project root `GEMINI.md`는 권장 아님(repo가 sync 제거) — 기존 workspace 정책 있을 때만 caveat 대안. `.agents/rules/` 대안 명시
+- [x] 2.5 ACO.md 배치/경로 권장안 안내(사본/절대경로), repo가 사용자 홈을 자동 수정하지 않음을 명시
+
+## 3. 문서 정합 보강
+
+- [x] 3.1 `docs/reference/context-sync.md`의 "agy AGENTS.md 미지원" 문구를 구체 보강: "Antigravity CLI는 로컬 `AGENTS.md`/`GEMINI.md`를 파싱하나 `aco sync` 자동 생성/동기화 대상에서만 제외(hand-maintained)"임을 명시. 새 sync 생성 target은 추가하지 않음
+
+## 4. 검증
+
+- [x] 4.1 정적 체크: `ACO.md` 필수 섹션(서브커맨드·위임 흐름·provider 전체·주의사항) 존재 + `README.md` 참조 안내가 3 provider 경로/메커니즘 포함 (grep 기반)
+- [x] 4.2 정확성 대조: ACO.md provider 목록·서브커맨드를 registry/`aco ask --help`와 대조, agy 경로를 knowledge(`~/.gemini/GEMINI.md`)와 대조
+- [x] 4.3 회귀 가드: `aco sync --check`(가능하면 `--strict`) 통과
+- [x] 4.4 allowlist diff gate: `packages/wrapper/src/cli.ts`·`commands/`·`sync/`, `.claude/commands/`, `templates/commands/`, `.agents/skills/`, `.codex/agents/` 무변경을 `git diff`로 확인 (명령/sync source 미변경 적극 증명)
+- [x] 4.5 적극적 제외 검증: `.aco/sync.yaml`/sync 대상에 `ACO.md`·`README.md` 미등록 정적 대조
+- [x] 4.6 artifact gate: `openspec validate aco-md-readme-reference --type change --strict` 통과
+- [ ] 4.7 (선택) 수동 spot check: 임시 `CLAUDE.md`+`@ACO.md` 로딩 1회 확인, 임시 `GEMINI.md` agy 파싱 1회 확인. `git diff --check`


### PR DESCRIPTION
Closes #153

## What

`aco` 사용법을 정리한 root `ACO.md`를 신설하고, README에 각 CLI(Claude / Codex / Antigravity)의 guideline 파일에서 `ACO.md`를 참조하도록 설정하는 방법을 안내한다. 사용자 전역 `CLAUDE.md`가 `@RTK.md`로 rtk 사용법을 끌어오는 user-level 패턴과 동일하다.

## Why

각 CLI가 세션 시작 시 `aco` 사용법을 일관되게 인지하게 되어, provider별로 호출 방식을 따로 학습할 필요가 없어진다. 새 명령어나 `aco sync` 자동화 없이 문서와 수동 참조 안내만으로 학습 비용을 낮춘다.

## Changes

- **`ACO.md`(신규):** 주요 서브커맨드, consent-gated 위임 흐름(`--dry-run` 후 `--yes`), 지원 provider(`codex`/`antigravity`/`mock`, 기본값 `mock`), self-delegation·permission 주의사항. `aco sync`는 구조적 표면만 동기화하고 guideline markdown(`AGENTS.md`/`GEMINI.md`)은 생성하지 않음을 명시.
- **`README.md`:** "각 CLI 가이드라인에 ACO.md 참조 추가하기" 섹션 추가. Claude는 `@ACO.md`(경로 안전: `~/.claude/ACO.md` 사본 또는 절대경로), Codex는 `AGENTS.md` 텍스트 pointer(자동 인라인 아님), Antigravity는 user-level `~/.gemini/GEMINI.md`(+ Rules `@filename` 참조, 전역 상대경로 경고).
- **`docs/reference/context-sync.md`:** `agy`가 로컬 `AGENTS.md`/`GEMINI.md`를 파싱하나 `aco sync` 생성 대상에서만 제외(hand-maintained)라는 capability vs sync 구분 보강.
- **`openspec/changes/aco-md-readme-reference/`(신규):** 본 변경의 OpenSpec 산출물(proposal/design/specs/tasks).

코드·명령어·`aco sync` 엔진은 변경하지 않는다(docs-only).

## 검증

- 정적·회귀 체크 25/25 통과: `ACO.md`/`README.md` 필수 내용, `aco sync --check`, command/sync source 무변경(allowlist diff gate), `ACO.md`/`README.md`의 sync target 미등록, `openspec validate --type change --strict`.
- 외부 AI 2개(`antigravity`, `codex`)로 spec·구현·커밋을 교차 리뷰하여 사실 오류(Gemini 잔존 문구, provider 목록 누락, consent 흐름 오기, `@` 경로 안전)를 정정.

## Checklist

- [x] 변경이 docs-only이며 코드/명령어/sync 엔진 무변경
- [x] `aco sync --check --strict` 통과(회귀 없음)
- [x] OpenSpec change `aco-md-readme-reference` strict validation 통과
- [x] provider 참조 모델을 실제 CLI 동작·knowledge와 대조해 정확성 확인
- [ ] 리뷰어 확인 후 머지
