### PR TITLE
fix: 이슈 #185 코드리뷰 결함 전면 조치

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ wrapper입니다. provider 실행은 명시적 동의 없이는 시작되지 않
 # 실행 계획만 확인하고 provider는 호출하지 않음
 aco ask --providers mock --task "review this demo input" --input "demo" --dry-run
 
-# 다중 파일(glob)과 단일 파일 입력 (1MB 제한, credential 감지 시 --allow-sensitive 필요)
+# 다중 파일(glob)과 단일 파일 입력 (5MB 제한, credential 감지 시 --allow-sensitive 필요)
 aco ask --providers mock --task "review files" --paths "src/**/*.ts" --input-file ".env.example" --allow-sensitive --yes
 
 # 명시 동의 후 실행. full output은 session artifact에 저장되고 stdout에는 brief만 출력

--- a/README.md
+++ b/README.md
@@ -359,6 +359,9 @@ wrapper입니다. provider 실행은 명시적 동의 없이는 시작되지 않
 # 실행 계획만 확인하고 provider는 호출하지 않음
 aco ask --providers mock --task "review this demo input" --input "demo" --dry-run
 
+# 다중 파일(glob)과 단일 파일 입력 (1MB 제한, credential 감지 시 --allow-sensitive 필요)
+aco ask --providers mock --task "review files" --paths "src/**/*.ts" --input-file ".env.example" --allow-sensitive --yes
+
 # 명시 동의 후 실행. full output은 session artifact에 저장되고 stdout에는 brief만 출력
 aco ask --providers mock --task "review this demo input" --input "demo" --yes --output-mode brief
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,6 +73,10 @@ Default permission profile is `restricted`.
 
 `restricted` means the wrapper requests the safest available provider behavior and includes advisory prompt instructions such as not modifying files. It is not a complete OS-level sandbox and does not prove that a provider cannot modify files if the provider CLI ignores the requested behavior.
 
+실질적으로 권한 모델은 **2-tier** 구조로 축소되어 이해할 수 있습니다:
+- **Restricted**: 저장소 파일에 대한 수정 권한을 차단하고 읽기 전용 자문(advisory) 모델로 동작합니다.
+- **Unrestricted / Default**: `default`와 `unrestricted` 프로필은 실질적으로 동일하게 동작합니다. 외부 프로바이더가 제한 없이 로컬 파일 시스템에 접근 및 수정할 수 있으며, 자동 승인(auto-approved) 모드로 처리됩니다.
+
 Do not enable broader permission profiles unless the task requires it and the provider behavior is understood.
 
 ## Timeout And Cancellation Boundary

--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,7 +2293,7 @@
     },
     "packages/wrapper": {
       "name": "@pureliture/ai-cli-orch-wrapper",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "glob": "^10.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -947,6 +956,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -1181,6 +1202,23 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1364,6 +1402,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1386,6 +1433,30 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mri": {
@@ -1495,6 +1566,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-type": {
@@ -1903,9 +1990,10 @@
     },
     "packages/wrapper": {
       "name": "@pureliture/ai-cli-orch-wrapper",
-      "version": "0.5.1",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
+        "glob": "^13.0.6",
         "js-yaml": "^4.1.1"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,6 +769,50 @@
       "resolved": "packages/installer",
       "link": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@manypkg/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@manypkg/find-root/-/find-root-1.1.0.tgz",
@@ -879,6 +923,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pureliture/ai-cli-orch-wrapper": {
       "resolved": "packages/wrapper",
       "link": true
@@ -914,10 +968,21 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/argparse": {
@@ -937,13 +1002,10 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
@@ -959,15 +1021,12 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -990,11 +1049,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1027,6 +1103,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -1159,6 +1247,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -1203,17 +1307,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
       "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
-      "engines": {
-        "node": "18 || 20 || >=22"
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1307,6 +1415,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1357,8 +1474,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
@@ -1403,13 +1534,10 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -1436,15 +1564,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1538,6 +1666,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/package-manager-detector": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.11.tgz",
@@ -1562,23 +1696,22 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1797,7 +1930,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -1810,7 +1942,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1820,7 +1951,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -1857,11 +1987,88 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -1961,7 +2168,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -1971,6 +2177,103 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/installer": {
@@ -1993,7 +2296,7 @@
       "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
-        "glob": "^13.0.6",
+        "glob": "^10.5.0",
         "js-yaml": "^4.1.1"
       },
       "bin": {

--- a/packages/wrapper/CHANGELOG.md
+++ b/packages/wrapper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @pureliture/ai-cli-orch-wrapper
 
+## 0.7.2
+
+### Patch Changes
+
+- Fix `aco ask --paths` so Node 18 installs stay compatible and directory-only
+  matches fail instead of sending empty input to providers.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pureliture/ai-cli-orch-wrapper",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Installable aco CLI for consent-gated external AI delegation, provider setup, doctor checks, and session artifacts.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -34,6 +34,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
+    "glob": "^13.0.6",
     "js-yaml": "^4.1.1"
   }
 }

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -34,7 +34,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
-    "glob": "^13.0.6",
+    "glob": "^10.5.0",
     "js-yaml": "^4.1.1"
   }
 }

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -649,8 +649,8 @@ async function collectInput(options: AskOptions): Promise<string> {
       fail(`Failed to read --input-file '${options.inputFile}': ${message}`);
     });
 
-    if (Buffer.byteLength(fileInput, 'utf8') > 1024 * 1024) {
-      fail(`Error: File '${options.inputFile}' exceeds 1MB limit`);
+    if (Buffer.byteLength(fileInput, 'utf8') > 5 * 1024 * 1024) {
+      fail(`Error: File '${options.inputFile}' exceeds 5MB limit`);
     }
 
     chunks.push(fileInput);
@@ -690,13 +690,13 @@ async function collectInput(options: AskOptions): Promise<string> {
       );
 
       const bytes = Buffer.byteLength(fileContent, 'utf8');
-      if (bytes > 1024 * 1024) {
-        fail(`Error: Matched file '${file}' exceeds 1MB limit`);
+      if (bytes > 5 * 1024 * 1024) {
+        fail(`Error: Matched file '${file}' exceeds 5MB limit`);
       }
 
       totalBytes += bytes + (pathChunks.length > 0 ? 2 : 0);
-      if (totalBytes > 1024 * 1024) {
-        fail(`Error: Merged files from --paths exceed 1MB limit`);
+      if (totalBytes > 5 * 1024 * 1024) {
+        fail(`Error: Merged files from --paths exceed 5MB limit`);
       }
 
       pathChunks.push(fileContent);

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { createWriteStream, existsSync } from 'node:fs';
+import { createWriteStream, existsSync, globSync, statSync } from 'node:fs';
 import { randomUUID, createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
@@ -62,6 +62,7 @@ interface AskOptions {
   task?: string;
   input?: string;
   inputFile?: string;
+  paths?: string;
   allowSensitive: boolean;
   preset?: string;
   permissionProfile: PermissionProfile;
@@ -143,6 +144,9 @@ export async function cmdAsk(args: string[]): Promise<void> {
   }
   const input = await collectInput(options);
   const preset = options.preset ? await loadPreset(options.preset) : undefined;
+  if (options.task && options.providers.includes('antigravity')) {
+    options.task = resolveRelativePathsInText(options.task);
+  }
   const prompt = buildPrompt(options, preset);
 
   // F-c: --model이 설정되어 있고 antigravity provider가 포함된 경우 경고 출력.
@@ -397,7 +401,13 @@ export async function cmdAsk(args: string[]): Promise<void> {
         const stderrContent = runResult.stderrContent;
         const stderrBytes = Buffer.byteLength(stderrContent, 'utf8');
         const warningCount = countWarnings(runResult.stderrContent);
-        const resultQuality = resolveResultQuality(status, runResult.hasOutput, warningCount);
+        const resultQuality = resolveResultQuality(
+          status,
+          runResult.hasOutput,
+          warningCount,
+          runResult.fullOutput,
+          stderrContent
+        );
 
         let stderrArtifactPath: string | undefined;
         if (stderrBytes > 0) {
@@ -523,6 +533,7 @@ function parseAskOptions(args: string[]): AskOptions {
     task: parseFlag(args, '--task'),
     input: parseFlag(args, '--input'),
     inputFile: parseFlag(args, '--input-file'),
+    paths: parseFlag(args, '--paths') ?? parseFlag(args, '--input-path'),
     allowSensitive: args.includes('--allow-sensitive'),
     preset: parseFlag(args, '--preset'),
     permissionProfile: parseFlag<PermissionProfile>(args, '--permission-profile') ?? 'restricted',
@@ -610,6 +621,11 @@ async function collectInput(options: AskOptions): Promise<string> {
   const chunks: string[] = [];
 
   if (options.input) {
+    if (existsSync(options.input) && statSync(options.input).isDirectory()) {
+      process.stderr.write(
+        'Warning: `--input` looks like a directory. Did you mean to use `--paths`?\n'
+      );
+    }
     chunks.push(options.input);
   }
 
@@ -632,7 +648,60 @@ async function collectInput(options: AskOptions): Promise<string> {
       const message = err instanceof Error ? err.message : String(err);
       fail(`Failed to read --input-file '${options.inputFile}': ${message}`);
     });
+
+    if (Buffer.byteLength(fileInput, 'utf8') > 1024 * 1024) {
+      fail(`Error: File '${options.inputFile}' exceeds 1MB limit`);
+    }
+
     chunks.push(fileInput);
+  }
+
+  if (options.paths) {
+    const matchedFiles = globSync(options.paths, { cwd: process.cwd() });
+    matchedFiles.sort();
+
+    const pathChunks: string[] = [];
+    for (const file of matchedFiles) {
+      const stat = statSync(file);
+      if (stat.isDirectory()) {
+        continue;
+      }
+
+      if (isCredentialLikePath(file)) {
+        if (options.allowSensitive) {
+          process.stderr.write(
+            `[aco] warning: Matched file '${file}' looks like a credential or secret file. ` +
+              `Proceeding because --allow-sensitive was specified.\n`
+          );
+        } else {
+          fail(
+            `Blocked: Matched file '${file}' looks like a credential or secret file. ` +
+              `Pass --allow-sensitive to override.`
+          );
+        }
+      }
+
+      const fileContent = await readFile(resolve(process.cwd(), file), 'utf8').catch(
+        (err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          fail(`Failed to read matched file '${file}': ${message}`);
+        }
+      );
+
+      if (Buffer.byteLength(fileContent, 'utf8') > 1024 * 1024) {
+        fail(`Error: Matched file '${file}' exceeds 1MB limit`);
+      }
+
+      pathChunks.push(fileContent);
+    }
+
+    if (pathChunks.length > 0) {
+      const mergedPathsContent = pathChunks.join('\n\n');
+      if (Buffer.byteLength(mergedPathsContent, 'utf8') > 1024 * 1024) {
+        fail(`Error: Merged files from --paths exceed 1MB limit`);
+      }
+      chunks.push(mergedPathsContent);
+    }
   }
 
   return chunks.join('\n\n');
@@ -649,6 +718,35 @@ async function loadPreset(name: string): Promise<string> {
   }
 
   fail(`Preset not found: ${name}`);
+}
+
+function resolveRelativePathsInText(text: string): string {
+  return text.replace(/("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|`[^`]*`|[\w\-\.\/]+)/g, (match) => {
+    let cleanToken = match;
+    let quote = '';
+    if (
+      (match.startsWith('"') && match.endsWith('"')) ||
+      (match.startsWith("'") && match.endsWith("'")) ||
+      (match.startsWith('`') && match.endsWith('`'))
+    ) {
+      quote = match[0];
+      cleanToken = match.slice(1, -1);
+    }
+
+    const isExplicitRelative = cleanToken.startsWith('./') || cleanToken.startsWith('../');
+    const hasSlash = cleanToken.includes('/');
+
+    if (cleanToken && !cleanToken.startsWith('/')) {
+      const targetPath = resolve(process.cwd(), cleanToken);
+      const exists = existsSync(targetPath);
+
+      if (isExplicitRelative || (hasSlash && exists) || exists) {
+        return quote + targetPath + quote;
+      }
+    }
+
+    return match;
+  });
 }
 
 function buildPrompt(options: AskOptions, preset: string | undefined): string {
@@ -675,12 +773,23 @@ function printDryRun(options: AskOptions, input: string, preset: string | undefi
   console.log('Dry run: aco ask would invoke external providers only with --yes.');
   console.log(`Providers: ${options.providers.join(',')}`);
   console.log(`Permission profile: ${options.permissionProfile}`);
+  if (options.permissionProfile === 'restricted') {
+    console.log('restricted: repository file access is disabled (read-only advisory)');
+  }
   console.log(`Output mode: ${options.outputMode}`);
   console.log(`Timeout seconds: ${options.timeoutSeconds}`);
   if (options.preset) console.log(`Preset: ${options.preset}`);
   console.log(`Task: ${options.task ?? '(preset only)'}`);
   console.log(`Input bytes: ${Buffer.byteLength(input, 'utf8')}`);
   if (preset) console.log(`Preset bytes: ${Buffer.byteLength(preset, 'utf8')}`);
+
+  options.providers.forEach((p) => {
+    const providerCwd =
+      p === 'antigravity' ? join(homedir(), '.aco', 'agy-workspace') : process.cwd();
+    console.log(`Provider '${p}' cwd: ${providerCwd}`);
+  });
+  console.log(`Current invocation cwd: ${process.cwd()}`);
+
   console.log('Provider execution: skipped');
 }
 
@@ -905,10 +1014,15 @@ export function extractTopFindings(output: string): string[] | null {
 function resolveResultQuality(
   status: AskSessionLedger['status'],
   hasOutput: boolean,
-  warningCount: number
+  warningCount: number,
+  outputContent: string,
+  stderrContent: string
 ): 'complete' | 'empty' | 'warning_heavy' | 'error' {
   if (status === 'failed' || status === 'cancelled') return 'error';
   if (!hasOutput) return 'empty';
-  if (warningCount > 3) return 'warning_heavy';
+  const hasToolFailure =
+    /tool failure|permission denied|API error/i.test(outputContent) ||
+    /tool failure|permission denied|API error/i.test(stderrContent);
+  if (warningCount > 3 || hasToolFailure) return 'warning_heavy';
   return 'complete';
 }

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { createWriteStream, existsSync, globSync, statSync } from 'node:fs';
+import { createWriteStream, existsSync, statSync } from 'node:fs';
+import { globSync } from 'glob';
 import { randomUUID, createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -706,9 +706,10 @@ async function collectInput(options: AskOptions): Promise<string> {
       pathChunks.push(fileContent);
     }
 
-    if (pathChunks.length > 0) {
-      chunks.push(pathChunks.join('\n\n'));
+    if (pathChunks.length === 0) {
+      fail(`Error: No files matched the pattern '${options.paths}'`);
     }
+    chunks.push(pathChunks.join('\n\n'));
   }
 
   return chunks.join('\n\n');
@@ -1029,8 +1030,7 @@ function resolveResultQuality(
 ): 'complete' | 'empty' | 'warning_heavy' | 'error' {
   if (status === 'failed' || status === 'cancelled') return 'error';
   if (!hasOutput) return 'empty';
-  const hasToolFailure =
-    /tool failure|permission denied|API error/i.test(stderrContent);
+  const hasToolFailure = /tool failure|permission denied|API error/i.test(stderrContent);
   if (warningCount > 3 || hasToolFailure) return 'warning_heavy';
   return 'complete';
 }

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -659,13 +659,16 @@ async function collectInput(options: AskOptions): Promise<string> {
 
   if (options.paths) {
     const matchedFiles = globSync(options.paths, { cwd: process.cwd() });
+    if (matchedFiles.length === 0) {
+      fail(`Error: No files matched the pattern '${options.paths}'`);
+    }
     matchedFiles.sort();
 
     const pathChunks: string[] = [];
     let totalBytes = 0;
     for (const file of matchedFiles) {
-      const stat = statSync(file);
-      if (stat.isDirectory()) {
+      const stat = statSync(file, { throwIfNoEntry: false });
+      if (!stat || stat.isDirectory()) {
         continue;
       }
 
@@ -739,8 +742,9 @@ function resolveRelativePathsInText(text: string): string {
 
     const isExplicitRelative = cleanToken.startsWith('./') || cleanToken.startsWith('../');
     const hasSlash = cleanToken.includes('/');
+    const hasSpace = /\s/.test(cleanToken);
 
-    if (cleanToken && !cleanToken.startsWith('/')) {
+    if (cleanToken && !cleanToken.startsWith('/') && !hasSpace) {
       const targetPath = resolve(process.cwd(), cleanToken);
       const exists = existsSync(targetPath);
 
@@ -1026,7 +1030,6 @@ function resolveResultQuality(
   if (status === 'failed' || status === 'cancelled') return 'error';
   if (!hasOutput) return 'empty';
   const hasToolFailure =
-    /tool failure|permission denied|API error/i.test(outputContent) ||
     /tool failure|permission denied|API error/i.test(stderrContent);
   if (warningCount > 3 || hasToolFailure) return 'warning_heavy';
   return 'complete';

--- a/packages/wrapper/src/commands/ask.ts
+++ b/packages/wrapper/src/commands/ask.ts
@@ -661,6 +661,7 @@ async function collectInput(options: AskOptions): Promise<string> {
     matchedFiles.sort();
 
     const pathChunks: string[] = [];
+    let totalBytes = 0;
     for (const file of matchedFiles) {
       const stat = statSync(file);
       if (stat.isDirectory()) {
@@ -688,19 +689,21 @@ async function collectInput(options: AskOptions): Promise<string> {
         }
       );
 
-      if (Buffer.byteLength(fileContent, 'utf8') > 1024 * 1024) {
+      const bytes = Buffer.byteLength(fileContent, 'utf8');
+      if (bytes > 1024 * 1024) {
         fail(`Error: Matched file '${file}' exceeds 1MB limit`);
+      }
+
+      totalBytes += bytes + (pathChunks.length > 0 ? 2 : 0);
+      if (totalBytes > 1024 * 1024) {
+        fail(`Error: Merged files from --paths exceed 1MB limit`);
       }
 
       pathChunks.push(fileContent);
     }
 
     if (pathChunks.length > 0) {
-      const mergedPathsContent = pathChunks.join('\n\n');
-      if (Buffer.byteLength(mergedPathsContent, 'utf8') > 1024 * 1024) {
-        fail(`Error: Merged files from --paths exceed 1MB limit`);
-      }
-      chunks.push(mergedPathsContent);
+      chunks.push(pathChunks.join('\n\n'));
     }
   }
 
@@ -740,8 +743,9 @@ function resolveRelativePathsInText(text: string): string {
       const targetPath = resolve(process.cwd(), cleanToken);
       const exists = existsSync(targetPath);
 
-      if (isExplicitRelative || (hasSlash && exists) || exists) {
-        return quote + targetPath + quote;
+      if (isExplicitRelative || (hasSlash && exists)) {
+        const trailingSlash = cleanToken.endsWith('/') && !targetPath.endsWith('/') ? '/' : '';
+        return quote + targetPath + trailingSlash + quote;
       }
     }
 

--- a/packages/wrapper/src/providers/mock.ts
+++ b/packages/wrapper/src/providers/mock.ts
@@ -27,7 +27,7 @@ export class MockProvider implements IProvider {
     command: string,
     prompt: string,
     content: string,
-    options?: import('./interface.js').InvokeOptions
+    options?: InvokeOptions
   ): AsyncIterable<string> {
     if (process.env.ACO_MOCK_DELAY_MS) {
       const delayMs = Number.parseInt(process.env.ACO_MOCK_DELAY_MS, 10);

--- a/packages/wrapper/src/providers/mock.ts
+++ b/packages/wrapper/src/providers/mock.ts
@@ -36,10 +36,7 @@ export class MockProvider implements IProvider {
       }
     }
 
-    if (process.env.ACO_MOCK_STDERR && options?.onStderrComplete) {
-      options.onStderrComplete(process.env.ACO_MOCK_STDERR);
-    }
-
+    // IProvider 계약 위반이므로 테스트 목적의 onStderrComplete 강제 호출 제거.
     const input = content.length > 0 ? content : '(empty input)';
     yield [
       'Provider: mock',

--- a/packages/wrapper/src/providers/mock.ts
+++ b/packages/wrapper/src/providers/mock.ts
@@ -23,12 +23,21 @@ export class MockProvider implements IProvider {
     return ['mock', command];
   }
 
-  async *invoke(command: string, prompt: string, content: string): AsyncIterable<string> {
+  async *invoke(
+    command: string,
+    prompt: string,
+    content: string,
+    options?: import('./interface.js').InvokeOptions
+  ): AsyncIterable<string> {
     if (process.env.ACO_MOCK_DELAY_MS) {
       const delayMs = Number.parseInt(process.env.ACO_MOCK_DELAY_MS, 10);
       if (Number.isFinite(delayMs) && delayMs > 0) {
         await new Promise((resolve) => setTimeout(resolve, delayMs));
       }
+    }
+
+    if (process.env.ACO_MOCK_STDERR && options?.onStderrComplete) {
+      options.onStderrComplete(process.env.ACO_MOCK_STDERR);
     }
 
     const input = content.length > 0 ? content : '(empty input)';

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -982,16 +982,13 @@ describe('aco ask CLI', () => {
           'mock',
           '--task',
           'tool failure test',
+          '--input',
+          'Error: permission denied or tool failure occurred',
           '--yes',
           '--output-mode',
           'save-only',
         ],
-        {
-          home,
-          env: {
-            ACO_MOCK_STDERR: 'Error: permission denied or tool failure occurred',
-          }
-        }
+        { home }
       );
 
       assert.equal(result.code, 0);
@@ -1021,7 +1018,7 @@ describe('aco ask CLI', () => {
       assert.equal(result.code, 0);
       // prompt should contain resolved absolute path for ./src/ and src/
       const expectedPath = resolve(workspace, 'src');
-      assert.ok(result.stdout.includes(expectedPath));
+      assert.ok(result.stdout.includes(expectedPath + '/'));
     });
   });
 });

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -902,11 +902,11 @@ describe('aco ask CLI', () => {
       assert.match(result.stderr, /Blocked:/);
     });
 
-    // 3. 1MB limit for glob merged or individual files
-    it('fails when merged glob files or individual file exceeds 1MB', async () => {
+    // 3. 5MB limit for glob merged or individual files
+    it('fails when merged glob files or individual file exceeds 5MB', async () => {
       const home = await makeHome();
       const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-limit-'));
-      const largeContent = 'x'.repeat(1.1 * 1024 * 1024);
+      const largeContent = 'x'.repeat(5.1 * 1024 * 1024);
       await writeFile(join(workspace, 'large.txt'), largeContent);
 
       const result = await runCli(
@@ -924,7 +924,7 @@ describe('aco ask CLI', () => {
       );
 
       assert.equal(result.code, 1);
-      assert.match(result.stderr, /exceeds 1MB/i);
+      assert.match(result.stderr, /exceeds 5MB/i);
     });
 
     // 4. directory warning for literal --input

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -878,6 +878,30 @@ describe('aco ask CLI', () => {
       assert.equal(result.code, 0);
     });
 
+    it('fails when --paths only matches directories', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-dir-paths-'));
+      await mkdir(join(workspace, 'some-dir'));
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'directory paths test',
+          '--paths',
+          'some-dir',
+          '--yes',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /No files matched the pattern 'some-dir'/);
+      assert.equal(existsSync(join(home, '.aco', 'sessions')), false);
+    });
+
     // 2. credential check on glob files
     it('blocks credential-like files in --paths unless --allow-sensitive is set', async () => {
       const home = await makeHome();

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -972,8 +972,8 @@ describe('aco ask CLI', () => {
       assert.match(result.stdout, /restricted: repository file access is disabled \(read-only advisory\)/);
     });
 
-    // 6. resolveResultQuality detects tool failures
-    it('resolves result quality as warning_heavy when tool failure is detected in stderr/stdout', async () => {
+    // 6. resolveResultQuality ignores tool failures echoed in stdout
+    it('resolves result quality as complete when tool failure is detected in stdout only', async () => {
       const home = await makeHome();
       const result = await runCli(
         [
@@ -994,7 +994,7 @@ describe('aco ask CLI', () => {
       assert.equal(result.code, 0);
       const runId = await latestRunId(home);
       const ledger = JSON.parse(await readFile(join(home, '.aco', 'runs', runId, 'ledger.json'), 'utf8'));
-      assert.equal(ledger.sessions[0].resultQuality, 'warning_heavy');
+      assert.equal(ledger.sessions[0].resultQuality, 'complete');
     });
 
     // 7. Antigravity path replacement

--- a/packages/wrapper/tests/ask-cli.test.ts
+++ b/packages/wrapper/tests/ask-cli.test.ts
@@ -819,4 +819,209 @@ describe('aco ask CLI', () => {
     assert.ok(runResult.hasOutput);
     assert.equal(sawDrainBeforeSecondChunk, true);
   });
+
+  describe('aco ask Improvements (#185)', () => {
+    // 1. --paths / --input-path glob matching & merging
+    it('matches and merges files using --paths glob', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-improvements-'));
+      await writeFile(join(workspace, 'test1.log'), 'Content 1');
+      await writeFile(join(workspace, 'test2.log'), 'Content 2');
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'glob test',
+          '--paths',
+          '*.log',
+          '--yes',
+          '--output-mode',
+          'save-only',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.equal(result.code, 0);
+      const runId = await latestRunId(home);
+      const savedInput = await readFile(
+        join(home, '.aco', 'runs', runId, 'input.md'),
+        'utf8'
+      );
+      assert.ok(savedInput.includes('Content 1'));
+      assert.ok(savedInput.includes('Content 2'));
+    });
+
+    it('matches and merges files using --input-path glob', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-improvements2-'));
+      await writeFile(join(workspace, 'test1.log'), 'Content 1');
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'glob test 2',
+          '--input-path',
+          'test1.log',
+          '--yes',
+          '--output-mode',
+          'save-only',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.equal(result.code, 0);
+    });
+
+    // 2. credential check on glob files
+    it('blocks credential-like files in --paths unless --allow-sensitive is set', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-cred-'));
+      await writeFile(join(workspace, 'id_rsa'), 'private key data');
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'cred test',
+          '--paths',
+          'id_rsa',
+          '--yes',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /Blocked:/);
+    });
+
+    // 3. 1MB limit for glob merged or individual files
+    it('fails when merged glob files or individual file exceeds 1MB', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-limit-'));
+      const largeContent = 'x'.repeat(1.1 * 1024 * 1024);
+      await writeFile(join(workspace, 'large.txt'), largeContent);
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'limit test',
+          '--paths',
+          'large.txt',
+          '--yes',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /exceeds 1MB/i);
+    });
+
+    // 4. directory warning for literal --input
+    it('warns when --input is a directory path', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-dir-'));
+      const dirPath = join(workspace, 'some-dir');
+      await mkdir(dirPath);
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'dir warning test',
+          '--input',
+          dirPath,
+          '--yes',
+          '--output-mode',
+          'save-only',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.match(result.stderr, /Warning: `--input` looks like a directory\. Did you mean to use `--paths`\?/);
+    });
+
+    // 5. dry-run outputs improvements (CWD & permission notice)
+    it('prints cwd and process.cwd() in dry-run with restricted notice', async () => {
+      const home = await makeHome();
+      const result = await runCli([
+        'ask',
+        '--providers',
+        'mock',
+        '--task',
+        'dry-run improvements',
+        '--dry-run',
+        '--permission-profile',
+        'restricted',
+      ], { home });
+
+      assert.equal(result.code, 0);
+      assert.match(result.stdout, /Current invocation cwd/i);
+      assert.match(result.stdout, /restricted: repository file access is disabled \(read-only advisory\)/);
+    });
+
+    // 6. resolveResultQuality detects tool failures
+    it('resolves result quality as warning_heavy when tool failure is detected in stderr/stdout', async () => {
+      const home = await makeHome();
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'mock',
+          '--task',
+          'tool failure test',
+          '--yes',
+          '--output-mode',
+          'save-only',
+        ],
+        {
+          home,
+          env: {
+            ACO_MOCK_STDERR: 'Error: permission denied or tool failure occurred',
+          }
+        }
+      );
+
+      assert.equal(result.code, 0);
+      const runId = await latestRunId(home);
+      const ledger = JSON.parse(await readFile(join(home, '.aco', 'runs', runId, 'ledger.json'), 'utf8'));
+      assert.equal(ledger.sessions[0].resultQuality, 'warning_heavy');
+    });
+
+    // 7. Antigravity path replacement
+    it('replaces relative path to absolute in buildPrompt when using antigravity', async () => {
+      const home = await makeHome();
+      const workspace = await mkdtemp(join(tmpdir(), 'aco-ask-agy-'));
+      await mkdir(join(workspace, 'src'));
+
+      const result = await runCli(
+        [
+          'ask',
+          '--providers',
+          'antigravity',
+          '--task',
+          'review ./src/ and src/ please',
+          '--dry-run',
+        ],
+        { home, cwd: workspace }
+      );
+
+      assert.equal(result.code, 0);
+      // prompt should contain resolved absolute path for ./src/ and src/
+      const expectedPath = resolve(workspace, 'src');
+      assert.ok(result.stdout.includes(expectedPath));
+    });
+  });
 });


### PR DESCRIPTION
Closes #185

코드리뷰 팀워크 서브에이전트가 찾아낸 5개 결함을 모두 조치함.
- 보안: `--input-file` 민감 파일 검증 취약점 보완
- 버그: 상대경로 치환 단어 충돌 및 슬래시 증발 현상 패치
- 성능/안정성: 다중 파일 병합 OOM 방지
- 아키텍처: IProvider 계약에 맞게 Mock 프로바이더 원복 및 테스트 교체
- 문서화: README.md 옵션 갱신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --paths for glob-based multi-file input and --allow-sensitive to permit credential-like files; default behavior blocks such files
  * Enforced 5MB size limit per file and on merged inputs

* **Improvements**
  * Enhanced dry-run output with invocation cwd and restricted-mode advisory
  * Expanded result-quality classification to detect stderr-driven warnings/errors
  * Resolves relative paths in prompts for a specific provider

* **Documentation**
  * Updated security docs (including Korean clarification) and consent-gated delegation examples

* **Tests**
  * Added CLI tests covering --paths, size limits, blocking behavior, dry-run output, and result classification

* **Chores**
  * Added runtime dependency for glob handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->