### PR TITLE
chore: version packages 0.5.0

### DIFF
--- a/.changeset/npm-publish-pipeline-restore.md
+++ b/.changeset/npm-publish-pipeline-restore.md
@@ -1,5 +1,0 @@
----
-"@pureliture/ai-cli-orch-wrapper": patch
----
-
-npm 배포 파이프라인 복원: `publishConfig.access = "public"` 추가, release workflow를 `release` label PR merge 전용으로 제한, `release` GitHub label 생성

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,7 +1903,7 @@
     },
     "packages/wrapper": {
       "name": "@pureliture/ai-cli-orch-wrapper",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1"

--- a/packages/wrapper/CHANGELOG.md
+++ b/packages/wrapper/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @pureliture/ai-cli-orch-wrapper
 
+## 0.5.0
+
+### Minor Changes
+
+- `aco sync`가 structured source(skill / Codex agent)가 하나도 없는 fresh repo에서 빈 manifest만 쓰고 성공하던 동작을 막고, 명확한 "No sync sources found" 에러로 non-zero 종료하도록 강화. 단 기존 manifest나 legacy 타깃이 있으면 통과시켜 stale-target·legacy Gemini·orphan Codex agent cleanup이 끝까지 돌게 한다 (#152).
+
+### Patch Changes
+
+- 11dc797: npm 배포 파이프라인 복원: `publishConfig.access = "public"` 추가, release workflow를 `release` label PR merge 전용으로 제한, `release` GitHub label 생성
+- `aco ask --output-mode save-only|full`(stream-only) 경로에서 run/session ledger의 `outputBytes`가 16KB capture 상한에 잘린 버퍼로 계산돼 실제 출력보다 작게 기록되던 문제 수정. provider session runner가 capture 상한과 무관하게 실제 스트리밍된 UTF-8 총 바이트를 별도로 세어 반환한다 (#139).
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pureliture/ai-cli-orch-wrapper",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Installable aco CLI for consent-gated external AI delegation, provider setup, doctor checks, and session artifacts.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release: @pureliture/ai-cli-orch-wrapper 0.4.1 → 0.5.0

이 PR은 changeset 기반 버전 bump PR입니다. `release` label과 함께 main에 머지되면 release workflow가 `changeset publish`로 npm에 배포합니다.

## What

- `packages/wrapper/package.json`: 0.4.1 → 0.5.0 (minor)
- `packages/wrapper/CHANGELOG.md`: 0.5.0 항목 추가
- 누적 changeset 3건 소비

## 포함된 변경 (0.5.0)

- **Minor** — `aco sync` structured source hard-fail 강화 (#152, PR #164): skill/Codex agent가 없는 fresh repo는 빈 성공 대신 "No sync sources found"로 non-zero 종료. 기존 manifest/legacy 타깃이 있으면 통과시켜 stale·orphan cleanup 보장.
- **Patch** — `aco ask` stream-only `outputBytes` 정확화 (#139, PR #163): 16KB capture 상한과 무관하게 실제 스트리밍 바이트를 기록.
- **Patch** — npm 배포 파이프라인 복원 changeset 소비.

## 버전 근거

#152가 sync의 관찰 가능한 CLI 동작을 바꾸므로(이전에 성공하던 경로가 실패) 0.x 관례상 minor로 올렸다.

## Checklist

- [x] `changeset version` 실행으로 버전·CHANGELOG 생성, 소비된 changeset 제거
- [x] base는 #139·#164 머지가 반영된 최신 main
- [ ] (머지 시) release workflow가 npm publish 수행 — 머지가 곧 배포임에 유의
