### PR TITLE
chore(gitignore): 로컬 스크래치/런타임 잡파일 무시 (commit.msg, cache/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,7 @@ templates/skills/improve-codebase-architecture/
 .claude/skills/openspec-*/
 .claude/commands/opsx/
 .codex/skills/openspec-*/
+
+# Local scratch / runtime cruft (not part of the repo)
+/commit.msg
+/cache/


### PR DESCRIPTION
## 배경

repo 루트의 `commit.msg`(커밋 메시지 초안 스크래치)와 `cache/projects.json`(antigravity `agy`가 cwd에 만드는 프로젝트 UUID 캐시)가 untracked로 남아 `git status`를 어지럽힌다. 둘 다 repo 산출물이 아니다.

## 변경 내용

- `.gitignore`에 root-anchored `/commit.msg`, `/cache/` 추가
- anchored 패턴이라 하위 패키지의 정상 `cache/` 디렉터리는 영향 없음

## 검증

- `git check-ignore -v`로 두 경로가 새 패턴에 매칭됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to exclude local runtime files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->