### PR TITLE
chore: version packages 0.5.1

### DIFF
--- a/.changeset/antigravity-agy-neutral-cwd.md
+++ b/.changeset/antigravity-agy-neutral-cwd.md
@@ -1,5 +1,0 @@
----
-"@pureliture/ai-cli-orch-wrapper": patch
----
-
-antigravity 위임이 `agy`를 고정 중립 작업 디렉터리(`~/.aco/agy-workspace`)에서 실행하도록 수정. 이전에는 호출 위치(임시·session·job 디렉터리 포함)를 그대로 상속해 Antigravity project 목록에 임시 경로가 무한 누적됐다. spawn 시 바이너리를 절대경로화하고, 워크스페이스 생성 실패 시 inherited cwd로 fallback해 위임이 hard-fail하지 않게 했다 (#166).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1903,7 +1903,7 @@
     },
     "packages/wrapper": {
       "name": "@pureliture/ai-cli-orch-wrapper",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.1"

--- a/packages/wrapper/CHANGELOG.md
+++ b/packages/wrapper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pureliture/ai-cli-orch-wrapper
 
+## 0.5.1
+
+### Patch Changes
+
+- 87d858f: antigravity 위임이 `agy`를 고정 중립 작업 디렉터리(`~/.aco/agy-workspace`)에서 실행하도록 수정. 이전에는 호출 위치(임시·session·job 디렉터리 포함)를 그대로 상속해 Antigravity project 목록에 임시 경로가 무한 누적됐다. spawn 시 바이너리를 절대경로화하고, 워크스페이스 생성 실패 시 inherited cwd로 fallback해 위임이 hard-fail하지 않게 했다 (#166).
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pureliture/ai-cli-orch-wrapper",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Installable aco CLI for consent-gated external AI delegation, provider setup, doctor checks, and session artifacts.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Release: @pureliture/ai-cli-orch-wrapper 0.5.0 → 0.5.1

changeset 기반 버전 bump PR. `release` label과 함께 main에 머지되면 release workflow가 `changeset publish`로 npm에 배포한다.

## What

- `packages/wrapper/package.json`: 0.5.0 → 0.5.1 (patch)
- `packages/wrapper/CHANGELOG.md`: 0.5.1 항목 추가
- `package-lock.json`: wrapper 버전 0.5.1 동기화
- 누적 changeset 1건 소비

## 포함된 변경 (0.5.1)

- **Patch** — antigravity 위임이 `agy`를 고정 중립 cwd(`~/.aco/agy-workspace`)에서 실행 (#166, PR #167): 임시 디렉터리가 Antigravity project로 누적되는 문제 해결. 바이너리 절대경로화 + 워크스페이스 생성 실패 시 inherited cwd fallback 포함.

## Checklist

- [x] `changeset version`으로 버전·CHANGELOG 생성, changeset 제거
- [x] package-lock.json 동기화
- [x] base는 #167 머지 반영된 최신 main
- [ ] (머지 시) release workflow가 npm publish — 머지가 곧 배포
