### PR TITLE
fix(ask): stream-only 출력 메트릭을 실제 스트리밍 바이트로 계산

### DIFF
--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -361,7 +361,9 @@ export async function cmdAsk(args: string[]): Promise<void> {
 
         const usage = await collectUsage(provider.key, session.id);
 
-        const outputBytes = Buffer.byteLength(runResult.fullOutput, 'utf8');
+        // stream-only 모드(save-only/full)에서 runResult.fullOutput은 16KB capture
+        // 상한으로 잘리므로, 실제 출력 바이트 수는 runner가 카운트한 outputBytes를 쓴다.
+        const outputBytes = runResult.outputBytes;
         const stderrContent = runResult.stderrContent;
         const stderrBytes = Buffer.byteLength(stderrContent, 'utf8');
         const warningCount = countWarnings(runResult.stderrContent);

--- a/packages/wrapper/src/runtime/provider-session-runner.ts
+++ b/packages/wrapper/src/runtime/provider-session-runner.ts
@@ -43,6 +43,13 @@ export interface ProviderSessionRunOptions {
 
 export interface ProviderSessionRunResult {
   fullOutput: string;
+  /**
+   * Total number of UTF-8 bytes streamed from the provider, counted before any
+   * in-memory capture truncation. Reflects the real bytes written to the output
+   * log even when `fullOutput` is empty (no-capture run path) or bounded
+   * (ask save-only/full path with a capture limit).
+   */
+  outputBytes: number;
   hasOutput: boolean;
   error?: unknown;
   /**
@@ -83,6 +90,7 @@ export async function invokeProviderForSession(
     : 0;
   const outputCapture = maxBuffer > 0 ? createBoundedOutputCapture(maxBuffer) : undefined;
   let hasOutput = false;
+  let outputBytes = 0;
   let error: unknown;
   let capturedStderr = '';
 
@@ -114,6 +122,7 @@ export async function invokeProviderForSession(
     )) {
       await writeChunk(options.output, chunk);
       outputCapture?.append(chunk);
+      outputBytes += Buffer.byteLength(chunk, 'utf8');
       hasOutput = true;
       await options.onChunk?.(chunk);
     }
@@ -125,6 +134,7 @@ export async function invokeProviderForSession(
 
   return {
     fullOutput: outputCapture?.value() ?? '',
+    outputBytes,
     hasOutput,
     stderrContent: capturedStderr,
     ...(error ? { error } : {}),

--- a/packages/wrapper/tests/command-output-buffering.test.ts
+++ b/packages/wrapper/tests/command-output-buffering.test.ts
@@ -123,9 +123,11 @@ describe('command invocation output buffering policy', () => {
       maxOutputBuffer: captureLimit,
     });
 
-    // fullOutput stays bounded by the capture limit (memory safety).
+    // fullOutput stays bounded by the capture limit (memory safety). The bound is
+    // a character (UTF-16 code-unit) limit, matching createBoundedOutputCapture's
+    // .length-based slicing — not a byte limit — so assert on length, not byteLength.
     assert.ok(
-      Buffer.byteLength(result.fullOutput, 'utf8') <= captureLimit,
+      result.fullOutput.length <= captureLimit,
       'fullOutput must stay within the capture limit'
     );
     // outputBytes must equal the real streamed size, not the bounded capture.

--- a/packages/wrapper/tests/command-output-buffering.test.ts
+++ b/packages/wrapper/tests/command-output-buffering.test.ts
@@ -51,4 +51,84 @@ describe('command invocation output buffering policy', () => {
     assert.equal(result.hasOutput, true);
     assert.equal(result.fullOutput, '');
   });
+
+  it('reports total streamed bytes even when fullOutput is not captured (stream-only run path)', async () => {
+    const chunk = 'X'.repeat(4096);
+    const provider: IProvider = {
+      key: 'mock',
+      installHint: 'mock',
+      icon: '⚪',
+      isAvailable: () => true,
+      checkAuth: async () => ({ ok: true }),
+      buildArgs: () => [],
+      invoke: async function* () {
+        yield chunk;
+        yield chunk;
+        yield chunk;
+      },
+    };
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const result = await invokeProviderForSession({
+      provider,
+      command: 'run',
+      prompt: 'prompt',
+      content: 'content',
+      permissionProfile: 'restricted',
+      sessionId: 'test-session',
+      output,
+      outputBuffer: resolveRunOutputBuffering(),
+    });
+
+    // fullOutput is intentionally empty in the no-capture run path.
+    assert.equal(result.fullOutput, '');
+    // outputBytes must reflect the real streamed size, not the (empty) buffer.
+    assert.equal(result.outputBytes, Buffer.byteLength(chunk, 'utf8') * 3);
+  });
+
+  it('reports total streamed bytes uncapped when output exceeds the ask capture limit', async () => {
+    const total = 20 * 1024;
+    const big = 'Y'.repeat(total);
+    const captureLimit = 16 * 1024;
+    const provider: IProvider = {
+      key: 'mock',
+      installHint: 'mock',
+      icon: '⚪',
+      isAvailable: () => true,
+      checkAuth: async () => ({ ok: true }),
+      buildArgs: () => [],
+      invoke: async function* () {
+        yield big;
+      },
+    };
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const result = await invokeProviderForSession({
+      provider,
+      command: 'ask',
+      prompt: 'prompt',
+      content: 'content',
+      permissionProfile: 'restricted',
+      sessionId: 'test-session',
+      output,
+      outputBuffer: resolveAskOutputBuffering('save-only'),
+      maxOutputBuffer: captureLimit,
+    });
+
+    // fullOutput stays bounded by the capture limit (memory safety).
+    assert.ok(
+      Buffer.byteLength(result.fullOutput, 'utf8') <= captureLimit,
+      'fullOutput must stay within the capture limit'
+    );
+    // outputBytes must equal the real streamed size, not the bounded capture.
+    assert.equal(result.outputBytes, total);
+  });
 });

--- a/packages/wrapper/tests/command-output-buffering.test.ts
+++ b/packages/wrapper/tests/command-output-buffering.test.ts
@@ -131,4 +131,79 @@ describe('command invocation output buffering policy', () => {
     // outputBytes must equal the real streamed size, not the bounded capture.
     assert.equal(result.outputBytes, total);
   });
+
+  it('counts UTF-8 byte length, not UTF-16 string length, for multibyte output', async () => {
+    const payload = '안녕하세요 🚀'.repeat(100);
+    const expectedBytes = Buffer.byteLength(payload, 'utf8');
+    // Guard the test itself: byte length must differ from string length,
+    // otherwise the assertion would not distinguish byteLength from .length.
+    assert.notEqual(expectedBytes, payload.length);
+
+    const provider: IProvider = {
+      key: 'mock',
+      installHint: 'mock',
+      icon: '⚪',
+      isAvailable: () => true,
+      checkAuth: async () => ({ ok: true }),
+      buildArgs: () => [],
+      invoke: async function* () {
+        yield payload;
+      },
+    };
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const result = await invokeProviderForSession({
+      provider,
+      command: 'run',
+      prompt: 'prompt',
+      content: 'content',
+      permissionProfile: 'restricted',
+      sessionId: 'test-session',
+      output,
+      outputBuffer: resolveRunOutputBuffering(),
+    });
+
+    assert.equal(result.outputBytes, expectedBytes);
+  });
+
+  it('reports bytes streamed before a mid-stream provider error', async () => {
+    const chunk = 'Z'.repeat(2048);
+    const provider: IProvider = {
+      key: 'mock',
+      installHint: 'mock',
+      icon: '⚪',
+      isAvailable: () => true,
+      checkAuth: async () => ({ ok: true }),
+      buildArgs: () => [],
+      invoke: async function* () {
+        yield chunk;
+        throw new Error('provider aborted mid-stream');
+      },
+    };
+    const output = new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+
+    const result = await invokeProviderForSession({
+      provider,
+      command: 'run',
+      prompt: 'prompt',
+      content: 'content',
+      permissionProfile: 'restricted',
+      sessionId: 'test-session',
+      output,
+      outputBuffer: resolveRunOutputBuffering(),
+    });
+
+    // The error is captured, and outputBytes reflects what reached the output
+    // before the abort — not silently reset to 0.
+    assert.ok(result.error instanceof Error);
+    assert.equal(result.outputBytes, Buffer.byteLength(chunk, 'utf8'));
+  });
 });


### PR DESCRIPTION
Closes #139

## What

`aco ask --output-mode save-only|full`(stream-only 버퍼링 경로)에서 run/session ledger의 `outputBytes`가 실제 출력과 어긋나던 문제를 고친다. 이제 `invokeProviderForSession`이 capture 상한과 무관하게 실제 스트리밍된 UTF-8 총 바이트를 별도로 세어 반환하고, `ask`가 그 값을 기록한다.

## Why

stream-only 모드에서 `runResult.fullOutput`은 16KB capture 상한(`SUMMARY_SOURCE_CHAR_LIMIT`)으로 잘린다. 그런데 `outputBytes`를 `Buffer.byteLength(runResult.fullOutput)`로 계산하고 있어, 출력이 16KB를 넘으면 ledger에 기록되는 바이트 수가 실제 출력 파일보다 작게 찍혔다. PR #135에서 추가한 run/session evidence 필드가 일반 사용 경로에서 체계적으로 왜곡되던 것이다.

원 리뷰는 "stream-only면 `fullOutput`이 빈 문자열이라 `outputBytes: 0`"으로 봤으나, `ask`는 `maxOutputBuffer`를 넘기므로 현재 코드에선 비지 않는다. 잔존 결함은 16KB 상한에 잘린 버퍼로 바이트를 세던 것이었고, runner가 실제 스트리밍 바이트를 카운트하도록 바꿔 두 경우(빈 캡처·초과 캡처)를 모두 견고하게 해결한다.

## Changes

- `provider-session-runner.ts`: 스트리밍된 UTF-8 총 바이트를 누계해 `ProviderSessionRunResult.outputBytes`로 반환. capture truncation 이전 값이라 정확.
- `commands/ask.ts`: capped `fullOutput` 대신 `runResult.outputBytes`로 `outputBytes` 기록. summary는 기존대로 bounded `fullOutput`에서 추출(capture가 켜져 있어 비지 않음).
- `tests/command-output-buffering.test.ts`: no-capture 경로·초과 capture 경로의 바이트 정확성 회귀 테스트 + (antigravity adversarial 리뷰 반영) 멀티바이트 UTF-8·중단 시나리오 테스트 추가.

## Review notes

`aco`로 antigravity multi-agent adversarial 리뷰를 돌려 7개 finding을 받았고, 실제 코드 대조로 판정했다.

- 채택(P1): 멀티바이트 미검증·에러중단 시나리오 부재 → 회귀 테스트 보강.
- 기각(P0/P1): "필수 필드 추가로 CI 컴파일 깨짐"은 해당 타입을 mock/하드코딩하는 곳이 없어 거짓(typecheck·438 테스트 green). "`cmdRun`이 항상 0바이트 기록"은 `cmdRun`이 `outputBytes`를 기록하지 않아 거짓.
- 기타 기각: write 성공 후 카운트는 "실제 기록 파일 바이트" 요구와 오히려 일치, chunk는 타입 계약상 string.

## Checklist

- [x] wrapper 전체 테스트 green (438 pass)
- [x] `typecheck` green
- [x] `format:check` green
- [x] stream-only 16KB 초과 출력에서 `outputBytes`가 실제 스트리밍 바이트와 일치 (회귀 테스트)
- [x] 멀티바이트 출력에서 byte length(UTF-8) ≠ string length 검증
- [x] 중단(error mid-stream) 시 `outputBytes`가 0으로 리셋되지 않음 검증
