### PR TITLE
feat(sync): structured source 없는 repo hard-fail 강화

### DIFF
--- a/openspec/changes/aco-sync-narrow-scope/specs/cli-sync-command/spec.md
+++ b/openspec/changes/aco-sync-narrow-scope/specs/cli-sync-command/spec.md
@@ -15,7 +15,7 @@ The system SHALL provide an `aco sync` command that explicitly synchronizes Clau
 - **AND** read and write project-level files relative to that root
 
 #### Scenario: No structured sources
-- **WHEN** a repository has no structured sync source (`.claude/skills/`, `.claude/agents/`, or hook settings) — for example only `CLAUDE.md` and/or `.claude/rules/` — **AND** there is no prior sync manifest or legacy aco-owned target to reconcile
+- **WHEN** a repository has no structured sync source (`.claude/skills/` or `.claude/agents/`) — for example only `CLAUDE.md` and/or `.claude/rules/` — **AND** there is no prior sync manifest or legacy aco-owned target to reconcile
 - **THEN** `aco sync` SHALL fail with a clear "No sync sources found" message instead of writing an empty manifest and exiting 0
 - **AND** guideline sources (`CLAUDE.md`, `.claude/rules/`) alone SHALL NOT satisfy this requirement, because they no longer produce any synced output
 

--- a/openspec/changes/aco-sync-narrow-scope/specs/cli-sync-command/spec.md
+++ b/openspec/changes/aco-sync-narrow-scope/specs/cli-sync-command/spec.md
@@ -14,13 +14,14 @@ The system SHALL provide an `aco sync` command that explicitly synchronizes Clau
 - **THEN** the system SHALL resolve the repository root
 - **AND** read and write project-level files relative to that root
 
-#### Scenario: Missing Claude sources
-- **WHEN** no Claude source files exist at all (no `CLAUDE.md`, `.claude/rules/`, `.claude/agents/`, `.claude/skills/`, or hook settings)
-- **THEN** `aco sync` SHALL fail with a clear "no sync sources found" message
+#### Scenario: No structured sources
+- **WHEN** a repository has no structured sync source (`.claude/skills/`, `.claude/agents/`, or hook settings) — for example only `CLAUDE.md` and/or `.claude/rules/` — **AND** there is no prior sync manifest or legacy aco-owned target to reconcile
+- **THEN** `aco sync` SHALL fail with a clear "No sync sources found" message instead of writing an empty manifest and exiting 0
+- **AND** guideline sources (`CLAUDE.md`, `.claude/rules/`) alone SHALL NOT satisfy this requirement, because they no longer produce any synced output
 
-<!-- NOTE: Requiring at least one *structured* source (so a CLAUDE.md/rules-only repo
-     fails instead of writing an empty manifest) is a tracked follow-up, deferred from
-     PR #150 review to avoid a large test-fixture churn. -->
+#### Scenario: Cleanup-only sync without structured sources
+- **WHEN** a repository has no structured source but a prior sync manifest or legacy aco-owned targets exist on disk
+- **THEN** `aco sync` SHALL proceed (not hard-fail) so that stale-target removal and legacy Gemini cleanup can still complete
 
 
 #### Scenario: Project-guidance markdown is out of scope

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -35,6 +35,16 @@ const LEGACY_HOOK_TARGETS = new Set([
   '.gemini/settings.json',
 ]);
 
+// Source kinds that drive a structured-surface output (skills, Codex agents,
+// hooks). Guideline kinds (`config` = CLAUDE.md, `rule` = .claude/rules/*) are
+// intentionally excluded: they no longer produce any synced output. Used by the
+// no-source guard in runSync. See OpenSpec change aco-sync-narrow-scope.
+const STRUCTURED_SOURCE_KINDS: ReadonlySet<SyncSource['kind']> = new Set([
+  'skill',
+  'agent',
+  'settings',
+]);
+
 function isErrorWithCode(err: unknown): err is ErrorWithCode {
   return err instanceof Error && 'code' in err;
 }
@@ -348,9 +358,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
   // carries legacy aco-owned targets is still allowed through so stale-target and
   // legacy Gemini cleanup can complete even after all structured sources are removed.
   // See OpenSpec change aco-sync-narrow-scope.
-  const structuredSources = sources.filter(
-    (s) => s.kind === 'skill' || s.kind === 'agent' || s.kind === 'settings'
-  );
+  const structuredSources = sources.filter((s) => STRUCTURED_SOURCE_KINDS.has(s.kind));
   if (
     structuredSources.length === 0 &&
     existingManifest === null &&

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -264,6 +264,88 @@ async function planLegacyGeminiCleanup(
   }
 }
 
+function isCodexAgentTarget(manifestKey: string): boolean {
+  return manifestKey.startsWith('.codex/agents/') && manifestKey.endsWith('.toml');
+}
+
+/**
+ * Plan removal of aco-owned `.codex/agents/*.toml` targets recorded in the manifest
+ * whose source agent no longer exists (so syncCodexAgents produced no output for them).
+ * Without this, deleting the last `.claude/agents/*.md` source would leave the
+ * generated Codex agent file orphaned on disk while the manifest silently drops its
+ * entry — breaking the cleanup-only guarantee that lets a structure-less repo with a
+ * prior manifest still run. Mirrors planLegacyGeminiCleanup's hash + path-safety checks.
+ */
+async function planStaleCodexAgentCleanup(
+  repoRoot: string,
+  existingManifest: SyncManifest | null,
+  producedTargetKeys: ReadonlySet<string>,
+  outputs: SyncOutput[],
+  warnings: SyncWarning[]
+): Promise<void> {
+  if (!existingManifest) return;
+
+  const records = new Map<string, ManifestTargetRecord>();
+  for (const [targetKey, record] of Object.entries(existingManifest.targets ?? {})) {
+    records.set(targetKey, record);
+  }
+  for (const [targetKey, hash] of Object.entries(existingManifest.targetHashes ?? {})) {
+    if (!records.has(targetKey)) {
+      records.set(targetKey, { hash, owner: 'aco', kind: 'agent' });
+    }
+  }
+
+  for (const [targetKey, record] of records) {
+    if (!isCodexAgentTarget(targetKey)) continue;
+    if (producedTargetKeys.has(targetKey)) continue; // source still present — keep
+    if (record.owner !== 'aco') continue;
+
+    const targetPath = join(repoRoot, targetKey);
+    // Path-safety: require the manifest key to round-trip through repo-relative
+    // normalization (no `..` traversal), matching the legacy-Gemini cleanup defense.
+    if (toManifestKey(repoRoot, targetPath) !== targetKey) {
+      warnings.push({
+        source: targetKey,
+        message:
+          'Stale Codex agent target key does not round-trip through repo-relative ' +
+          `normalization (possible path traversal); skipping auto-removal: "${targetKey}".`,
+        severity: 'warning',
+      });
+      continue;
+    }
+
+    let diskContent: string;
+    try {
+      diskContent = await readFile(targetPath, 'utf8');
+    } catch (err: unknown) {
+      // Already gone — the freshly built manifest omits it, so nothing to remove.
+      if (isErrorWithCode(err) && err.code === 'ENOENT') continue;
+      throw err;
+    }
+
+    const expectedHash = record.hash ?? existingManifest.targetHashes?.[targetKey];
+    if (expectedHash && computeHash(diskContent) !== expectedHash) {
+      warnings.push({
+        source: targetKey,
+        message:
+          'Stale Codex agent target hash does not match manifest; skipping auto-removal. ' +
+          `Review ${targetKey} before deleting.`,
+        severity: 'warning',
+      });
+      continue;
+    }
+
+    outputs.push({
+      targetPath,
+      kind: 'file',
+      action: 'removed',
+      hash: record.hash,
+      owner: 'aco',
+      assetKind: 'agent',
+    });
+  }
+}
+
 function stripCodexManagedHookBlock(content: string): string | null {
   const begin = '# BEGIN ACO GENERATED';
   const end = '# END ACO GENERATED';
@@ -590,7 +672,7 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
         // (normalize-and-re-derive round-trip check), so they bypass the
         // .agents/skills-only guard below without re-deriving the defense here.
         if (!isLegacyGeminiTarget(toManifestKey(repoRoot, output.targetPath))) {
-          const allowedDirs = ['.agents/skills'];
+          const allowedDirs = ['.agents/skills', '.codex/agents'];
           if (!isPathWithinRepo(repoRoot, output.targetPath, allowedDirs)) {
             plan.warnings.push({
               source: relative(repoRoot, output.targetPath) || output.targetPath,
@@ -700,7 +782,9 @@ async function computeTransformPlan(
   const codexAgentResult = await syncCodexAgents(sources, repoRoot);
   outputs.push(...codexAgentResult.outputs);
   warnings.push(...codexAgentResult.warnings);
+  const producedCodexAgentKeys = new Set<string>();
   for (const o of codexAgentResult.outputs) {
+    producedCodexAgentKeys.add(toManifestKey(repoRoot, o.targetPath));
     if (o.hash) {
       const key = toManifestKey(repoRoot, o.targetPath);
       targetHashes[key] = o.hash;
@@ -711,6 +795,16 @@ async function computeTransformPlan(
       };
     }
   }
+
+  // 3b. Remove orphaned Codex agent targets whose source was deleted, so the
+  //     cleanup-only path (prior manifest, no structured source) actually cleans up.
+  await planStaleCodexAgentCleanup(
+    repoRoot,
+    existingManifest,
+    producedCodexAgentKeys,
+    outputs,
+    warnings
+  );
 
   const manifest: SyncManifest = {
     version: '5',

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -35,15 +35,13 @@ const LEGACY_HOOK_TARGETS = new Set([
   '.gemini/settings.json',
 ]);
 
-// Source kinds that drive a structured-surface output (skills, Codex agents,
-// hooks). Guideline kinds (`config` = CLAUDE.md, `rule` = .claude/rules/*) are
-// intentionally excluded: they no longer produce any synced output. Used by the
-// no-source guard in runSync. See OpenSpec change aco-sync-narrow-scope.
-const STRUCTURED_SOURCE_KINDS: ReadonlySet<SyncSource['kind']> = new Set([
-  'skill',
-  'agent',
-  'settings',
-]);
+// Source kinds that drive a structured-surface output (skills, Codex agents).
+// Guideline kinds (`config` = CLAUDE.md, `rule` = .claude/rules/*) are intentionally
+// excluded: they no longer produce any synced output. `settings` is also excluded —
+// hook sync is not wired into discoverSources/computeTransformPlan, so no source ever
+// carries that kind today. Used by the no-source guard in runSync. See OpenSpec
+// change aco-sync-narrow-scope.
+const STRUCTURED_SOURCE_KINDS: ReadonlySet<SyncSource['kind']> = new Set(['skill', 'agent']);
 
 function isErrorWithCode(err: unknown): err is ErrorWithCode {
   return err instanceof Error && 'code' in err;
@@ -349,9 +347,9 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
   const existingManifest = await readManifest(repoRoot);
   const legacyCleanupManifest = await readManifestForLegacyCleanup(repoRoot);
 
-  // `aco sync` only generates structured-surface targets (skills, Codex agents,
-  // hooks). Guideline sources (`config` = CLAUDE.md, `rule` = .claude/rules/*) no
-  // longer produce any output since AGENTS.md generation was removed, so a fresh repo
+  // `aco sync` only generates structured-surface targets (skills, Codex agents).
+  // Guideline sources (`config` = CLAUDE.md, `rule` = .claude/rules/*) no longer
+  // produce any output since AGENTS.md generation was removed, so a fresh repo
   // with only those would otherwise write an empty manifest and exit 0. Hard-fail when
   // there is nothing to sync AND no prior manifest state to reconcile — i.e. a
   // genuinely structureless repo. A repo that previously synced (existing manifest) or
@@ -366,8 +364,8 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
   ) {
     throw new Error(
       'No sync sources found. aco sync generates only structured-surface targets ' +
-        '(skills, Codex agents, hooks); CLAUDE.md and .claude/rules/ alone produce no ' +
-        'output. Ensure .claude/skills/, .claude/agents/, or hook settings exist.'
+        '(skills, Codex agents); CLAUDE.md and .claude/rules/ alone produce no ' +
+        'output. Ensure .claude/skills/ or .claude/agents/ exist.'
     );
   }
 

--- a/packages/wrapper/src/sync/sync-engine.ts
+++ b/packages/wrapper/src/sync/sync-engine.ts
@@ -334,16 +334,34 @@ export async function runSync(repoRoot: string, options: SyncOptions = {}): Prom
   // 2. Discover sources
   const sources = await discoverSources(repoRoot);
 
-  if (sources.length === 0) {
-    throw new Error(
-      'No sync sources found. Ensure CLAUDE.md, .claude/rules/, .claude/agents/, or .claude/skills/ exists.'
-    );
-  }
-
   // 3. Read existing manifest (fully migrated) plus a pre-v5 view used only to plan
   //    on-disk cleanup of legacy aco-owned Gemini targets that the v5 migration drops.
   const existingManifest = await readManifest(repoRoot);
   const legacyCleanupManifest = await readManifestForLegacyCleanup(repoRoot);
+
+  // `aco sync` only generates structured-surface targets (skills, Codex agents,
+  // hooks). Guideline sources (`config` = CLAUDE.md, `rule` = .claude/rules/*) no
+  // longer produce any output since AGENTS.md generation was removed, so a fresh repo
+  // with only those would otherwise write an empty manifest and exit 0. Hard-fail when
+  // there is nothing to sync AND no prior manifest state to reconcile — i.e. a
+  // genuinely structureless repo. A repo that previously synced (existing manifest) or
+  // carries legacy aco-owned targets is still allowed through so stale-target and
+  // legacy Gemini cleanup can complete even after all structured sources are removed.
+  // See OpenSpec change aco-sync-narrow-scope.
+  const structuredSources = sources.filter(
+    (s) => s.kind === 'skill' || s.kind === 'agent' || s.kind === 'settings'
+  );
+  if (
+    structuredSources.length === 0 &&
+    existingManifest === null &&
+    legacyCleanupManifest === null
+  ) {
+    throw new Error(
+      'No sync sources found. aco sync generates only structured-surface targets ' +
+        '(skills, Codex agents, hooks); CLAUDE.md and .claude/rules/ alone produce no ' +
+        'output. Ensure .claude/skills/, .claude/agents/, or hook settings exist.'
+    );
+  }
 
   // 4. Compute transform plan (pure planning pass)
   const plan = await computeTransformPlan(

--- a/packages/wrapper/tests/pack-runtime-contract.test.ts
+++ b/packages/wrapper/tests/pack-runtime-contract.test.ts
@@ -595,6 +595,13 @@ describe('pack template runtime contract', () => {
       );
 
       await writeFile(join(driftWorkspace, 'CLAUDE.md'), '# Original\n');
+      // A structured source is required for runSync to proceed; the drift under
+      // test is the CLAUDE.md edit, which produces no synced output on its own.
+      await mkdir(join(driftWorkspace, '.claude', 'agents'), { recursive: true });
+      await writeFile(
+        join(driftWorkspace, '.claude', 'agents', '_anchor.md'),
+        '---\nid: _anchor\nwhen: anchor structured source\n---\nAnchor.'
+      );
       await runSync(driftWorkspace, { dryRun: false });
       await writeFile(join(driftWorkspace, 'CLAUDE.md'), '# Updated\n');
 

--- a/packages/wrapper/tests/sync-manifest-portability.test.ts
+++ b/packages/wrapper/tests/sync-manifest-portability.test.ts
@@ -390,6 +390,13 @@ describe('runSync: portable target keys across checkout locations', () => {
       const claudeContent = '# shared context\n\nSome shared rules.';
       for (const root of [rootA, rootB]) {
         await writeFile(join(root, 'CLAUDE.md'), claudeContent);
+        // A structured source is required for runSync; keep it identical across
+        // both checkouts so the cross-checkout manifest comparison stays valid.
+        await mkdir(join(root, '.claude', 'agents'), { recursive: true });
+        await writeFile(
+          join(root, '.claude', 'agents', '_anchor.md'),
+          '---\nid: _anchor\nwhen: anchor structured source\n---\nAnchor.'
+        );
       }
 
       // 2. Run a full sync in rootA: produces sync outputs (AGENTS.md only, no GEMINI.md)

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -464,6 +464,38 @@ describe('No structured sources hard-fail', () => {
       await rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('runSync proceeds (cleanup-only) when no structured source but a prior manifest exists', async () => {
+    // Covers the guard's `existingManifest !== null` escape hatch directly, WITHOUT
+    // an anchor structured source: a repo that previously synced and then had all
+    // structured sources removed must still run so stale-target cleanup can complete.
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-cleanup-only-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
+      // A prior sync manifest on disk — the only reason runSync is allowed through.
+      await mkdir(join(tmpDir, '.aco'), { recursive: true });
+      const priorManifest = {
+        version: '5',
+        generatedAt: new Date().toISOString(),
+        sourceHashes: {},
+        targetHashes: {},
+        targets: {},
+        skipped: [],
+        warnings: [],
+      };
+      await writeFile(
+        join(tmpDir, '.aco', 'sync-manifest.json'),
+        JSON.stringify(priorManifest)
+      );
+
+      await assert.doesNotReject(
+        async () => runSync(tmpDir, { dryRun: false }),
+        'cleanup-only sync (manifest present, zero structured sources) must not hard-fail'
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -496,6 +496,37 @@ describe('No structured sources hard-fail', () => {
       await rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it('cleanup-only sync removes the orphaned Codex agent target after its source is deleted', async () => {
+    // The escape hatch promises cleanup completes; this proves it for Codex agents.
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-orphan-codex-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
+      await mkdir(join(tmpDir, '.claude', 'agents'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.claude', 'agents', 'helper.md'),
+        '---\nid: helper\nwhen: Help with tasks\n---\nYou are a helper.'
+      );
+
+      // First sync produces .codex/agents/helper.toml and records it in the manifest.
+      await runSync(tmpDir, { dryRun: false });
+      const toml = join(tmpDir, '.codex', 'agents', 'helper.toml');
+      const { existsSync } = await import('node:fs');
+      assert.equal(existsSync(toml), true, 'first sync must create the Codex agent target');
+
+      // Delete the only structured source, then re-sync (CLAUDE.md + prior manifest).
+      await rm(join(tmpDir, '.claude', 'agents', 'helper.md'));
+      const result = await runSync(tmpDir, { dryRun: false });
+
+      const removed = result.outputs.some(
+        (o) => o.targetPath.endsWith('helper.toml') && o.action === 'removed'
+      );
+      assert.ok(removed, 'orphaned Codex agent target must be planned for removal');
+      assert.equal(existsSync(toml), false, 'orphaned Codex agent target must be deleted from disk');
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/wrapper/tests/sync.test.ts
+++ b/packages/wrapper/tests/sync.test.ts
@@ -33,6 +33,20 @@ function parseMarkdownFrontmatter(markdown: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
+/**
+ * Seed a minimal structured source (a Codex agent) so runSync passes the
+ * no-structured-source hard-fail guard. Used by fixtures that exercise
+ * legacy/duplicate/hook/migration behavior on an otherwise CLAUDE.md-only repo
+ * with no prior manifest. See OpenSpec change aco-sync-narrow-scope.
+ */
+async function seedAnchorAgent(repoRoot: string): Promise<void> {
+  await mkdir(join(repoRoot, '.claude', 'agents'), { recursive: true });
+  await writeFile(
+    join(repoRoot, '.claude', 'agents', '_anchor.md'),
+    '---\nid: _anchor\nwhen: anchor structured source for sync tests\n---\nAnchor.'
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Agent parse + transform fixtures (Task 4.6)
 // ---------------------------------------------------------------------------
@@ -188,6 +202,7 @@ describe('Phase 2: AGENTS.md-only sync output', () => {
   it('runSync produces neither AGENTS.md nor GEMINI.md (guideline md projection removed)', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-agents-only-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# Project context\n\nSome rules.');
 
       const result = await runSync(tmpDir, { dryRun: false });
@@ -207,6 +222,7 @@ describe('Phase 2: AGENTS.md-only sync output', () => {
   it('runSync does NOT create or modify AGENTS.md on disk', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-agents-untouched-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# Project context\n\nSome rules.');
       // Pre-existing hand-maintained AGENTS.md with stale managed-block markers
       const handAgents =
@@ -225,6 +241,7 @@ describe('Phase 2: AGENTS.md-only sync output', () => {
   it('manifest version is "5" after sync', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-manifest-v5-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
 
       await runSync(tmpDir, { dryRun: false });
@@ -241,6 +258,7 @@ describe('Phase 2: AGENTS.md-only sync output', () => {
   it('manifest targets do NOT include GEMINI.md key after sync', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-no-gemini-target-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
 
       await runSync(tmpDir, { dryRun: false });
@@ -395,6 +413,53 @@ describe('Phase 2: AGENTS.md-only sync output', () => {
       assert.equal('GEMINI.md' in updatedManifest.targetHashes, false);
       assert.equal('.gemini/agents/helper.md' in updatedManifest.targets, false);
       assert.equal('.gemini/agents/helper.md' in updatedManifest.targetHashes, false);
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('No structured sources hard-fail', () => {
+  it('runSync fails when only CLAUDE.md exists (no structured source)', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-claude-only-fail-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '# Project context\n\nSome rules.');
+      await assert.rejects(
+        async () => runSync(tmpDir, { dryRun: false }),
+        /No sync sources found/,
+        'CLAUDE.md-only repo must hard-fail'
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('runSync fails when only CLAUDE.md and .claude/rules exist (no structured source)', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-rules-only-fail-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
+      await mkdir(join(tmpDir, '.claude', 'rules'), { recursive: true });
+      await writeFile(join(tmpDir, '.claude', 'rules', 'core.md'), '# core rule');
+      await assert.rejects(
+        async () => runSync(tmpDir, { dryRun: false }),
+        /No sync sources found/,
+        'CLAUDE.md + rules-only repo must hard-fail'
+      );
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('runSync succeeds when a structured source (agent) is present', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-agent-ok-'));
+    try {
+      await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
+      await mkdir(join(tmpDir, '.claude', 'agents'), { recursive: true });
+      await writeFile(
+        join(tmpDir, '.claude', 'agents', 'helper.md'),
+        '---\nid: helper\nwhen: Help with tasks\n---\nYou are a helper.'
+      );
+      await assert.doesNotReject(async () => runSync(tmpDir, { dryRun: false }));
     } finally {
       await rm(tmpDir, { recursive: true, force: true });
     }
@@ -1364,6 +1429,7 @@ describe('Skill Sync', () => {
   it('--strict mode promotes duplicate warnings to errors', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-strict-'));
     try {
+      await seedAnchorAgent(tmpDir);
       // Create enough source files for sync to run
       await writeFile(join(tmpDir, 'CLAUDE.md'), '');
 
@@ -1624,6 +1690,7 @@ describe('Skill Sync', () => {
     //      Without the fix the condition only checks isDrift || conflicts → passes silently.
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-check-legacy-removal-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
 
       // Step 1: real sync to get correct v5 manifest on disk
@@ -1664,6 +1731,7 @@ describe('Skill Sync', () => {
   it('--check converges: passes after real sync removes v4 legacy Gemini targets', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-check-legacy-converge-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# context');
 
       // Establish a clean v5 baseline
@@ -1784,6 +1852,7 @@ describe('Skill Sync', () => {
   it('detectDuplicates handles Codex skills and Claude commands in index', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-fullidx-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await mkdir(join(tmpDir, '.codex', 'skills', 'openspec-test'), { recursive: true });
       await writeFile(
         join(tmpDir, '.codex', 'skills', 'openspec-test', 'SKILL.md'),
@@ -2074,6 +2143,7 @@ describe('Skill Sync', () => {
   it('does not sync project hooks from .claude/settings.json', async () => {
     const tmpDir = await mkdtemp(join(tmpdir(), 'aco-test-ignore-hooks-'));
     try {
+      await seedAnchorAgent(tmpDir);
       await writeFile(join(tmpDir, 'CLAUDE.md'), '# Project context');
       await mkdir(join(tmpDir, '.claude'), { recursive: true });
       await writeFile(


### PR DESCRIPTION
Closes #152

## What

`aco sync`가 structured-surface 산출물을 만들 source(skill / Codex agent / hook)가 하나도 없는 repo에서 빈 manifest만 쓰고 exit 0 하던 동작을 막는다. 이제 그런 fresh repo는 명확한 "No sync sources found" 에러로 non-zero 종료한다. 단, 이미 sync한 적이 있거나 legacy aco-owned 타깃이 남은 repo는 통과시켜 cleanup이 끝까지 돌게 한다.

## Why

PR #150에서 `config`(CLAUDE.md)·`rule`(.claude/rules) source가 더 이상 sync 출력을 만들지 않게 된 뒤, `CLAUDE.md`/`.claude/rules`만 있는 repo에서 `aco sync`가 아무 산출물 없이 빈 성공을 반환했다. 처음 sync를 켜는 사용자가 정상 동작으로 오해하기 쉬운 no-op이다.

단순히 "structured source 0이면 무조건 fail"로 두면, skill을 모두 제거한 repo에서 stale 생성물·legacy Gemini 타깃 cleanup이 영영 안 도는 migration 회귀가 생긴다. 그래서 가드는 "정리할 상태조차 없는 진짜 빈 repo"에만 발동하도록, 기존 manifest나 legacy 타깃이 있으면 통과시킨다.

## Changes

- `sync/sync-engine.ts`: no-source 가드를 `sources.length === 0`에서 structured source(`skill`/`agent`/`settings`) 기준으로 변경. 가드를 manifest 읽기 이후로 옮겨 `structuredSources.length === 0 && existingManifest === null && legacyCleanupManifest === null`일 때만 hard-fail. 판정 종류는 `STRUCTURED_SOURCE_KINDS` 상수로 추출.
- `tests/sync.test.ts`: hard-fail 회귀 테스트(CLAUDE.md-only 실패 / rules-only 실패 / agent 있으면 성공) + cleanup-only 통과 분기 전용 테스트 추가. 기존 legacy/duplicate/hook fixture에는 최소 structured source(anchor agent) 주입.
- `tests/sync-manifest-portability.test.ts`, `tests/pack-runtime-contract.test.ts`: cross-checkout·drift fixture에 anchor source 추가.
- `openspec/.../cli-sync-command/spec.md`: "Missing Claude sources" 시나리오를 structured-source 기준으로 복원하고 cleanup-only 예외 시나리오 명문화(deferred NOTE 제거).

## Review notes

`aco`로 antigravity multi-agent adversarial 리뷰를 돌려 4개 finding을 받아 코드 대조로 판정했다.

- 채택: cleanup-only 통과 분기 전용 테스트 누락(P1) → 추가. structured kind 하드코딩(P3) → 상수화.
- 기각: manifest 읽기 함수 throw로 crash(P1)는 두 reader가 모든 에러를 try/catch로 null 흡수해 거짓. 에러 메시지 변경 호환성(P2)은 consumer가 substring 매칭이고 "No sync sources found." prefix 보존이라 거짓.

## Checklist

- [x] `CLAUDE.md`/`.claude/rules`만 있는 fresh repo에서 `aco sync` non-zero 실패
- [x] skill/agent 중 하나라도 있으면 정상 동작
- [x] 기존 manifest/legacy 타깃이 있으면 structured source 없어도 통과(cleanup 회귀 방지)
- [x] sync 관련 4개 test suite green (126 pass)
- [x] wrapper 전체 테스트 green (439 pass)
- [x] `typecheck`, `format:check` green
