### PR TITLE
fix(antigravity): agy를 고정 중립 cwd에서 실행해 임시 디렉터리 project 누적 방지

### DIFF
--- a/.changeset/antigravity-agy-neutral-cwd.md
+++ b/.changeset/antigravity-agy-neutral-cwd.md
@@ -1,0 +1,5 @@
+---
+"@pureliture/ai-cli-orch-wrapper": patch
+---
+
+antigravity 위임이 `agy`를 고정 중립 작업 디렉터리(`~/.aco/agy-workspace`)에서 실행하도록 수정. 이전에는 호출 위치(임시·session·job 디렉터리 포함)를 그대로 상속해 Antigravity project 목록에 임시 경로가 무한 누적됐다. spawn 시 바이너리를 절대경로화하고, 워크스페이스 생성 실패 시 inherited cwd로 fallback해 위임이 hard-fail하지 않게 했다 (#166).

--- a/packages/wrapper/src/providers/antigravity.ts
+++ b/packages/wrapper/src/providers/antigravity.ts
@@ -1,9 +1,25 @@
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { which } from '../util/which.js';
 import { spawnStream } from '../util/spawn-stream.js';
 import { buildProviderEnv } from '../util/provider-env.js';
 import type { AuthResult, InvokeOptions, IProvider, PermissionProfile } from './interface.js';
 import { readVersion } from '../util/read-version.js';
 import { defaultSummarizeOutput } from '../util/summarize-output.js';
+
+/**
+ * Stable, neutral working directory for `agy` invocations.
+ *
+ * agy persists every cwd it runs in as a project in `~/.gemini/antigravity-cli`,
+ * so inheriting aco's cwd (often an ephemeral temp/session/job dir) floods the
+ * Antigravity sidebar with junk projects. Pinning a single fixed directory keeps
+ * exactly one stable entry instead. Review content is passed via `-p`/stdin, not
+ * read from cwd, so this does not affect delegation output.
+ */
+export function agyWorkspaceDir(): string {
+  return join(homedir(), '.aco', 'agy-workspace');
+}
 
 export class AntigravityProvider implements IProvider {
   readonly key = 'antigravity';
@@ -78,7 +94,11 @@ export class AntigravityProvider implements IProvider {
     const env = buildProviderEnv([]);
     const combined = content ? `${prompt}\n\n${content}` : prompt;
     const args = [...this.buildArgs(command, options), combined];
-    yield* spawnStream(binary, args, { processName: 'agy', stdin: 'pipe', env }, options);
+    // Pin agy to a stable neutral cwd so ephemeral invocation dirs are not
+    // registered as Antigravity projects. See agyWorkspaceDir() above.
+    const cwd = agyWorkspaceDir();
+    await mkdir(cwd, { recursive: true });
+    yield* spawnStream(binary, args, { processName: 'agy', stdin: 'pipe', env, cwd }, options);
   }
 
   summarizeOutput(output: string, maxLength: number): string {

--- a/packages/wrapper/src/providers/antigravity.ts
+++ b/packages/wrapper/src/providers/antigravity.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { which } from '../util/which.js';
 import { spawnStream } from '../util/spawn-stream.js';
 import { buildProviderEnv } from '../util/provider-env.js';
@@ -87,6 +87,11 @@ export class AntigravityProvider implements IProvider {
   ): AsyncIterable<string> {
     const binary = which('agy');
     if (!binary) throw new Error('agy CLI not found in PATH');
+    // which() may return a PATH-relative path when PATH contains relative entries.
+    // Resolve to absolute against the current cwd BEFORE switching the child's cwd:
+    // a relative binary would otherwise be re-resolved against agyWorkspaceDir() and
+    // fail with ENOENT.
+    const resolvedBinary = resolve(binary);
 
     // agy는 OS Keyring 인증 방식을 사용하므로 auth env var가 필요 없다.
     // buildProviderEnv([])는 BASE_ENV_KEYS(PATH, HOME 등 기반 키)만 전달하고
@@ -99,16 +104,19 @@ export class AntigravityProvider implements IProvider {
     // If the workspace dir cannot be created (path is a file, parent not writable),
     // fall back to the inherited cwd so the delegation still runs — a cosmetic
     // project-pollution risk must not become a hard delegation failure.
-    let cwd: string | undefined = agyWorkspaceDir();
+    // agyWorkspaceDir() (os.homedir()) can throw in restricted environments, so it
+    // lives inside the try with mkdir — failure falls back to the inherited cwd.
+    let cwd: string | undefined;
     try {
+      cwd = agyWorkspaceDir();
       await mkdir(cwd, { recursive: true });
     } catch {
       cwd = undefined;
     }
     yield* spawnStream(
-      binary,
+      resolvedBinary,
       args,
-      { processName: 'agy', stdin: 'pipe', env, ...(cwd !== undefined && { cwd }) },
+      { processName: 'agy', stdin: 'pipe', env, cwd },
       options
     );
   }

--- a/packages/wrapper/src/providers/antigravity.ts
+++ b/packages/wrapper/src/providers/antigravity.ts
@@ -96,9 +96,21 @@ export class AntigravityProvider implements IProvider {
     const args = [...this.buildArgs(command, options), combined];
     // Pin agy to a stable neutral cwd so ephemeral invocation dirs are not
     // registered as Antigravity projects. See agyWorkspaceDir() above.
-    const cwd = agyWorkspaceDir();
-    await mkdir(cwd, { recursive: true });
-    yield* spawnStream(binary, args, { processName: 'agy', stdin: 'pipe', env, cwd }, options);
+    // If the workspace dir cannot be created (path is a file, parent not writable),
+    // fall back to the inherited cwd so the delegation still runs — a cosmetic
+    // project-pollution risk must not become a hard delegation failure.
+    let cwd: string | undefined = agyWorkspaceDir();
+    try {
+      await mkdir(cwd, { recursive: true });
+    } catch {
+      cwd = undefined;
+    }
+    yield* spawnStream(
+      binary,
+      args,
+      { processName: 'agy', stdin: 'pipe', env, ...(cwd !== undefined && { cwd }) },
+      options
+    );
   }
 
   summarizeOutput(output: string, maxLength: number): string {

--- a/packages/wrapper/src/util/spawn-stream.ts
+++ b/packages/wrapper/src/util/spawn-stream.ts
@@ -34,6 +34,13 @@ export interface SpawnStreamConfig {
    * Use buildProviderEnv() to construct an allowlist env.
    */
   env?: NodeJS.ProcessEnv;
+  /**
+   * Working directory for the child process.
+   * If omitted, the child inherits the parent process cwd (legacy behavior).
+   * Providers whose binary derives persistent state from cwd (e.g. agy registers
+   * cwd as an Antigravity project) should pass a stable, neutral directory.
+   */
+  cwd?: string;
 }
 
 /**
@@ -151,6 +158,7 @@ export async function* spawnStream(
       stdio: [stdinValue, 'pipe', 'pipe'],
       detached: process.platform !== 'win32',
       ...(config.env !== undefined && { env: config.env }),
+      ...(config.cwd !== undefined && { cwd: config.cwd }),
     });
   } catch (err) {
     if (stdinFd !== undefined) {

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
-import { AntigravityProvider } from '../src/providers/antigravity';
+import { AntigravityProvider, agyWorkspaceDir } from '../src/providers/antigravity';
 import { CodexProvider } from '../src/providers/codex';
 import { MockProvider } from '../src/providers/mock';
 import { ProviderRegistry } from '../src/providers/registry';
@@ -144,6 +144,14 @@ describe('AntigravityProvider', () => {
 
   it('key is "antigravity"', () => {
     assert.equal(new AntigravityProvider().key, 'antigravity');
+  });
+
+  it('agyWorkspaceDir() is a stable neutral dir under ~/.aco (not an ephemeral cwd)', () => {
+    const dir = agyWorkspaceDir();
+    assert.equal(dir, path.join(os.homedir(), '.aco', 'agy-workspace'));
+    // Stable across calls — agy must register the same single project, not the cwd.
+    assert.equal(dir, agyWorkspaceDir());
+    assert.notEqual(dir, process.cwd());
   });
 
   it('installHint contains curl', () => {

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -179,6 +179,39 @@ describe('AntigravityProvider', () => {
     }
   });
 
+  it('resolves a PATH-relative agy binary to absolute before switching cwd (no ENOENT)', async () => {
+    // Repro: PATH contains a relative entry (e.g. node_modules/.bin). which() returns
+    // a relative path; without absolute-resolution the new cwd breaks binary lookup.
+    const runRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-agy-relpath-'));
+    const relBinName = 'relbin';
+    await fs.mkdir(path.join(runRoot, relBinName), { recursive: true });
+    await fs.writeFile(
+      path.join(runRoot, relBinName, 'agy'),
+      '#!/usr/bin/env node\nprocess.stdout.write(process.cwd());\n',
+      { mode: 0o755 }
+    );
+    const origPath = process.env.PATH;
+    const origCwd = process.cwd();
+    process.chdir(runRoot);
+    // relative entry FIRST (which() returns it, relative) + original PATH so the
+    // fake script's `#!/usr/bin/env node` shebang still resolves node.
+    process.env.PATH = `${relBinName}${path.delimiter}${origPath ?? ''}`;
+    try {
+      const chunks: string[] = [];
+      for await (const c of new AntigravityProvider().invoke('review', 'p', 'c', {
+        permissionProfile: 'restricted',
+      })) {
+        chunks.push(c);
+      }
+      // No ENOENT, and agy still ran in the neutral workspace dir.
+      assert.equal(await fs.realpath(chunks.join('').trim()), await fs.realpath(agyWorkspaceDir()));
+    } finally {
+      process.chdir(origCwd);
+      process.env.PATH = origPath;
+      await fs.rm(runRoot, { recursive: true, force: true });
+    }
+  });
+
   it('installHint contains curl', () => {
     assert.ok(new AntigravityProvider().installHint.includes('curl'));
   });

--- a/packages/wrapper/tests/providers.test.ts
+++ b/packages/wrapper/tests/providers.test.ts
@@ -154,6 +154,31 @@ describe('AntigravityProvider', () => {
     assert.notEqual(dir, process.cwd());
   });
 
+  it('invoke() runs agy in the neutral workspace dir, not the inherited cwd', async () => {
+    // Integration guard: a refactor that drops the cwd wiring must fail here.
+    // Fake `agy` prints its own process.cwd(); we assert it ran in agyWorkspaceDir().
+    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), 'aco-agy-fake-'));
+    const fakeAgy = path.join(binDir, 'agy');
+    await fs.writeFile(fakeAgy, '#!/usr/bin/env node\nprocess.stdout.write(process.cwd());\n', {
+      mode: 0o755,
+    });
+    const origPath = process.env.PATH;
+    process.env.PATH = `${binDir}${path.delimiter}${origPath ?? ''}`;
+    try {
+      const chunks: string[] = [];
+      for await (const c of new AntigravityProvider().invoke('review', 'p', 'c', {
+        permissionProfile: 'restricted',
+      })) {
+        chunks.push(c);
+      }
+      const childCwd = await fs.realpath(chunks.join('').trim());
+      assert.equal(childCwd, await fs.realpath(agyWorkspaceDir()));
+    } finally {
+      process.env.PATH = origPath;
+      await fs.rm(binDir, { recursive: true, force: true });
+    }
+  });
+
   it('installHint contains curl', () => {
     assert.ok(new AntigravityProvider().installHint.includes('curl'));
   });

--- a/packages/wrapper/tests/spawn-stream-buffering.test.ts
+++ b/packages/wrapper/tests/spawn-stream-buffering.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { access, mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { access, mkdtemp, writeFile, rm, realpath } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnStream } from '../src/util/spawn-stream.js';
@@ -136,6 +136,29 @@ process.stdout.write('started');
       await assert.rejects(access(markerPath), /ENOENT/);
     } finally {
       await rm(tmpBin, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('spawnStream working directory', () => {
+  it('runs the child process in the provided cwd', async () => {
+    const tmpBin = await mkdtemp(join(tmpdir(), 'aco-spawn-cwd-bin-'));
+    const tmpCwd = await realpath(await mkdtemp(join(tmpdir(), 'aco-spawn-cwd-run-')));
+    const binary = await makeScriptBinary(tmpBin, 'print-cwd', 'process.stdout.write(process.cwd());');
+
+    try {
+      const chunks: string[] = [];
+      for await (const chunk of spawnStream(binary, [], {
+        processName: 'print-cwd',
+        stdin: 'ignore',
+        cwd: tmpCwd,
+      })) {
+        chunks.push(chunk);
+      }
+      assert.equal(await realpath(chunks.join('').trim()), tmpCwd);
+    } finally {
+      await rm(tmpBin, { recursive: true, force: true });
+      await rm(tmpCwd, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
Closes #166

## What

antigravity 위임이 `agy`를 호출 위치(cwd) 그대로 실행해, 임시·session·job 디렉터리가 Antigravity의 project 목록에 무한 누적되던 문제를 고친다. 이제 `agy`를 고정 중립 작업 디렉터리 `~/.aco/agy-workspace`에서 실행해, 사이드바에는 안정적인 단일 항목 하나만 남는다.

## Why

`agy`는 실행된 cwd를 `~/.gemini/antigravity-cli`에 persistent project로 등록한다. aco antigravity provider가 cwd를 지정하지 않아 aco 프로세스의 cwd(임시 디렉터리 포함)를 상속 → 일회성 디렉터리가 계속 project로 쌓였다.

`agy`에는 project 등록을 끄는 flag가 없고(routine-harness knowledge + `agy --help` 확인), 리뷰 대상은 `-p`/stdin으로 전달되어 cwd 파일을 읽지 않으므로, 고정 중립 cwd로 실행하면 위임 출력에 영향 없이 누적을 막을 수 있다.

> Note: agy 자체가 cwd를 무조건 등록하고 비활성 flag가 없어 "0개"는 agy 정상 사용 범위에서 불가능하다. 본 PR은 N개 임시 난립을 안정적인 1개로 수렴시키며 agy 정상 동작(실제 HOME·인증·settings)을 100% 보존한다.

## Changes

- `util/spawn-stream.ts`: provider-neutral `cwd` 옵션 추가, child process spawn에 전달(미지정 시 기존처럼 parent cwd 상속 — 하위호환).
- `providers/antigravity.ts`: `agyWorkspaceDir()`(`~/.aco/agy-workspace`)를 mkdir 후 agy의 cwd로 지정. 워크스페이스 생성 실패(경로가 파일·권한 없음) 시 inherited cwd로 fallback해 위임이 hard-fail하지 않게 방어.
- tests: spawn-stream cwd 전달 검증 + `agyWorkspaceDir()` 안정·중립 경로 검증 + fake `agy`로 invoke()가 실제로 중립 cwd에서 agy를 실행하는지 통합 검증.

## Review notes

`aco`로 antigravity multi-agent adversarial 리뷰를 돌렸고(브랜치 빌드로 실행 → #166 자체의 라이브 통합 테스트 겸함), 임시 cwd가 더 이상 등록되지 않고 `~/.aco/agy-workspace`만 등록됨을 실측 확인. 리뷰 findings 중 채택:

- mkdir 실패 시 위임 전체 실패 위험 → inherited cwd fallback 추가.
- invoke() cwd 배선 통합 테스트 부재 → fake agy 테스트 추가.

기각: "agy가 cwd 상대경로를 쓸 수 있다"는 aco가 content를 `-p`로만 전달하고 agy에 `--project-dir` 류 flag가 없어 해당 없음(알려진 tradeoff).

## Checklist

- [x] 임시 디렉터리에서 antigravity 위임 실행 시 해당 임시 경로가 Antigravity project로 등록되지 않음 (실측 확인)
- [x] `agy` 정상 동작(실제 HOME·인증·settings) 보존 — cwd만 변경
- [x] cwd 미지정 레거시 호출 하위호환 유지
- [x] wrapper 전체 테스트 green (448 pass), `typecheck`·`format:check` green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The Antigravity provider now runs in a stable, neutral working directory instead of the current directory, providing consistent behavior for workspace-dependent operations.
* Graceful fallback to standard delegation if workspace directory creation fails.

## Improvements
* Enhanced process execution infrastructure to support custom working directories for improved operational isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pureliture/ai-cli-orch-wrapper/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->